### PR TITLE
Better check for is_admin().

### DIFF
--- a/MPM/mpm_settings.php
+++ b/MPM/mpm_settings.php
@@ -239,7 +239,7 @@ class MPM_Settings extends WC_Settings_API
 	public function gateways_add_dynamic ($gateways)
 	{
 		// This is in the WooCommerce admin settings, so we'll use the Settings class instead.
-		if (is_admin())
+		if (is_admin() && !defined('DOING_AJAX'))
 		{
 			$page = $this->get_current_admin_page_if_existing();
 


### PR DESCRIPTION
This was especially a problem in the old version, when "get_screen" was still being used. Nevertheless, this code doesn't need to be executed upon every AJAX request. :)
