### PR TITLE
Fix for collaboration with Polylang

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -982,7 +982,9 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
             // we probably have a multilang site. Retrieve current language.
             $slug = get_bloginfo('language');
             $pos  = strpos($slug, '-');
-            $slug = substr($slug, 0, $pos);
+            if ($pos !== false)
+                $slug = substr($slug, 0, $pos);
+                
             $slug = '/' . $slug;
         }
 


### PR DESCRIPTION
If language code doesn't contain a dash, use full language code as slug