### PR TITLE
Api key filter added

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/api.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/api.php
@@ -30,6 +30,10 @@ class Mollie_WC_Helper_Api
 
         $api_key = $this->settings_helper->getApiKey($test_mode);
 
+        if(has_filter('mollie_api_key_filter')) {
+            $api_key = apply_filters('mollie_api_key_filter', $api_key);
+        }
+
         if (empty($api_key))
         {
             throw new Mollie_WC_Exception_InvalidApiKey(__('No API key provided.', 'mollie-payments-for-woocommerce'));


### PR DESCRIPTION
We would like to use this filter on the api key so we can change the api key based on a pick up location. Every pick up location uses different mollie accounts. Having a filter to change the api key doesn't really affect the security, because if a plugin would like to change the api key, they can simple do so by changing the database value of the api key setting.