### PR TITLE
Recurring: Order notes and renewal order status

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
@@ -57,7 +57,7 @@ abstract class Mollie_WC_Gateway_AbstractSepaRecurring extends Mollie_WC_Gateway
         $this->updateOrderStatus(
             $renewal_order,
             self::STATUS_PROCESSING,
-            sprintf(__("Awaiting payment confirmation for %s Days", 'mollie-payments-for-woocommerce') . "\n", self::WAITING_CONFIRMATION_PERIOD_DAYS)
+            sprintf(__("Awaiting payment confirmation for %s days", 'mollie-payments-for-woocommerce') . "\n", self::WAITING_CONFIRMATION_PERIOD_DAYS)
         );
 
         $paymentMethodTitle = $this->getPaymentMethodTitle($payment);

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
@@ -57,8 +57,7 @@ abstract class Mollie_WC_Gateway_AbstractSepaRecurring extends Mollie_WC_Gateway
         $this->updateOrderStatus(
             $renewal_order,
             self::STATUS_COMPLETED,
-            __("Awaiting payment confirmation. For %s Days", 'mollie-payments-for-woocommerce') . "\n",
-            self::WAITING_CONFIRMATION_PERIOD_DAYS
+            sprintf(__("Awaiting payment confirmation for %s Days", 'mollie-payments-for-woocommerce') . "\n", self::WAITING_CONFIRMATION_PERIOD_DAYS)
         );
 
         $paymentMethodTitle = $this->getPaymentMethodTitle($payment);

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
@@ -56,7 +56,7 @@ abstract class Mollie_WC_Gateway_AbstractSepaRecurring extends Mollie_WC_Gateway
     {
         $this->updateOrderStatus(
             $renewal_order,
-            self::STATUS_COMPLETED,
+            self::STATUS_PROCESSING,
             sprintf(__("Awaiting payment confirmation for %s Days", 'mollie-payments-for-woocommerce') . "\n", self::WAITING_CONFIRMATION_PERIOD_DAYS)
         );
 


### PR DESCRIPTION
- Fixed the order note regarding SEPA payment confirmation.
- The order status of a renewal order will now be changed from pending to processing when the SEPA recurring payment is confirmed (instead of completed). This way the shop owner has a better view on which orders still need to be processed / shipped.