### PR TITLE
WC 3.0: Add support for WooCommerce 3.0 (backwards compatible)

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -728,10 +728,10 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     }
 
     /**
-     * @param Wc_Order $order
+     * @param WC_Order $order
      * @param Mollie_API_Object_Payment $payment
      */
-    protected function onWebhookPaid(Wc_Order $order, Mollie_API_Object_Payment $payment)
+    protected function onWebhookPaid(WC_Order $order, Mollie_API_Object_Payment $payment)
     {
         Mollie_WC_Plugin::debug(__METHOD__ . ' called.');
 
@@ -771,10 +771,10 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 
     /**
-     * @param Wc_Order $order
+     * @param WC_Order $order
      * @param Mollie_API_Object_Payment $payment
      */
-    protected function onWebhookCancelled(Wc_Order $order, Mollie_API_Object_Payment $payment)
+    protected function onWebhookCancelled(WC_Order $order, Mollie_API_Object_Payment $payment)
     {
         Mollie_WC_Plugin::debug(__METHOD__ . ' called.');
 
@@ -813,10 +813,10 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     }
 
     /**
-     * @param Wc_Order $order
+     * @param WC_Order $order
      * @param Mollie_API_Object_Payment $payment
      */
-    protected function onWebhookExpired(Wc_Order $order, Mollie_API_Object_Payment $payment)
+    protected function onWebhookExpired(WC_Order $order, Mollie_API_Object_Payment $payment)
     {
         Mollie_WC_Plugin::debug(__METHOD__ . ' called.');
 

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -426,11 +426,17 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $return_url          = $this->getReturnUrl($order);
         $webhook_url         = $this->getWebhookUrl($order);
 
-
-        $payment_description = strtr($payment_description, array(
-            '{order_number}' => $order->get_order_number(),
-            '{order_date}'   => date_i18n(wc_date_format(), strtotime($order->order_date)),
-        ));
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $payment_description = strtr($payment_description, array(
+			    '{order_number}' => $order->get_order_number(),
+			    '{order_date}'   => date_i18n(wc_date_format(), strtotime($order->order_date)),
+		    ));
+	    } else {
+		    $payment_description = strtr($payment_description, array(
+			    '{order_number}' => $order->get_order_number(),
+			    '{order_date}'   => date_i18n(wc_date_format(), $order->get_date_created()->getTimestamp()),
+		    ));
+	    }
 
 	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		    $paymentRequestData = array(

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -703,19 +703,20 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
      * @param $order
      * @param $payment
      */
-    protected function handlePayedOrderWebhook($order, $payment)
-    {
-        // Duplicate webhook call
-        Mollie_WC_Plugin::setHttpResponseCode(204);
+	protected function handlePayedOrderWebhook( $order, $payment ) {
+		// Duplicate webhook call
+		Mollie_WC_Plugin::setHttpResponseCode( 204 );
 
-	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-		    Mollie_WC_Plugin::debug($this->id . ": Order $order->id does not need a payment (payment webhook {$payment->id}).", true);
-	    } else {
-		    Mollie_WC_Plugin::debug($this->id . ": Order $order->get_id() does not need a payment (payment webhook {$payment->id}).", true);
-	    }
+		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+			$order_id = $order->id;
+		} else {
+			$order    = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order );
+			$order_id = $order->get_id();
+		}
 
+		Mollie_WC_Plugin::debug( $this->id . ": Order $order_id does not need a payment (payment webhook {$payment->id}).", true );
 
-    }
+	}
 
     /**
      * @param $payment

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -564,7 +564,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 		    switch ($new_status)
 		    {
 			    case self::STATUS_ON_HOLD:
-				    if (!get_post_meta($order->get_id(), '_order_stock_reduced', $single = true))
+				    if ( ! $order->get_meta( '_order_stock_reduced', true ) )
 				    {
 					    // Reduce order stock
 					    wc_reduce_stock_levels( $order->get_id() );
@@ -577,7 +577,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 			    case self::STATUS_PENDING:
 			    case self::STATUS_FAILED:
 			    case self::STATUS_CANCELLED:
-				    if (get_post_meta($order->get_id(), '_order_stock_reduced', $single = true))
+				    if ( $order->get_meta( '_order_stock_reduced', true ) )
 				    {
 					    // Restore order stock
 					    Mollie_WC_Plugin::getDataHelper()->restoreOrderStock($order);

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -567,7 +567,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 				    if (!get_post_meta($order->get_id(), '_order_stock_reduced', $single = true))
 				    {
 					    // Reduce order stock
-					    $order->reduce_order_stock();
+					    wc_reduce_stock_levels( $order->get_id() );
 
 					    Mollie_WC_Plugin::debug(__METHOD__ . ":  Stock for order {$order->get_id()} reduced.");
 				    }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -736,7 +736,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     {
         Mollie_WC_Plugin::debug(__METHOD__ . ' called.');
 
-        // Woocommerce 2.2.0 has the option to store the Payment transaction id.
+        // WooCommerce 2.2.0 has the option to store the Payment transaction id.
         $woo_version = get_option('woocommerce_version', 'Unknown');
 
         if (version_compare($woo_version, '2.2.0', '>='))

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -310,7 +310,11 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 
         try
         {
-            Mollie_WC_Plugin::debug($this->id . ': Create payment for order ' . $order->id, true);
+	        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		        Mollie_WC_Plugin::debug( $this->id . ': Create payment for order ' . $order->id, true );
+	        } else {
+		        Mollie_WC_Plugin::debug( $this->id . ': Create payment for order ' . $order->get_id(), true );
+	        }
 
             do_action(Mollie_WC_Plugin::PLUGIN_ID . '_create_payment', $data, $order);
 
@@ -335,7 +339,11 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             do_action(Mollie_WC_Plugin::PLUGIN_ID . '_payment_created', $payment, $order);
 
-            Mollie_WC_Plugin::debug($this->id . ': Payment ' . $payment->id . ' (' . $payment->mode . ') created for order ' . $order->id);
+	        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		        Mollie_WC_Plugin::debug( $this->id . ': Payment ' . $payment->id . ' (' . $payment->mode . ') created for order ' . $order->id );
+	        } else {
+		        Mollie_WC_Plugin::debug( $this->id . ': Payment ' . $payment->id . ' (' . $payment->mode . ') created for order ' . $order->get_id() );
+	        }
 
             // Set initial status
             // Status is only updated if the new status is not the same as the default order status (pending)
@@ -361,7 +369,11 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         }
         catch (Mollie_API_Exception $e)
         {
-            Mollie_WC_Plugin::debug($this->id . ': Failed to create payment for order ' . $order->id . ': ' . $e->getMessage());
+	        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		        Mollie_WC_Plugin::debug( $this->id . ': Failed to create payment for order ' . $order->id . ': ' . $e->getMessage() );
+	        } else {
+		        Mollie_WC_Plugin::debug( $this->id . ': Failed to create payment for order ' . $order->get_id() . ': ' . $e->getMessage() );
+	        }
 
             /* translators: Placeholder 1: Payment method title */
             $message = sprintf(__('Could not create %s payment.', 'mollie-payments-for-woocommerce'), $this->title);
@@ -383,11 +395,19 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
      */
     protected function saveMollieInfo($order, $payment)
     {
-        // Set active Mollie payment
-        Mollie_WC_Plugin::getDataHelper()->setActiveMolliePayment($order->id, $payment);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    // Set active Mollie payment
+		    Mollie_WC_Plugin::getDataHelper()->setActiveMolliePayment($order->id, $payment);
 
-        // Set Mollie customer
-        Mollie_WC_Plugin::getDataHelper()->setUserMollieCustomerId($order->customer_user, $payment->customerId);
+		    // Set Mollie customer
+		    Mollie_WC_Plugin::getDataHelper()->setUserMollieCustomerId($order->customer_user, $payment->customerId);
+	    } else {
+		    // Set active Mollie payment
+		    Mollie_WC_Plugin::getDataHelper()->setActiveMolliePayment($order->get_id(), $payment);
+
+		    // Set Mollie customer
+		    Mollie_WC_Plugin::getDataHelper()->setUserMollieCustomerId($order->get_customer_id(), $payment->customerId);
+	    }
     }
 
     /**
@@ -412,28 +432,53 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
             '{order_date}'   => date_i18n(wc_date_format(), strtotime($order->order_date)),
         ));
 
-        $paymentRequestData = array(
-            'amount'          => $order->get_total(),
-            'description'     => $payment_description,
-            'redirectUrl'     => $return_url,
-            'webhookUrl'      => $webhook_url,
-            'method'          => $mollie_method,
-            'issuer'          => $selected_issuer,
-            'locale'          => $payment_locale,
-            'billingAddress'  => $order->billing_address_1,
-            'billingCity'     => $order->billing_city,
-            'billingRegion'   => $order->billing_state,
-            'billingPostal'   => $order->billing_postcode,
-            'billingCountry'  => $order->billing_country,
-            'shippingAddress' => $order->shipping_address_1,
-            'shippingCity'    => $order->shipping_city,
-            'shippingRegion'  => $order->shipping_state,
-            'shippingPostal'  => $order->shipping_postcode,
-            'shippingCountry' => $order->shipping_country,
-            'metadata'        => array(
-                'order_id' => $order->id,
-            ),
-        );
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $paymentRequestData = array(
+			    'amount'          => $order->get_total(),
+			    'description'     => $payment_description,
+			    'redirectUrl'     => $return_url,
+			    'webhookUrl'      => $webhook_url,
+			    'method'          => $mollie_method,
+			    'issuer'          => $selected_issuer,
+			    'locale'          => $payment_locale,
+			    'billingAddress'  => $order->billing_address_1,
+			    'billingCity'     => $order->billing_city,
+			    'billingRegion'   => $order->billing_state,
+			    'billingPostal'   => $order->billing_postcode,
+			    'billingCountry'  => $order->billing_country,
+			    'shippingAddress' => $order->shipping_address_1,
+			    'shippingCity'    => $order->shipping_city,
+			    'shippingRegion'  => $order->shipping_state,
+			    'shippingPostal'  => $order->shipping_postcode,
+			    'shippingCountry' => $order->shipping_country,
+			    'metadata'        => array(
+				    'order_id' => $order->id,
+			    ),
+		    );
+	    } else {
+		    $paymentRequestData = array(
+			    'amount'          => $order->get_total(),
+			    'description'     => $payment_description,
+			    'redirectUrl'     => $return_url,
+			    'webhookUrl'      => $webhook_url,
+			    'method'          => $mollie_method,
+			    'issuer'          => $selected_issuer,
+			    'locale'          => $payment_locale,
+			    'billingAddress'  => $order->get_billing_address_1(),
+			    'billingCity'     => $order->get_billing_city(),
+			    'billingRegion'   => $order->get_billing_state(),
+			    'billingPostal'   => $order->get_billing_postcode(),
+			    'billingCountry'  => $order->get_billing_country(),
+			    'shippingAddress' => $order->get_shipping_address_1(),
+			    'shippingCity'    => $order->get_shipping_city(),
+			    'shippingRegion'  => $order->get_shipping_state(),
+			    'shippingPostal'  => $order->get_shipping_postcode(),
+			    'shippingCountry' => $order->get_shipping_country(),
+			    'metadata'        => array(
+				    'order_id' => $order->get_id(),
+			    ),
+		    );
+	    }
 
         if ($store_customer)
             $paymentRequestData['customerId'] = $customer_id;
@@ -449,7 +494,9 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
      */
     protected function getUserMollieCustomerId($order, $test_mode)
     {
-       return  Mollie_WC_Plugin::getDataHelper()->getUserMollieCustomerId($order->customer_user, $test_mode);
+	    $order_customer_id = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $order->customer_user : $order->get_customer_id();
+
+	    return  Mollie_WC_Plugin::getDataHelper()->getUserMollieCustomerId($order_customer_id, $test_mode);
     }
 
     /**
@@ -477,32 +524,65 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     {
         $order->update_status($new_status, $note);
 
-        switch ($new_status)
-        {
-            case self::STATUS_ON_HOLD:
-                if (!get_post_meta($order->id, '_order_stock_reduced', $single = true))
-                {
-                    // Reduce order stock
-                    $order->reduce_order_stock();
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 
-                    Mollie_WC_Plugin::debug(__METHOD__ . ":  Stock for order {$order->id} reduced.");
-                }
+		    switch ($new_status)
+		    {
+			    case self::STATUS_ON_HOLD:
+				    if (!get_post_meta($order->id, '_order_stock_reduced', $single = true))
+				    {
+					    // Reduce order stock
+					    $order->reduce_order_stock();
 
-                break;
+					    Mollie_WC_Plugin::debug(__METHOD__ . ":  Stock for order {$order->id} reduced.");
+				    }
 
-            case self::STATUS_PENDING:
-            case self::STATUS_FAILED:
-            case self::STATUS_CANCELLED:
-                if (get_post_meta($order->id, '_order_stock_reduced', $single = true))
-                {
-                    // Restore order stock
-                    Mollie_WC_Plugin::getDataHelper()->restoreOrderStock($order);
+				    break;
 
-                    Mollie_WC_Plugin::debug(__METHOD__ . " Stock for order {$order->id} restored.");
-                }
+			    case self::STATUS_PENDING:
+			    case self::STATUS_FAILED:
+			    case self::STATUS_CANCELLED:
+				    if (get_post_meta($order->id, '_order_stock_reduced', $single = true))
+				    {
+					    // Restore order stock
+					    Mollie_WC_Plugin::getDataHelper()->restoreOrderStock($order);
 
-                break;
-        }
+					    Mollie_WC_Plugin::debug(__METHOD__ . " Stock for order {$order->id} restored.");
+				    }
+
+				    break;
+		    }
+
+	    } else {
+
+		    switch ($new_status)
+		    {
+			    case self::STATUS_ON_HOLD:
+				    if (!get_post_meta($order->get_id(), '_order_stock_reduced', $single = true))
+				    {
+					    // Reduce order stock
+					    $order->reduce_order_stock();
+
+					    Mollie_WC_Plugin::debug(__METHOD__ . ":  Stock for order {$order->get_id()} reduced.");
+				    }
+
+				    break;
+
+			    case self::STATUS_PENDING:
+			    case self::STATUS_FAILED:
+			    case self::STATUS_CANCELLED:
+				    if (get_post_meta($order->get_id(), '_order_stock_reduced', $single = true))
+				    {
+					    // Restore order stock
+					    Mollie_WC_Plugin::getDataHelper()->restoreOrderStock($order);
+
+					    Mollie_WC_Plugin::debug(__METHOD__ . " Stock for order {$order->get_id()} restored.");
+				    }
+
+				    break;
+		    }
+
+	    }
     }
 
 
@@ -587,7 +667,11 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
             return;
         }
 
-        Mollie_WC_Plugin::debug($this->id . ": Mollie payment {$payment->id} (" . $payment->mode . ") webhook call for order {$order->id}.", true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    Mollie_WC_Plugin::debug($this->id . ": Mollie payment {$payment->id} (" . $payment->mode . ") webhook call for order {$order->id}.", true);
+	    } else {
+		    Mollie_WC_Plugin::debug($this->id . ": Mollie payment {$payment->id} (" . $payment->mode . ") webhook call for order {$order->get_id()}.", true);
+	    }
 
         $method_name = 'onWebhook' . ucfirst($payment->status);
 
@@ -617,7 +701,13 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     {
         // Duplicate webhook call
         Mollie_WC_Plugin::setHttpResponseCode(204);
-        Mollie_WC_Plugin::debug($this->id . ": Order $order->id does not need a payment (payment webhook {$payment->id}).", true);
+
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    Mollie_WC_Plugin::debug($this->id . ": Order $order->id does not need a payment (payment webhook {$payment->id}).", true);
+	    } else {
+		    Mollie_WC_Plugin::debug($this->id . ": Order $order->get_id() does not need a payment (payment webhook {$payment->id}).", true);
+	    }
+
 
     }
 
@@ -682,10 +772,16 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     {
         Mollie_WC_Plugin::debug(__METHOD__ . ' called.');
 
-        // Unset active Mollie payment id
-        Mollie_WC_Plugin::getDataHelper()
-            ->unsetActiveMolliePayment($order->id)
-            ->setCancelledMolliePaymentId($order->id, $payment->id);
+	    // Unset active Mollie payment id
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    Mollie_WC_Plugin::getDataHelper()
+		                    ->unsetActiveMolliePayment($order->id)
+		                    ->setCancelledMolliePaymentId($order->id, $payment->id);
+	    } else {
+		    Mollie_WC_Plugin::getDataHelper()
+		                    ->unsetActiveMolliePayment($order->get_id())
+		                    ->setCancelledMolliePaymentId($order->get_id(), $payment->id);
+	    }
 
         // New order status
         $new_order_status = self::STATUS_PENDING;
@@ -748,7 +844,9 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     {
         $data_helper = Mollie_WC_Plugin::getDataHelper();
 
-        if ($data_helper->hasCancelledMolliePayment($order->id))
+	    $hasCancelledMolliePayment = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $data_helper->hasCancelledMolliePayment($order->id) : $data_helper->hasCancelledMolliePayment($order->get_id());;
+
+        if ($hasCancelledMolliePayment)
         {
             Mollie_WC_Plugin::addNotice(__('You have cancelled your payment. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'));
 
@@ -875,13 +973,23 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
      */
     public function displayInstructions(WC_Order $order, $admin_instructions = false, $plain_text = false)
     {
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $order_payment_method = $order->payment_method;
+	    } else {
+		    $order_payment_method = $order->get_payment_method();
+	    }
+
         // Invalid gateway
-        if ($this->id !== $order->payment_method)
+        if ($this->id !== $order_payment_method)
         {
             return;
         }
 
-        $payment = Mollie_WC_Plugin::getDataHelper()->getActiveMolliePayment($order->id);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $payment = Mollie_WC_Plugin::getDataHelper()->getActiveMolliePayment($order->id);
+	    } else {
+		    $payment = Mollie_WC_Plugin::getDataHelper()->getActiveMolliePayment($order->get_id());
+	    }
 
         // Mollie payment not found or invalid gateway
         if (!$payment || $payment->method != $this->getMollieMethodId())
@@ -1005,10 +1113,18 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $site_url   = get_site_url();
 
         $return_url = WC()->api_request_url('mollie_return');
-        $return_url = add_query_arg(array(
-            'order_id'       => $order->id,
-            'key'            => $order->order_key,
-        ), $return_url);
+
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $return_url = add_query_arg(array(
+			    'order_id'       => $order->id,
+			    'key'            => $order->order_key,
+		    ), $return_url);
+	    } else {
+		    $return_url = add_query_arg(array(
+			    'order_id'       => $order->get_id(),
+			    'key'            => $order->get_order_key(),
+		    ), $return_url);
+	    }
 
         $lang_url   = $this->getSiteUrlWithLanguage();
         $return_url = str_replace($site_url, $lang_url, $return_url);
@@ -1025,10 +1141,18 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $site_url    = get_site_url();
 
         $webhook_url = WC()->api_request_url(strtolower(get_class($this)));
-        $webhook_url = add_query_arg(array(
-            'order_id' => $order->id,
-            'key'      => $order->order_key,
-        ), $webhook_url);
+
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $webhook_url = add_query_arg(array(
+			    'order_id' => $order->id,
+			    'key'      => $order->order_key,
+		    ), $webhook_url);
+	    } else {
+		    $webhook_url = add_query_arg(array(
+			    'order_id' => $order->get_id(),
+			    'key'      => $order->get_order_key(),
+		    ), $webhook_url);
+	    }
 
         $lang_url    = $this->getSiteUrlWithLanguage();
         $webhook_url = str_replace($site_url, $lang_url, $webhook_url);

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
@@ -420,7 +420,7 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 	        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		        update_post_meta( $orderId, '_mollie_customer_id', $customer_id );
 	        } else {
-		        $order = wc_get_order( 100 );
+		        $order = wc_get_order( $orderId );
 		        $order->update_meta_data( '_mollie_customer_id', $customer_id );
 		        $order->save();
 	        }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
@@ -355,7 +355,7 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 		    $order->update_meta_data( '_mollie_payment_id', $payment->id );
 		    $order->update_meta_data( '_mollie_payment_mode', $payment->mode );
 
-		    $order->delete_meta_data( '_mollie_cancelled_payment_id' );
+		    $order->delete_meta_data( array ( '_mollie_cancelled_payment_id' ) );
 
 		    if ( $payment->customerId ) {
 			    $order->update_meta_data( '_mollie_customer_id', $payment->customerId );
@@ -372,10 +372,10 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 
 		    foreach ( $subscriptions as $subscription ) {
 			    $this->unsetActiveMolliePayment( $subscription->id );
-			    $subscription->delete_meta_data( '_mollie_customer_id' );
+			    $subscription->delete_meta_data( array ( '_mollie_customer_id' ) );
 			    $subscription->update_meta_data( '_mollie_payment_id', $payment->id );
 			    $subscription->update_meta_data( '_mollie_payment_mode', $payment->mode );
-			    $subscription->delete_meta_data( '_mollie_cancelled_payment_id' );
+			    $subscription->delete_meta_data( array ( '_mollie_cancelled_payment_id' ) );
 			    if ( $payment->customerId ) {
 				    $subscription->update_meta_data( '_mollie_customer_id', $payment->customerId );
 			    }
@@ -400,8 +400,8 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 		    delete_post_meta($order_id, '_mollie_payment_mode');
 	    } else {
 		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
-		    $order->delete_meta_data( '_mollie_payment_id' );
-		    $order->delete_meta_data( '_mollie_payment_mode' );
+		    $order->delete_meta_data( array ( '_mollie_payment_id' ) );
+		    $order->delete_meta_data( array ( '_mollie_payment_mode' ) );
 		    $order->save();
 	    }
 
@@ -535,10 +535,10 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 		    delete_post_meta( $renewal_order->id, '_mollie_payment_mode' );
 		    delete_post_meta( $renewal_order->id, '_mollie_cancelled_payment_id' );
 	    } else {
-		    $renewal_order->delete_meta_data( '_mollie_card_4_digits' );
-		    $renewal_order->delete_meta_data( '_mollie_payment_id' );
-		    $renewal_order->delete_meta_data( '_mollie_payment_mode' );
-		    $renewal_order->delete_meta_data( '_mollie_cancelled_payment_id' );
+		    $renewal_order->delete_meta_data( array ( '_mollie_card_4_digits' ) );
+		    $renewal_order->delete_meta_data( array ( '_mollie_payment_id' ) );
+		    $renewal_order->delete_meta_data( array ( '_mollie_payment_mode' ) );
+		    $renewal_order->delete_meta_data( array ( '_mollie_cancelled_payment_id' ) );
 		    $renewal_order->save();
 	    }
 

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
@@ -420,7 +420,7 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 	        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		        update_post_meta( $orderId, '_mollie_customer_id', $customer_id );
 	        } else {
-		        $order = wc_get_order( $orderId );
+		        $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $orderId );
 		        $order->update_meta_data( '_mollie_customer_id', $customer_id );
 		        $order->save();
 	        }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
@@ -81,10 +81,17 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
         $return_url          = $this->getReturnUrl($order);
         $webhook_url         = $this->getWebhookUrl($order);
 
-        $payment_description = strtr($payment_description, array(
-            '{order_number}' => $order->get_order_number(),
-            '{order_date}'   => date_i18n(wc_date_format(), strtotime($order->order_date)),
-        ));
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $payment_description = strtr($payment_description, array(
+			    '{order_number}' => $order->get_order_number(),
+			    '{order_date}'   => date_i18n(wc_date_format(), strtotime($order->order_date)),
+		    ));
+	    } else {
+		    $payment_description = strtr($payment_description, array(
+			    '{order_number}' => $order->get_order_number(),
+			    '{order_date}'   => date_i18n(wc_date_format(), $order->get_date_created()->getTimestamp()),
+		    ));
+	    }
 
 	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		    $data = array_filter(array(

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractsubscription.php
@@ -86,14 +86,7 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 			    '{order_number}' => $order->get_order_number(),
 			    '{order_date}'   => date_i18n(wc_date_format(), strtotime($order->order_date)),
 		    ));
-	    } else {
-		    $payment_description = strtr($payment_description, array(
-			    '{order_number}' => $order->get_order_number(),
-			    '{order_date}'   => date_i18n(wc_date_format(), $order->get_date_created()->getTimestamp()),
-		    ));
-	    }
 
-	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		    $data = array_filter(array(
 			    'amount'          => $order->get_total(),
 			    'description'     => $payment_description,
@@ -109,6 +102,11 @@ abstract class Mollie_WC_Gateway_AbstractSubscription extends Mollie_WC_Gateway_
 			    'customerId'      => $customer_id,
 		    ));
 	    } else {
+		    $payment_description = strtr($payment_description, array(
+			    '{order_number}' => $order->get_order_number(),
+			    '{order_date}'   => date_i18n(wc_date_format(), $order->get_date_created()->getTimestamp()),
+		    ));
+
 		    $data = array_filter(array(
 			    'amount'          => $order->get_total(),
 			    'description'     => $payment_description,

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/banktransfer.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/banktransfer.php
@@ -75,10 +75,12 @@ class Mollie_WC_Gateway_BankTransfer extends Mollie_WC_Gateway_Abstract
             $args['dueDate'] = $expiry_date;
         }
 
+	    $order_billing_email = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $order->billing_email : $order->get_billing_email();
+
         // Mail payment instructions
-        if ($this->get_option('mail_payment_instructions') === 'yes' && !empty($order->billing_email))
+        if ($this->get_option('mail_payment_instructions') === 'yes' && !empty($order_billing_email))
         {
-            $args['billingEmail'] = trim($order->billing_email);
+            $args['billingEmail'] = trim($order_billing_email);
         }
 
         return $args;

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -490,7 +490,13 @@ class Mollie_WC_Helper_Data
     {
         if (!empty($customer_id))
         {
-            update_user_meta($user_id, 'mollie_customer_id', $customer_id);
+	        if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		        update_user_meta( $user_id, 'mollie_customer_id', $customer_id );
+	        } else {
+		        $customer = new WC_Customer( $user_id );
+		        $customer->update_meta_data( 'mollie_customer_id', $customer_id );
+		        $customer->save();
+	        }
         }
 
         return $this;
@@ -508,7 +514,12 @@ class Mollie_WC_Helper_Data
             return NULL;
         }
 
-        $customer_id = get_user_meta($user_id, 'mollie_customer_id', $single = true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $customer_id = get_user_meta( $user_id, 'mollie_customer_id', $single = true );
+	    } else {
+		    $customer    = new WC_Customer( $user_id );
+		    $customer_id = $customer->get_meta( 'mollie_customer_id' );
+	    }
 
         if (empty($customer_id))
         {

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -634,15 +634,15 @@ class Mollie_WC_Helper_Data
         {
             if ($item['product_id'] > 0)
             {
-                $product = $order->get_product_from_item($item);
+	            $product = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $order->get_product_from_item($item) : $item->get_product();
 
-                if ($product && $product->exists() && $product->managing_stock())
+	            if ($product && $product->exists() && $product->managing_stock())
                 {
-                    $old_stock = $product->stock;
+	                $old_stock = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $product->stock : $product->get_stock_quantity();
 
                     $qty = apply_filters( 'woocommerce_order_item_quantity', $item['qty'], $order, $item);
 
-                    $new_quantity = $product->increase_stock( $qty );
+	                $new_quantity = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $product->increase_stock( $qty ) : wc_update_product_stock( $product, $qty, 'increase');
 
                     do_action('woocommerce_auto_stock_restored', $product, $item);
 

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -67,7 +67,7 @@ class Mollie_WC_Helper_Data
         $max_option_name_length = 191;
 
         /**
-         * Prior to Wordpress version 4.4.0, the maximum length for wp_options.option_name is 64 characters.
+         * Prior to WooPress version 4.4.0, the maximum length for wp_options.option_name is 64 characters.
          * @see https://core.trac.wordpress.org/changeset/34030
          */
         if ($wp_version < '4.4.0') {

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -186,7 +186,9 @@ class Mollie_WC_Helper_Data
             }
         }
 
-        return isset($payment_gateways[$order->payment_method]) ? $payment_gateways[$order->payment_method] : false;
+	    $order_payment_method = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? $order->payment_method : $order->get_payment_method();
+
+	    return isset($payment_gateways[$order_payment_method]) ? $payment_gateways[$order_payment_method] : false;
     }
 
     /**
@@ -657,6 +659,10 @@ class Mollie_WC_Helper_Data
         }
 
         // Mark order stock as not-reduced
-        delete_post_meta($order->id, '_order_stock_reduced');
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    delete_post_meta($order->id, '_order_stock_reduced');
+	    } else {
+		    delete_post_meta($order->get_id(), '_order_stock_reduced');
+	    }
     }
 }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -453,15 +453,30 @@ class Mollie_WC_Helper_Data
      */
     public function setActiveMolliePayment ($order_id, Mollie_API_Object_Payment $payment)
     {
-        add_post_meta($order_id, '_mollie_payment_id', $payment->id, $single = true);
-        add_post_meta($order_id, '_mollie_payment_mode', $payment->mode, $single = true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    add_post_meta( $order_id, '_mollie_payment_id', $payment->id, $single = true );
+		    add_post_meta( $order_id, '_mollie_payment_mode', $payment->mode, $single = true );
 
-        delete_post_meta($order_id, '_mollie_cancelled_payment_id');
+		    delete_post_meta( $order_id, '_mollie_cancelled_payment_id' );
 
-        if ($payment->customerId)
-        {
-            add_post_meta($order_id, '_mollie_customer_id', $payment->customerId, $single = true);
-        }
+		    if ( $payment->customerId ) {
+			    add_post_meta( $order_id, '_mollie_customer_id', $payment->customerId, $single = true );
+		    }
+
+	    } else {
+		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+
+		    $order->update_meta_data( '_mollie_payment_id', $payment->id );
+		    $order->update_meta_data( '_mollie_payment_mode', $payment->mode );
+
+		    $order->delete_meta_data( '_mollie_cancelled_payment_id' );
+
+		    if ( $payment->customerId ) {
+			    $order->update_meta_data( '_mollie_customer_id', $payment->customerId );
+		    }
+
+		    $order->save();
+	    }
 
         return $this;
     }
@@ -531,8 +546,15 @@ class Mollie_WC_Helper_Data
      */
     public function unsetActiveMolliePayment ($order_id)
     {
-        delete_post_meta($order_id, '_mollie_payment_id');
-        delete_post_meta($order_id, '_mollie_payment_mode');
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    delete_post_meta($order_id, '_mollie_payment_id');
+		    delete_post_meta($order_id, '_mollie_payment_mode');
+	    } else {
+		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+		    $order->delete_meta_data( '_mollie_payment_id' );
+		    $order->delete_meta_data( '_mollie_payment_mode' );
+		    $order->save();
+	    }
 
         return $this;
     }
@@ -545,7 +567,14 @@ class Mollie_WC_Helper_Data
      */
     public function getActiveMolliePaymentId ($order_id)
     {
-        return get_post_meta($order_id, '_mollie_payment_id', $single = true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $mollie_payment_id = get_post_meta( $order_id, '_mollie_payment_id', $single = true );
+	    } else {
+		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+		    $mollie_payment_id = $order->get_meta( '_mollie_payment_id', true );
+	    }
+
+	    return $mollie_payment_id;
     }
 
     /**
@@ -556,7 +585,14 @@ class Mollie_WC_Helper_Data
      */
     public function getActiveMolliePaymentMode ($order_id)
     {
-        return get_post_meta($order_id, '_mollie_payment_mode', $single = true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $mollie_payment_mode = get_post_meta( $order_id, '_mollie_payment_mode', $single = true );
+	    } else {
+		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+		    $mollie_payment_mode = $order->get_meta( '_mollie_payment_mode', true );
+	    }
+
+	    return $mollie_payment_mode;
     }
 
     /**
@@ -598,7 +634,13 @@ class Mollie_WC_Helper_Data
      */
     public function setCancelledMolliePaymentId ($order_id, $payment_id)
     {
-        add_post_meta($order_id, '_mollie_cancelled_payment_id', $payment_id, $single = true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+	    	add_post_meta($order_id, '_mollie_cancelled_payment_id', $payment_id, $single = true);
+	    } else {
+		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+		    $order->update_meta_data( '_mollie_cancelled_payment_id', $payment_id );
+		    $order->save();
+	    }
 
         return $this;
     }
@@ -609,7 +651,14 @@ class Mollie_WC_Helper_Data
      */
     public function getCancelledMolliePaymentId ($order_id)
     {
-        return get_post_meta($order_id, '_mollie_cancelled_payment_id', $single = true);
+	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		    $mollie_cancelled_payment_id = get_post_meta( $order_id, '_mollie_cancelled_payment_id', $single = true );
+	    } else {
+		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+		    $mollie_cancelled_payment_id = $order->get_meta( '_mollie_cancelled_payment_id', true );
+	    }
+
+        return $mollie_cancelled_payment_id;
     }
 
     /**
@@ -662,7 +711,8 @@ class Mollie_WC_Helper_Data
 	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		    delete_post_meta($order->id, '_order_stock_reduced');
 	    } else {
-		    delete_post_meta($order->get_id(), '_order_stock_reduced');
+		    $order->delete_meta_data( '_order_stock_reduced' );
+		    $order->save();
 	    }
     }
 }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -469,7 +469,7 @@ class Mollie_WC_Helper_Data
 		    $order->update_meta_data( '_mollie_payment_id', $payment->id );
 		    $order->update_meta_data( '_mollie_payment_mode', $payment->mode );
 
-		    $order->delete_meta_data( '_mollie_cancelled_payment_id' );
+		    $order->delete_meta_data( array ( '_mollie_cancelled_payment_id' ) );
 
 		    if ( $payment->customerId ) {
 			    $order->update_meta_data( '_mollie_customer_id', $payment->customerId );
@@ -551,8 +551,8 @@ class Mollie_WC_Helper_Data
 		    delete_post_meta($order_id, '_mollie_payment_mode');
 	    } else {
 		    $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
-		    $order->delete_meta_data( '_mollie_payment_id' );
-		    $order->delete_meta_data( '_mollie_payment_mode' );
+		    $order->delete_meta_data( array ( '_mollie_payment_id' ) );
+		    $order->delete_meta_data( array ( '_mollie_payment_mode' ) );
 		    $order->save();
 	    }
 
@@ -711,7 +711,7 @@ class Mollie_WC_Helper_Data
 	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 		    delete_post_meta($order->id, '_order_stock_reduced');
 	    } else {
-		    $order->delete_meta_data( '_order_stock_reduced' );
+		    $order->delete_meta_data( array(  '_order_stock_reduced' ));
 		    $order->save();
 	    }
     }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/data.php
@@ -713,7 +713,9 @@ class Mollie_WC_Helper_Data
                         $new_quantity
                     ));
 
-                    $order->send_stock_notifications($product, $new_quantity, $item['qty']);
+	                if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
+		                $order->send_stock_notifications( $product, $new_quantity, $item['qty'] );
+	                }
                 }
             }
         }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/settings.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/settings.php
@@ -428,7 +428,7 @@ class Mollie_WC_Helper_Settings
         $max_option_name_length = 191;
 
         /**
-         * Prior to Wordpress version 4.4.0, the maximum length for wp_options.option_name is 64 characters.
+         * Prior to WooPress version 4.4.0, the maximum length for wp_options.option_name is 64 characters.
          * @see https://core.trac.wordpress.org/changeset/34030
          */
         if ($wp_version < '4.4.0') {

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -337,7 +337,7 @@ class Mollie_WC_Plugin
         // Convert message to string
         if (!is_string($message))
         {
-            $message = print_r($message, true);
+            $message = ( version_compare( WC_VERSION, '3.0', '<' ) ) ? print_r($message, true) : wc_print_r($message, true);
         }
 
         // Set debug header
@@ -346,19 +346,31 @@ class Mollie_WC_Plugin
             header("X-Mollie-Debug: $message");
         }
 
-        // Log message
-        if (self::getSettingsHelper()->isDebugEnabled())
-        {
-            static $logger;
+	    // Log message
+	    if ( self::getSettingsHelper()->isDebugEnabled() ) {
 
-            if (empty($logger))
-            {
-                // TODO: Use error_log() fallback if Wc_Logger is not available
-                $logger = new WC_Logger();
-            }
+		    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 
-            $logger->add(self::PLUGIN_ID . '-' . date('Y-m-d'), $message);
-        }
+			    static $logger;
+
+			    if ( empty( $logger ) ) {
+				    // TODO: Use error_log() fallback if Wc_Logger is not available
+				    $logger = new WC_Logger();
+			    }
+
+			    $logger->add( self::PLUGIN_ID . '-' . date( 'Y-m-d' ), $message );
+
+		    } else {
+
+			    $logger = wc_get_logger();
+
+			    $context = array ( 'source' => self::PLUGIN_ID . '-' . date( 'Y-m-d' ) );
+
+			    $logger->debug( $message, $context );
+
+		    }
+
+	    }
     }
 
     /**

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -89,7 +89,7 @@ class Mollie_WC_Plugin
         $currentDate = new DateTime();
         $items = $wpdb->get_results("SELECT * FROM {$wpdb->mollie_pending_payment} WHERE expired_time < {$currentDate->getTimestamp()};");
         foreach ($items as $item){
-            $order =  wc_get_order( $item->post_id );
+	        $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $item->post_id );
             if ($order->get_status() == Mollie_WC_Gateway_Abstract::STATUS_COMPLETED){
 
                 $new_order_status = Mollie_WC_Gateway_Abstract::STATUS_FAILED;

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -97,8 +97,8 @@ class Mollie_WC_Plugin
 		            $paymentMethodId = get_post_meta( $order->id, '_payment_method_title', true );
 		            $molliePaymentId = get_post_meta( $order->id, '_mollie_payment_id', true );
 	            } else {
-		            $paymentMethodId = get_post_meta( $order->get_id(), '_payment_method_title', true );
-		            $molliePaymentId = get_post_meta( $order->get_id(), '_mollie_payment_id', true );
+		            $paymentMethodId = $order->get_meta( '_payment_method_title', true );
+		            $molliePaymentId = $order->get_meta( '_mollie_payment_id', true );
 	            }
                 $order->add_order_note(sprintf(
                 /* translators: Placeholder 1: payment method title, placeholder 2: payment ID */
@@ -123,7 +123,7 @@ class Mollie_WC_Plugin
 			            )
 		            );
 	            } else {
-		            if ( get_post_meta( $order->get_id(), '_order_stock_reduced', $single = true ) ) {
+		            if ( $order->get_meta( '_order_stock_reduced', $single = true ) ) {
 			            // Restore order stock
 			            Mollie_WC_Plugin::getDataHelper()->restoreOrderStock( $order );
 

--- a/mollie-payments-for-woocommerce/readme.txt
+++ b/mollie-payments-for-woocommerce/readme.txt
@@ -114,13 +114,13 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 == Changelog ==
 
 = 2.5.5 - 31/03/2017 =
-* Allow the option name to have maximum 191 characters for newer Wordpress installations.
+* Allow the option name to have maximum 191 characters for newer WooPress installations.
 
 = 2.5.4 - 07/03/2017 =
 * Added an option to disable storing the customer details at Mollie
 
 = 2.5.3 - 01/03/2017 =
-* Bugfix for crashing Wordpress when using PHP version 5.3 or lower
+* Bugfix for crashing WooPress when using PHP version 5.3 or lower
 
 = 2.5.2 - 28/02/2017 =
 * The plugin is now compatible with WooCommerce Subscriptions for recurring payments


### PR DESCRIPTION
Pull request for switch to WooCommerce 3.0 get_ methods, backwards compatible with older versions of WooCommerce.

Issue: https://github.com/mollie/WooCommerce/issues/89