### PR TITLE
Fix wrong date formatting

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/banktransfer.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/banktransfer.php
@@ -212,7 +212,7 @@ class Mollie_WC_Gateway_BankTransfer extends Mollie_WC_Gateway_Abstract
             {
                 $expiry_date = DateTime::createFromFormat( 'U', time() );
 	            $expiry_date->add( new DateInterval( $payment->expiryPeriod ) );
-	            $expiry_date = $expiry_date->format( wc_date_format() );
+	            $expiry_date = $expiry_date->format( 'Y-m-d H:i:s' );
 	            $expiry_date = date_i18n( wc_date_format(), strtotime( $expiry_date ) );
 
                 if ($admin_instructions)


### PR DESCRIPTION
Fix wrong date formatting in some cases. For example when the specified date format in WP is 'd/m/Y' then strtotime will parse a date like '05/11/2017' as 'm/d/Y' (see strtotime for details) which causes the month and date to be flipped. Instead, we should format the date in a specific accepted format (for example 'Y-m-d H:i:s') to prevent this problem. Afterwards it is correctly formatted for display using date_i18n and wc_date_format anyway.

Sidenote: I have not tested the change, but it should work.