### PR TITLE
Fixes #211, Removes fatal error for thankyou page without valid order

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -1387,6 +1387,9 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 	 * @param WC_Order $order
 	 */
 	public function onOrderReceivedText( $text, $order ) {
+		if ( !is_a( $order, 'WC_Order' ) ) {
+			return $text;
+		}
 
 		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
 			$order_payment_method = $order->payment_method;


### PR DESCRIPTION
Fixes #211 

This check prevents the mollie-for-woocommerce plugin from triggering a fatal error when the filter on https://github.com/woocommerce/woocommerce/blob/3.4.1/templates/checkout/thankyou.php#L83 is called.