### PR TITLE
Added New action hook in Mollie_WC_Gateway_Abstract::getReturnRedirec…

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -1421,7 +1421,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 			}
 
 		}
-
+		
+		do_action( Mollie_WC_Plugin::PLUGIN_ID . '_payment_success', $order );
 		/*
 		 * Return to order received page
 		 */


### PR DESCRIPTION
Hi Devs, 

From last few days, we are working towards making our plugin UpSroke: Upsells for WooCommerce compatible with "mollie for WooCommerce." 

As we just completed the integration on our end, there we need confirmation for a payment processed by Mollie. 

For other WooCommerce gateways, we rely upon WC_Order::payment_complete() function to set up the funnel after the payment process. 

However, in the case of Mollie, we cannot use that method as the success of payment received by the webhook & we cannot wait until webhook received and executes WC_Order::payment_complete(). 

So we figured out a need of action hook to initiate the funnel when mollie completes the return handling of a customer to store. 

it would be great if this change reviewed and approved as soon as possible. 

Thanks.