### PR TITLE
WIP: Automated deployment of the plugin to Wordpress

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,49 +1,81 @@
-#! /bin/bash
-# Original by https://github.com/GaryJones/wordpress-plugin-git-flow-svn-deploy
-set -e
+#!/usr/bin/env bash
+# Script for deploying the Mollie WooCommerce plugin to the Wordpress store. This script is a modified version of the
+# following script: https://github.com/GaryJones/wordpress-plugin-svn-deploy.
+#
+# All prompts for input were replaced by hardcoded variables or environment variables to make it fully automated.
+#
+# Steps to deploying:
+#
+#  1. Check local plugin directory exists.
+#  2. Check main plugin file exists.
+#  3. Check readme.txt version matches main plugin file version.
+#  4. Check if Git tag exists for version number (must match exactly).
+#  5. Checkout SVN repo.
+#  6. Set to SVN ignore some the files we don't need to commit.
+#  7. Export HEAD of master from git to the trunk of SVN.
+#  8. Initialise and update git submodules.
+#  9. Install Composer and install the required dependencies of the submodules.
+# 10. Move /trunk/assets up to /assets.
+# 11. Move into /trunk, and SVN commit.
+# 12. Move into /assets, and SVN commit.
+# 13. Copy /trunk into /tags/{version}, and SVN commit.
+# 14. Delete temporary local SVN checkout.
 
 echo
-echo "Deploy mollie-payments-for-woocommerce WordPress Plugin"
+echo "Mollie WooCommerce Plugin SVN Deploy"
 echo
 
-# Set up some default values. Feel free to change these in your own script
-CURRENTDIR=`pwd`
+# Set the required variables to deploy.
 PLUGINSLUG="mollie-payments-for-woocommerce"
+CURRENTDIR=$(pwd)
+SVNPATH="$CURRENTDIR/deployment/$PLUGINSLUG"
+SVNURL="https://plugins.svn.wordpress.org/$PLUGINSLUG"
+SVNUSER="molopsdeploy"
 PLUGINDIR="$CURRENTDIR/$PLUGINSLUG"
-SVNPATH="/tmp/$PLUGINSLUG"
-SVNURL="http://plugins.svn.wordpress.org/$PLUGINSLUG"
 MAINFILE="$PLUGINSLUG.php"
 
-default_svnuser="mollie"
+# Check directory exists.
+if [ ! -d "$PLUGINDIR" ]; then
+  echo "Directory $PLUGINDIR not found. Aborting."
+  exit 1;
+fi
 
-# Get some user input
-# Can't use the -i flag for read, since that doesn't work for bash 3
+# Check main plugin file exists.
+if [ ! -f "$PLUGINDIR/$MAINFILE" ]; then
+  echo "Plugin file $PLUGINDIR/$MAINFILE not found. Aborting."
+  exit 1;
+fi
 
-printf "Your WordPress repo SVN username ($default_svnuser): "
-read -e input
-SVNUSER="${input:-$default_svnuser}" # Populate with default if empty
+echo "Checking version in main plugin file matches version in readme.txt file..."
+echo
+
+# Check version in readme.txt is the same as plugin file after translating both
+# to Unix line breaks to work around grep's failure to identify Mac line breaks.
+PLUGINVERSION=$(grep -i "Version:" $PLUGINDIR/$MAINFILE | awk -F' ' '{print $NF}' | tr -d '\r')
+echo "$MAINFILE version: $PLUGINVERSION"
+READMEVERSION=$(grep -i "Stable tag:" $PLUGINDIR/readme.txt | awk -F' ' '{print $NF}' | tr -d '\r')
+echo "readme.txt version: $READMEVERSION"
+
+if [ "$READMEVERSION" = "trunk" ]; then
+	echo "Version in readme.txt & $MAINFILE don't match, but Stable tag is trunk. Let's continue..."
+elif [ "$PLUGINVERSION" != "$READMEVERSION" ]; then
+	echo "Version in readme.txt & $MAINFILE don't match. Exiting...."
+	exit 1;
+elif [ "$PLUGINVERSION" = "$READMEVERSION" ]; then
+	echo "Versions match in readme.txt and $MAINFILE. Let's continue..."
+fi
+
 echo
 
 echo "That's all of the data collected."
 echo
 echo "Slug: $PLUGINSLUG"
+echo "Plugin directory: $PLUGINDIR"
+echo "Main file: $MAINFILE"
 echo "Temp checkout path: $SVNPATH"
 echo "Remote SVN repo: $SVNURL"
 echo "SVN username: $SVNUSER"
-echo "Plugin directory: $PLUGINDIR"
-echo "Main file: $MAINFILE"
 echo
-
-printf "OK to proceed (Y|n)? "
-read -e input
-PROCEED="${input:-y}"
-echo
-
-# Allow user cancellation
-if [ "$PROCEED" != "y" -a "$PROCEED" != "Y" ]; then echo "Aborting..."; exit 1; fi
-
-# git config
-GITPATH="$PLUGINDIR/" # this file should be in the base of your git repository
 
 # Let's begin...
 echo ".........................................."
@@ -53,98 +85,126 @@ echo
 echo ".........................................."
 echo
 
-# Check version in readme.txt is the same as plugin file after translating both to unix line breaks to work around grep's failure to identify mac line breaks
-PLUGINVERSION=`grep "Version:" $PLUGINDIR/$MAINFILE | awk -F' ' '{print $NF}' | tr -d '\r'`
-echo "$MAINFILE version: $PLUGINVERSION"
-READMEVERSION=`grep "^Stable tag:" $PLUGINDIR/readme.txt | awk -F' ' '{print $NF}' | tr -d '\r'`
-echo "readme.txt version: $READMEVERSION"
+echo
 
-if [ "$READMEVERSION" = "trunk" ]; then
-	echo "Version in readme.txt & $MAINFILE don't match, but Stable tag is trunk. Let's proceed..."
-elif [ "$PLUGINVERSION" != "$READMEVERSION" ]; then
-	echo "Version in readme.txt & $MAINFILE don't match. Exiting...."
-	exit 1;
-elif [ "$PLUGINVERSION" = "$READMEVERSION" ]; then
-	echo "Versions match in readme.txt and $MAINFILE. Let's proceed..."
-fi
+echo "Changing to $PLUGINDIR"
+cd $PLUGINDIR
 
+# Check for git tag (may need to allow for leading "v"?)
+# if git show-ref --tags --quiet --verify -- "refs/tags/$PLUGINVERSION"
 if git show-ref --tags --quiet --verify -- "refs/tags/$PLUGINVERSION"
 	then
-		echo "Version $PLUGINVERSION already exists as git tag. Exiting....";
-		exit 1;
+		echo "Git tag $PLUGINVERSION does exist. Let's continue..."
 	else
-		echo "Git version does not exist. Let's proceed..."
+		echo "$PLUGINVERSION does not exist as a git tag. Aborting.";
+		exit 1;
 fi
 
-default_commitmsg="Release $PLUGINVERSION, see readme.txt for changelog."
-
-printf "Enter a commit message for this new version ($default_commitmsg): "
-read -e input
-COMMITMSG="${input:-$default_commitmsg}" # Populate with default if empty
-git commit -am "$COMMITMSG"
-
-echo "Tagging new version in git"
-git tag -a "$PLUGINVERSION" -m "Tagging version $PLUGINVERSION"
-
-echo "Pushing git master to origin, with tags"
-git push origin master
-git push origin master --tags
-
 echo
-echo "Clear $SVNPATH"
-rm -fr $SVNPATH/
 
-echo
-echo "Creating local copy of SVN repo trunk ..."
+echo "Creating local copy of SVN repo trunk..."
 svn checkout $SVNURL $SVNPATH --depth immediates
 svn update --quiet $SVNPATH/trunk --set-depth infinity
 
-echo "Ignoring GitHub specific files"
-svn propset svn:ignore "README.md
-Thumbs.db
-.git
-.gitignore" "$SVNPATH/trunk/"
+# Remove all files from the SVN trunk, the correct files will be added below.
+rm -rf $SVNPATH/trunk/*
 
-echo "Copying plugin files to the trunk of SVN"
-rsync $PLUGINSLUG/* -ri --del -m --exclude ".*" $SVNPATH/trunk/ | grep sT
+# Go back to root repository folder; the master & submodules need to checked out from here.
+echo "Changing to $CURRENTDIR"
+cd $CURRENTDIR
+
+echo "Exporting the HEAD of master from git to the trunk of SVN"
+git checkout-index -a -f --prefix=$SVNPATH/trunk/
+
+# If submodule exist, recursively check out their indexes
+if [ -f ".gitmodules" ]
+	then
+		echo "Exporting the HEAD of each submodule from git to the trunk of SVN"
+		git submodule init
+		git submodule update
+		git config -f .gitmodules --get-regexp '^submodule\..*\.path$' |
+			while read path_key path
+			do
+				echo "This is the submodule path: $path"
+				echo "The following line is the command to checkout the submodule."
+				echo "git submodule foreach --recursive 'git checkout-index -a -f --prefix=$SVNPATH/trunk/$path/'"
+				git submodule foreach --recursive "git checkout-index -a -f --prefix=$SVNPATH/trunk/$path/"
+			done
+fi
+
+echo
+
+# Install Composer, and use it to install all the submodule's dependencies.
+./deployment/install_composer.sh
+find $SVNPATH/trunk/$PLUGINSLUG/includes -name "composer.json" | while read line; do
+    ./composer.phar install --no-dev --working-dir=$(dirname -- $line)
+done
 
 # Support for the /assets folder on the .org repo.
-echo "Moving assets"
+echo "Moving assets."
 # Make the directory if it doesn't already exist
 mkdir -p $SVNPATH/assets/
-rsync $CURRENTDIR/assets/* -ri --del -m --exclude ".*" $SVNPATH/assets/ | grep sT
+mv $SVNPATH/trunk/assets/* $SVNPATH/assets/
 svn add --force $SVNPATH/assets/
 
-echo "Changing directory to SVN and committing to trunk"
-cd $SVNPATH/trunk/
+echo
+
+echo "Changing directory to SVN folder."
+cd $SVNPATH
+
+# Move all files inside the 'mollie-payments-for-woocommerce' to a temporary folder, then
+# remove all leftover files in the trunk folder, and return the moved files to the trunk folder.
+echo "Only include the plugin folder's files from the GitHub repository in the SVN trunk"
+mkdir ./temp_trunk/
+mv ./trunk/$PLUGINSLUG/* ./temp_trunk/
+rm -rf ./trunk
+mv ./temp_trunk ./trunk
+
+# Now that all files are in the correct positions, we can ignore a bunch of files.
+echo "Ignoring all the files we won't need to commit to SVN"
+svn propset svn:ignore -R -F $CURRENTDIR/deployment/.svnignore "$SVNPATH/trunk/"
+
 # Delete all files that should not now be added.
 svn status | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs svn del
 # Add all new files that are not set to be ignored
 svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs svn add
+
+# The script is still WIP; don't do any commits!
+exit 1
+
+echo "Committing to trunk."
 svn commit --username=$SVNUSER -m "Preparing for $PLUGINVERSION release"
 
-echo "Updating WordPress plugin repo assets and committing"
+echo
+
+# Stop at this point.
+
+echo "Updating WordPress plugin repo assets and committing."
 cd $SVNPATH/assets/
 # Delete all new files that are not set to be ignored
 svn status | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs svn del
 # Add all new files that are not set to be ignored
 svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs svn add
-svn update --accept mine-full $SVNPATH/assets/*
-svn commit --username=$SVNUSER -m "Updating assets for $PLUGINVERSION release"
+svn update --quiet --accept working $SVNPATH/assets/*
+svn commit --username=$SVNUSER -m "Updating assets"
 
-echo "Creating new SVN tag and committing it"
+echo
+
+echo "Creating new SVN tag and committing it."
 cd $SVNPATH
-svn update --quiet $SVNPATH/tags/$PLUGINVERSION
 svn copy --quiet trunk/ tags/$PLUGINVERSION/
 # Remove assets and trunk directories from tag directory
-# svn delete --force --quiet $SVNPATH/tags/$PLUGINVERSION/assets
-# svn delete --force --quiet $SVNPATH/tags/$PLUGINVERSION/trunk
+svn delete --force --quiet $SVNPATH/tags/$PLUGINVERSION/assets
+svn delete --force --quiet $SVNPATH/tags/$PLUGINVERSION/trunk
+svn update --quiet --accept working $SVNPATH/tags/$PLUGINVERSION
 cd $SVNPATH/tags/$PLUGINVERSION
 svn commit --username=$SVNUSER -m "Tagging version $PLUGINVERSION"
 
-echo "Removing temporary directory $SVNPATH"
+echo
+
+echo "Removing temporary directory $SVNPATH."
 cd $SVNPATH
 cd ..
 rm -fr $SVNPATH/
 
-echo "*** FINISHED ***"
+echo "*** FIN ***"

--- a/deployment/.svnignore
+++ b/deployment/.svnignore
@@ -1,0 +1,6 @@
+.*
+build
+tests
+phpunit.xml
+Thumbs.db
+composer.lock

--- a/deployment/install_composer.sh
+++ b/deployment/install_composer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Script to install composer programmatically. SOURCE:
+# https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
This branch will contain an updated deployment script that automatically prepares a new version of the WooCommerce plugin and releases it to the Wordpress store. Thanks @davdebcom, for helping out to make this possible.

The base deployment script that has been adjusted can be seen in this repository: https://github.com/GaryJones/wordpress-plugin-svn-deploy

Modifications made to fit the script to our plugin structure:
- Replaced input prompts by hardcoded values.
- Remove all the files from the Wordpress SVN trunk before checkout out all the plugin files, otherwise the checkout process will not execute successfully.
- Install Composer in the script and automatically install all the dependencies of the libraries that the WooCommerce plugin requires, by searching for all `composer.json` files.
- Automatically ignore all files we don't want to commit to SVN, which is defined in `deployment/.svnignore`.

The script is still WIP, and it is halted before actually committing the changes to SVN. All files seem to be in place correctly, except for that one `mollie-api-php` endpoint class and example are deleted for some reason. To see the changes that would be committed to SVN, please run the following commands from the root of this repository, after running the deployment script:
```
cd deployment/mollie-payments-for-woocommerce
svn status
```

After verifying that the file structure is as it should be, we should probably test locally that the committing process actually works, and then configure Travis to run this when a new tag is pushed to master, using the correct credentials.

Tagging @davdebcom & @willemstuursma for feedback.