### PR TITLE
Only return the last digits of IBAN in Sofort mail

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/sofort.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/sofort.php
@@ -63,7 +63,7 @@ class Mollie_WC_Gateway_Sofort extends Mollie_WC_Gateway_AbstractSepaRecurring
                 /* translators: Placeholder 1: consumer name, placeholder 2: consumer IBAN, placeholder 3: consumer BIC */
                 __('Payment completed by <strong>%s</strong> (IBAN (last 4 digits): %s, BIC: %s)', 'mollie-payments-for-woocommerce'),
                 $payment->details->consumerName,
-                implode(' ', str_split($payment->details->consumerAccount, 4)),
+		        substr($payment->details->consumerAccount, -4),
                 $payment->details->consumerBic
             );
         }


### PR DESCRIPTION
Code change to return only the last 4 digits of the IBAN for the Sofort mail instead of entire IBAN.
Code to return last 4 digits of IBAN is now the same as used in Ideal gateway.