### PR TITLE
Convert de_DE_formal to de_DE

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/settings.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/settings.php
@@ -78,6 +78,7 @@ class Mollie_WC_Helper_Settings
 
 		// Convert known exceptions
 		( $locale == 'nl_NL_formal' ? $locale = 'nl_NL': '');
+                ( $locale == 'de_DE_formal' ? $locale = 'de_DE': '');
 		( $locale == 'no_NO' ? $locale = 'nb_NO': '');
 
 		// TODO: Once in a while, check API changelog to make sure there haven't been changes to this list.


### PR DESCRIPTION
Besides nl_NL_formal there is also de_DE_formal that must be converted to de_DE to work with Mollie