### PR TITLE
check for product existence before calling methods

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/orderlines.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/orderlines.php
@@ -266,7 +266,7 @@ class Mollie_WC_Helper_OrderLines {
 	 * @return integer $item_vatRate Item tax percentage formatted for Mollie Orders API.
 	 */
 	private function get_item_vatRate( $cart_item, $product ) {
-		if ( $product->is_taxable() && $cart_item['line_subtotal_tax'] > 0 ) {
+		if ( $product && $product->is_taxable() && $cart_item['line_subtotal_tax'] > 0 ) {
 			// Calculate tax rate.
 
 			$_tax      = new WC_Tax();
@@ -331,7 +331,7 @@ class Mollie_WC_Helper_OrderLines {
 	 * @return string $item_reference Cart item reference.
 	 */
 	private function get_item_reference( $product ) {
-		if ( $product->get_sku() ) {
+		if ( $product && $product->get_sku() ) {
 			$item_reference = $product->get_sku();
 		} else {
 			$item_reference = $product->get_id();


### PR DESCRIPTION
prevents crash on products that are no longer in the catalog but still in unpaid orders or third party products outside of the catalog

for the VAT rate, technically it would be better to query the tax line items rather than the taxes because this would create a discrepancy when VAT rates change and an order was placed before the change but paid after the change.