### PR TITLE
Remove Apple Pay method securely without causing type errors

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -13,6 +13,9 @@ class Mollie_WC_Plugin
     const DB_VERSION_PARAM_NAME = 'mollie-db-version';
     const PENDING_PAYMENT_DB_TABLE_NAME = 'mollie_pending_payment';
 
+    const POST_DATA_KEY = 'post_data';
+    const POST_APPLE_PAY_METHOD_NOT_ALLOWED_KEY = 'mollie_apple_pay_method_not_allowed';
+
     /**
      * @var bool
      */
@@ -421,15 +424,22 @@ class Mollie_WC_Plugin
     public static function maybeDisableApplePayGateway(array $gateways)
     {
         $gateways = array_merge($gateways, self::$GATEWAYS);
-        $postData = (string)filter_input(INPUT_POST, 'post_data', FILTER_SANITIZE_STRING) ?: '';
+        $postData = (string)filter_input(
+            INPUT_POST,
+            self::POST_DATA_KEY,
+            FILTER_SANITIZE_STRING
+        ) ?: '';
 
         if (!$postData) {
             return $gateways;
         }
 
         parse_str($postData, $postData);
-        if (isset($postData['mollie_apple_pay_method_not_allowed']) && !is_admin()) {
-            $gateways = array_diff($gateways, ['Mollie_WC_Gateway_Applepay']);
+        if (isset($postData[self::POST_APPLE_PAY_METHOD_NOT_ALLOWED_KEY]) && !is_admin()) {
+            $index = array_search('Mollie_WC_Gateway_Applepay', $gateways, true);
+            if ($index !== false) {
+                unset($gateways[$index]);
+            }
         }
 
         return $gateways;

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -380,6 +380,8 @@ class Mollie_WC_Plugin
      */
 	public static function addGateways( array $gateways ) {
 
+        $gateways = array_merge($gateways, self::$GATEWAYS);
+
         // Return if function get_current_screen() is not defined
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return $gateways;
@@ -423,7 +425,6 @@ class Mollie_WC_Plugin
      */
     public static function maybeDisableApplePayGateway(array $gateways)
     {
-        $gateways = array_merge($gateways, self::$GATEWAYS);
         $postData = (string)filter_input(
             INPUT_POST,
             self::POST_DATA_KEY,

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+    "redefinable-internals": [
+        "filter_input"
+    ]
+}

--- a/tests/php/Unit/Mollie_WC_PluginTest.php
+++ b/tests/php/Unit/Mollie_WC_PluginTest.php
@@ -1,0 +1,50 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace Mollie\WooCommerce\Tests\Unit;
+
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+use Mollie\WooCommerce\Tests\TestCase;
+use Mollie_WC_Plugin as Testee;
+use stdClass;
+
+/**
+ * Class Mollie_WC_PluginTest
+ */
+class Mollie_WC_PluginTest extends TestCase
+{
+    /**
+     * Test Disable Apple Pay Gateway
+     */
+    public function testMaybeDisableApplePayGateway()
+    {
+        /*
+         * Setup stubs
+         */
+        $postData = Testee::POST_APPLE_PAY_METHOD_NOT_ALLOWED_KEY . '=1';
+        $gateways = [
+            uniqid(),
+            new stdClass(),
+        ];
+
+        /*
+         * We test frontend
+         */
+        when('is_admin')->justReturn(false);
+
+        /*
+         * Expect to have the request to remove the apple pay method
+         */
+        expect('filter_input')
+            ->once()
+            ->with(INPUT_POST, Testee::POST_DATA_KEY, FILTER_SANITIZE_STRING)
+            ->andReturn($postData);
+
+        /*
+         * Execute Test
+         */
+        $result = Testee::maybeDisableApplePayGateway($gateways);
+
+        self::assertEquals(false, isset($result[Testee::POST_APPLE_PAY_METHOD_NOT_ALLOWED_KEY]));
+    }
+}


### PR DESCRIPTION
WooCommerce allow to register gateways not only as class string names but
you can also register an instance of a class.

When we are looking for `Mollie_WC_Gateway_Applepay` to remove it using
`array_diff` we could cause an error because the `$gateways` list may
contains instances of classes.

Using array search will fix the problem.

The solution is unit tested