### PR TITLE
Always check if active payment instance has been set properly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "autoload-dev": {
         "psr-4": {
             "Mollie\\WooCommerce\\Tests\\": "tests/php",
-            "Mollie\\WooCommerce\\Tests\\Unit\\": "tests/php/Unit"
+            "Mollie\\WooCommerce\\Tests\\Unit\\": "tests/php/Unit",
+            "Mollie\\WooCommerce\\Tests\\Functional\\": "tests/php/Functional"
         }
     }
 }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\PaymentMethod;
 
 abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
@@ -394,29 +395,30 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     }
 
 	/**
-	 * @param int $order_id
+     * @param int $orderId
 	 *
-	 * @throws \Mollie\Api\Exceptions\ApiException
 	 * @return array
+	 *@throws \Mollie\Api\Exceptions\ApiException
 	 */
-	public function process_payment( $order_id ) {
-		$order = Mollie_WC_Plugin::getDataHelper()->getWcOrder( $order_id );
+    public function process_payment($orderId)
+    {
+        $order = Mollie_WC_Plugin::getDataHelper()->getWcOrder($orderId);
 
-		if ( ! $order ) {
-			Mollie_WC_Plugin::debug( $this->id . ': Could not process payment, order ' . $order_id . ' not found.' );
+        if ( ! $order ) {
+            Mollie_WC_Plugin::debug(
+                $this->id . ': Could not process payment, order ' . $orderId . ' not found.'
+            );
+            Mollie_WC_Plugin::addNotice(
+                sprintf(__('Could not load order %s', 'mollie-payments-for-woocommerce'), $orderId),
+                'error'
+            );
 
-			Mollie_WC_Plugin::addNotice( sprintf( __( 'Could not load order %s', 'mollie-payments-for-woocommerce' ), $order_id ), 'error' );
-
-			return array ( 'result' => 'failure' );
+            return array ( 'result' => 'failure' );
 		}
 
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			Mollie_WC_Plugin::debug( $this->id . ': Start process_payment for order ' . $order->id, true );
-		} else {
-			Mollie_WC_Plugin::debug( $this->id . ': Start process_payment for order ' . $order->get_id(), true );
-		}
+        Mollie_WC_Plugin::debug($this->id . ': Start process_payment for order ' . $orderId, true);
 
-		$initial_order_status = $this->getInitialOrderStatus();
+        $initial_order_status = $this->getInitialOrderStatus();
 
 		// Overwrite plugin-wide
 		$initial_order_status = apply_filters( Mollie_WC_Plugin::PLUGIN_ID . '_initial_order_status', $initial_order_status );
@@ -433,8 +435,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 		//
 		// PROCESS SUBSCRIPTION SWITCH - If this is a subscription switch and customer has a valid mandate, process the order internally
 		//
-		if ( ( '0.00' === $order->get_total() ) && ( Mollie_WC_Plugin::getDataHelper()->isSubscription( $order_id ) == true ) &&
-		     0 != $order->get_user_id() && ( wcs_order_contains_switch( $order ) )
+        if (('0.00' === $order->get_total()) && (Mollie_WC_Plugin::getDataHelper()->isSubscription($orderId) == true)
+            && 0 != $order->get_user_id() && ( wcs_order_contains_switch( $order ) )
 		) {
 
 			$payment_object = Mollie_WC_Plugin::getPaymentFactoryHelper()->getPaymentObject( 'payment' );
@@ -445,8 +447,10 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 			$data = apply_filters( 'woocommerce_' . $this->id . '_args', $data, $order );
 
 			try {
-				Mollie_WC_Plugin::debug( $this->id . ': Subscription switch started, fetching mandate(s) for order #' . $order_id );
-				$mandates = Mollie_WC_Plugin::getApiHelper()->getApiClient( $test_mode )->customers->get( $customer_id )->mandates();
+                Mollie_WC_Plugin::debug(
+                    "{$this->id}: Subscription switch started, fetching mandate(s) for order #{$orderId}"
+                );
+                $mandates = Mollie_WC_Plugin::getApiHelper()->getApiClient( $test_mode )->customers->get( $customer_id )->mandates();
 				$validMandate = false;
 				foreach ( $mandates as $mandate ) {
 					if ( $mandate->status == 'valid' ) {
@@ -462,16 +466,20 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 					$order->add_order_note( sprintf(
 						__( 'Order completed internally because of an existing valid mandate at Mollie.', 'mollie-payments-for-woocommerce' ) ) );
 
-					Mollie_WC_Plugin::debug( $this->id . ': Subscription switch completed, valid mandate for order #' . $order_id );
+                    Mollie_WC_Plugin::debug(
+                        "{$this->id}: Subscription switch completed, valid mandate for order #{$orderId}"
+                    );
 
-					return array (
+                    return array (
 						'result'   => 'success',
 						'redirect' => $this->get_return_url( $order ),
 					);
 
 				} else {
-					Mollie_WC_Plugin::debug( $this->id . ': Subscription switch failed, no valid mandate for order #' . $order_id );
-					Mollie_WC_Plugin::addNotice( __( 'Subscription switch failed, no valid mandate found. Place a completely new order to change your subscription.', 'mollie-payments-for-woocommerce' ), 'error' );
+                    Mollie_WC_Plugin::debug(
+                        "{$this->id}: Subscription switch failed, no valid mandate for order #{$orderId}"
+                    );
+                    Mollie_WC_Plugin::addNotice( __( 'Subscription switch failed, no valid mandate found. Place a completely new order to change your subscription.', 'mollie-payments-for-woocommerce' ), 'error' );
 					throw new Mollie\Api\Exceptions\ApiException( __( 'Subscription switch failed, no valid mandate.', 'mollie-payments-for-woocommerce' ) );
 				}
 			}
@@ -526,12 +534,10 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 			//
 
 			if ( $mollie_payment_type == 'order' ) {
-
-				if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-					Mollie_WC_Plugin::debug( $this->id . ': Create Mollie payment object for order ' . $order->id, true );
-				} else {
-					Mollie_WC_Plugin::debug( $this->id . ': Create Mollie payment object for order ' . $order->get_id(), true );
-				}
+                Mollie_WC_Plugin::debug(
+                    "{$this->id}: Create Mollie payment object for order {$orderId}",
+                    true
+                );
 
 				$payment_object     = Mollie_WC_Plugin::getPaymentFactoryHelper()->getPaymentObject( 'order' );
 				$paymentRequestData = $payment_object->getPaymentRequestData( $order, $customer_id );
@@ -653,25 +659,23 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 				$payment_object->id . ( $payment_object->mode == 'test' ? ( ' - ' . __( 'test mode', 'mollie-payments-for-woocommerce' ) ) : '' )
 			) );
 
-			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-				Mollie_WC_Plugin::debug( "For order " . $order->id . " redirect user to Mollie Checkout URL: " . $payment_object->getCheckoutUrl() );
-			} else {
-				Mollie_WC_Plugin::debug( "For order " . $order->get_id() . " redirect user to Mollie Checkout URL: " . $payment_object->getCheckoutUrl() );
-			}
+            Mollie_WC_Plugin::debug(
+                "For order {$orderId} redirect user to Mollie Checkout URL: "
+                . $payment_object->getCheckoutUrl()
+            );
 
-			return array (
+            return array (
 				'result'   => 'success',
 				'redirect' => $this->getProcessPaymentRedirect( $order, $payment_object ),
 			);
 		}
 		catch ( Mollie\Api\Exceptions\ApiException $e ) {
-			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-				Mollie_WC_Plugin::debug( $this->id . ': Failed to create Mollie payment object for order ' . $order->id . ': ' . $e->getMessage() );
-			} else {
-				Mollie_WC_Plugin::debug( $this->id . ': Failed to create Mollie payment object for order ' . $order->get_id() . ': ' . $e->getMessage() );
-			}
+            Mollie_WC_Plugin::debug(
+                "{$this->id}: Failed to create Mollie payment object for order {$orderId} : "
+                . $e->getMessage()
+            );
 
-			/* translators: Placeholder 1: Payment method title */
+            /* translators: Placeholder 1: Payment method title */
 			$message = sprintf( __( 'Could not create %s payment.', 'mollie-payments-for-woocommerce' ), $this->title );
 
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -955,17 +959,12 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 	 */
 	protected function processRefunds( WC_Order $order, $payment ) {
 
-		// Get order ID in the correct way depending on WooCommerce version
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$order_id = $order->id;
-		} else {
-			$order_id = $order->get_id();
-		}
+        $orderId = $this->wooCommerceOrderId($order);
 
-		// Debug log ID (order id/payment id)
-		$log_id = 'order ' . $order_id . ' / payment ' . $payment->id;
+        // Debug log ID (order id/payment id)
+        $log_id = "order {$orderId} / payment {$payment->id}";
 
-		// Add message to log
+        // Add message to log
 		Mollie_WC_Plugin::debug( __METHOD__ . ' called for ' . $log_id );
 
 		// Make sure there are refunds to process at all
@@ -1015,9 +1014,6 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 				return;
 			}
 
-			$data_helper = Mollie_WC_Plugin::getDataHelper();
-			$order       = $data_helper->getWcOrder( $order_id );
-
 			foreach ( $refunds_to_process as $refund_to_process ) {
 
 				Mollie_WC_Plugin::debug( __METHOD__ . ' New refund ' . $refund_to_process . ' processed in Mollie Dashboard for ' . $log_id . '. Order note added, but order not updated.' );
@@ -1053,17 +1049,12 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 	 */
 	protected function processChargebacks( WC_Order $order, $payment ) {
 
-		// Get order ID in the correct way depending on WooCommerce version
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$order_id = $order->id;
-		} else {
-			$order_id = $order->get_id();
-		}
+        $orderId = $this->wooCommerceOrderId($order);
 
-		// Debug log ID (order id/payment id)
-		$log_id = 'order ' . $order_id . ' / payment ' . $payment->id;
+        // Debug log ID (order id/payment id)
+        $log_id = "order {$orderId} / payment {$payment->id}";
 
-		// Add message to log
+        // Add message to log
 		Mollie_WC_Plugin::debug( __METHOD__ . ' called for ' . $log_id );
 
 		// Make sure there are chargebacks to process at all
@@ -1113,9 +1104,6 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 				return;
 			}
 
-			$data_helper = Mollie_WC_Plugin::getDataHelper();
-			$order       = $data_helper->getWcOrder( $order_id );
-
 			// Update order notes, add message about chargeback
 			foreach ( $chargebacks_to_process as $chargeback_to_process ) {
 
@@ -1159,9 +1147,9 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 			// Send a "Failed order" email to notify the admin
 			$emails = WC()->mailer()->get_emails();
-			if ( ! empty( $emails ) && ! empty( $order_id ) && ! empty( $emails['WC_Email_Failed_Order'] ) ) {
-				$emails['WC_Email_Failed_Order']->trigger( $order_id );
-			}
+            if (!empty($emails) && !empty($orderId) && !empty($emails['WC_Email_Failed_Order'])) {
+                $emails['WC_Email_Failed_Order']->trigger($orderId);
+            }
 
 
 			$order->update_meta_data( '_mollie_processed_chargeback_ids', $processed_chargeback_ids );
@@ -1176,11 +1164,11 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 			// Do extra checks if WooCommerce Subscriptions is installed
 			if ( class_exists( 'WC_Subscriptions' ) && class_exists( 'WC_Subscriptions_Admin' ) ) {
 				// Also store it on the subscriptions being purchased or paid for in the order
-				if ( wcs_order_contains_subscription( $order_id ) ) {
-					$subscriptions = wcs_get_subscriptions_for_order( $order_id );
-				} elseif ( wcs_order_contains_renewal( $order_id ) ) {
-					$subscriptions = wcs_get_subscriptions_for_renewal_order( $order_id );
-				} else {
+                if (wcs_order_contains_subscription($orderId)) {
+                    $subscriptions = wcs_get_subscriptions_for_order($orderId);
+                } elseif (wcs_order_contains_renewal($orderId)) {
+                    $subscriptions = wcs_get_subscriptions_for_renewal_order($orderId);
+                } else {
 					$subscriptions = array ();
 				}
 
@@ -1236,20 +1224,19 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 	 */
 	public function getReturnRedirectUrlForOrder( WC_Order $order ) {
 
-		// Get order ID in the correct way depending on WooCommerce version
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$order_id = $order->id;
-		} else {
-			$order_id = $order->get_id();
-		}
+        $orderId = $this->wooCommerceOrderId($order);
 
-		Mollie_WC_Plugin::debug( __METHOD__ . " $order_id: Determine what the redirect URL in WooCommerce should be." );
+        Mollie_WC_Plugin::debug(
+            __METHOD__ . " {$orderId}: Determine what the redirect URL in WooCommerce should be."
+        );
 
-		if ( $this->orderNeedsPayment( $order ) ) {
+        if ( $this->orderNeedsPayment( $order ) ) {
 
-			$hasCancelledMolliePayment = Mollie_WC_Plugin::getPaymentObject()->getCancelledMolliePaymentId( $order_id );
+            $hasCancelledMolliePayment = $this
+                ->paymentObject()
+                ->getCancelledMolliePaymentId($orderId);
 
-			if ( $hasCancelledMolliePayment ) {
+            if ( $hasCancelledMolliePayment ) {
 
 				$settings_helper                 = Mollie_WC_Plugin::getSettingsHelper();
 				$order_status_cancelled_payments = $settings_helper->getOrderStatusCancelledPayments();
@@ -1278,9 +1265,22 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 
 			}
 
-			$payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment($order_id, false );
+            try {
+                $payment = $this->activePaymentObject($orderId, false);
+            } catch (UnexpectedValueException $exc) {
+                Mollie_WC_Plugin::addNotice(
+                    __(
+                        'There was a problem when processing your payment. Please try again.',
+                        'mollie-payments-for-woocommerce'
+                    )
+                );
+                // Return to order payment page
+                if (method_exists($order, 'get_checkout_payment_url')) {
+                    return $order->get_checkout_payment_url(false);
+                }
+            }
 
-			if ( ! $payment->isOpen() && ! $payment->isPending() && ! $payment->isPaid() && ! $payment->isAuthorized() ) {
+            if ( ! $payment->isOpen() && ! $payment->isPending() && ! $payment->isPaid() && ! $payment->isAuthorized() ) {
 				Mollie_WC_Plugin::addNotice( __( 'Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce' ) );
 				// Return to order payment page
 				if ( method_exists( $order, 'get_checkout_payment_url' ) ) {
@@ -1298,7 +1298,42 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 		return $this->get_return_url( $order );
 	}
 
-	/**
+    /**
+     * Retrieve the payment object
+     *
+     * @return Mollie_WC_Payment_Object
+     */
+    protected function paymentObject()
+    {
+        return Mollie_WC_Plugin::getPaymentObject();
+    }
+
+    /**
+     * Retrieve the active payment object
+     *
+     * @param $order_id
+     * @param $useCache
+     * @return Payment
+     * @throws UnexpectedValueException
+     */
+    protected function activePaymentObject($order_id, $useCache)
+    {
+        // TODO Assert int value for $order_id
+
+        $paymentObject = $this->paymentObject();
+
+        $activePaymentObject = $paymentObject->getActiveMolliePayment($order_id, $useCache);
+
+        if ($activePaymentObject === null) {
+            throw new UnexpectedValueException(
+                'Active Payment Object is not a valid Payment Resource instance'
+            );
+        }
+
+        return $activePaymentObject;
+    }
+
+    /**
 	 * Process a refund if supported
 	 *
 	 * @param int    $order_id
@@ -1322,13 +1357,12 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 			return new WP_Error( '1', $error_message );
 		}
 
-		// Check if there is a Mollie Payment Order object connected to this WooCommerce order
-		$payment_object_id = Mollie_WC_Plugin::getPaymentObject()->getActiveMollieOrderId( $order_id);
+        $paymentObject = $this->paymentObject();
 
-		// If there is no Mollie Payment Order object, try getting a Mollie Payment Payment object
-		if ( $payment_object_id == null ) {
-			$payment_object_id = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePaymentId( $order_id);
-		}
+        // Check if there is a Mollie Payment Order object connected to this WooCommerce order
+        $payment_object_id = $paymentObject->getActiveMollieOrderId($order_id);
+        // If there is no Mollie Payment Order object, try getting a Mollie Payment Payment object
+        $payment_object_id or $payment_object_id = $paymentObject->getActiveMolliePaymentId($order_id);
 
 		// Mollie Payment object not found
 		if ( ! $payment_object_id ) {
@@ -1401,15 +1435,17 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 				return;
 			}
 
-			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-				$payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment( $order->id );
-			} else {
-				$payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment( $order->get_id() );
-			}
+            $orderId = $this->wooCommerceOrderId($order);
 
-			// Mollie payment not found or invalid gateway
-			if ( ! $payment || $payment->method != $this->getMollieMethodId() ) {
-				return;
+            try {
+                $payment = $this->activePaymentObject($orderId, true);
+            } catch (UnexpectedValueException $exc) {
+                return;
+            }
+
+            // Invalid gateway
+            if ($payment->method !== $this->getMollieMethodId()) {
+                return;
 			}
 
 			$instructions = $this->getInstructions( $order, $payment, $admin_instructions, $plain_text );
@@ -1429,6 +1465,19 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 		self::$alreadyDisplayedInstructions = true;
 
 	}
+
+    /**
+     * Retrieve the order Id from an instance of WC_Order with BC in mind
+     *
+     * @param WC_Order $order
+     * @return int
+     */
+    protected function wooCommerceOrderId(WC_Order $order)
+    {
+        return version_compare(WC_VERSION, '3.0', '<')
+            ? $order->id
+            : $order->get_id();
+    }
 
     /**
      * @param WC_Order                  $order
@@ -1518,17 +1567,18 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 				return $title;
 			}
 
-			// Checks and title for pending/open orders
-			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-				$payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment( $order->id );
-			} else {
-				$payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment( $order->get_id() );
-			}
+            $orderId = $this->wooCommerceOrderId($order);
 
-			// Mollie payment not found or invalid gateway
-			if ( ! $payment || $payment->method != $this->getMollieMethodId() ) {
-				return $title;
-			}
+            try {
+                $payment = $this->activePaymentObject($orderId, true);
+            } catch (UnexpectedValueException $exc) {
+                return $title;
+            }
+
+            // Invalid Gateway
+            if ($payment->method !== $this->getMollieMethodId()) {
+                return $title;
+            }
 
 			if ( $payment->isOpen() ) {
 
@@ -1600,37 +1650,45 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 	 */
 	protected function orderNeedsPayment( WC_Order $order ) {
 
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$order_id = $order->id;
-		} else {
-			$order_id = $order->get_id();
-		}
+        $orderId = $this->wooCommerceOrderId($order);
 
-		// Check whether the order is processed and paid via another gateway
+        // Check whether the order is processed and paid via another gateway
 		if ( $this->isOrderPaidByOtherGateway( $order ) ) {
-			Mollie_WC_Plugin::debug( __METHOD__ . ' ' . $this->id . ': Order ' . $order_id . ' orderNeedsPayment check: no, previously processed by other (non-Mollie) gateway.', true );
+            Mollie_WC_Plugin::debug(
+                __METHOD__ . ' ' . $this->id . ': Order ' . $orderId . ' orderNeedsPayment check: no, previously processed by other (non-Mollie) gateway.',
+                true
+            );
 
-			return false;
+            return false;
 		}
 
 		// Check whether the order is processed and paid via Mollie
 		if ( ! $this->isOrderPaidAndProcessed( $order ) ) {
-			Mollie_WC_Plugin::debug( __METHOD__ . ' ' . $this->id . ': Order ' . $order_id . ' orderNeedsPayment check: yes, order not previously processed by Mollie gateway.', true );
+            Mollie_WC_Plugin::debug(
+                __METHOD__ . ' ' . $this->id . ': Order ' . $orderId . ' orderNeedsPayment check: yes, order not previously processed by Mollie gateway.',
+                true
+            );
 
-			return true;
+            return true;
 		}
 
 		if ( $order->needs_payment() ) {
-			Mollie_WC_Plugin::debug( __METHOD__ . ' ' . $this->id . ': Order ' . $order_id . ' orderNeedsPayment check: yes, WooCommerce thinks order needs payment.', true );
+            Mollie_WC_Plugin::debug(
+                __METHOD__ . ' ' . $this->id . ': Order ' . $orderId . ' orderNeedsPayment check: yes, WooCommerce thinks order needs payment.',
+                true
+            );
 
-			return true;
+            return true;
 		}
 
 		// Has initial order status 'on-hold'
 		if ( $this->getInitialOrderStatus() === self::STATUS_ON_HOLD && Mollie_WC_Plugin::getDataHelper()->hasOrderStatus( $order, self::STATUS_ON_HOLD ) ) {
-			Mollie_WC_Plugin::debug( __METHOD__ . ' ' . $this->id . ': Order ' . $order_id . ' orderNeedsPayment check: yes, has status On-Hold. ', true );
+            Mollie_WC_Plugin::debug(
+                __METHOD__ . ' ' . $this->id . ': Order ' . $orderId . ' orderNeedsPayment check: yes, has status On-Hold. ',
+                true
+            );
 
-			return true;
+            return true;
 		}
 
 		return false;

--- a/tests/php/Functional/Mollie_WC_Gateway_AbstractTest.php
+++ b/tests/php/Functional/Mollie_WC_Gateway_AbstractTest.php
@@ -1,0 +1,38 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace Mollie\WooCommerce\Tests\Functional;
+
+use function Brain\Monkey\Functions\when;
+use Mollie\WooCommerce\Tests\TestCase;
+use Mollie_WC_Payment_Object;
+use Mollie_WC_Plugin;
+
+/**
+ * Class Mollie_WC_Gateway_AbstractTest
+ * @package Mollie\WooCommerce\Tests\Unit
+ */
+class Mollie_WC_Gateway_AbstractTest extends TestCase
+{
+    /**
+     * Test paymentObject return a valid Mollie_WC_Payment_Object instance
+     */
+    public function testPaymentObject()
+    {
+        /*
+         * Setup Stubs
+         */
+        when('wc_get_base_location')
+            ->justReturn(
+                [
+                    'country' => uniqid(),
+                ]
+            );
+
+        $result = Mollie_WC_Plugin::getPaymentObject();
+
+        self::assertInstanceOf(
+            Mollie_WC_Payment_Object::class,
+            $result
+        );
+    }
+}

--- a/tests/php/TestCase.php
+++ b/tests/php/TestCase.php
@@ -7,6 +7,7 @@ use function Brain\Monkey\tearDown;
 use Mockery;
 use PHPUnit\Framework\TestCase as PhpUniTestCase;
 use PHPUnit_Framework_MockObject_MockBuilder;
+use PHPUnit_Framework_MockObject_MockObject;
 use Xpmock\Reflection;
 use Xpmock\TestCaseTrait;
 
@@ -46,23 +47,16 @@ class TestCase extends PhpUniTestCase
      * @param string $className
      * @param array $constructorArguments
      * @param array $methods
-     * @param string $sutMethod
      * @return PHPUnit_Framework_MockObject_MockBuilder
      */
-    protected function buildTesteeMock(
-        $className,
-        $constructorArguments,
-        $methods,
-        $sutMethod
-    ) {
-
+    protected function buildTesteeMock($className, $constructorArguments, $methods)
+    {
         $testee = $this->getMockBuilder($className);
         $constructorArguments
             ? $testee->setConstructorArgs($constructorArguments)
             : $testee->disableOriginalConstructor();
 
-        $methods and $testee->setMethods($methods);
-        $sutMethod and $testee->setMethodsExcept([$sutMethod]);
+        $testee->setMethods($methods);
 
         return $testee;
     }
@@ -78,13 +72,19 @@ class TestCase extends PhpUniTestCase
      */
     protected function buildTesteeMethodMock($className, $constructorArguments, $methods)
     {
-        $testee = $this->buildTesteeMock(
-            $className,
-            $constructorArguments,
-            $methods,
-            ''
-        )->getMock();
+        $testee = $this->buildTesteeMock($className, $constructorArguments, $methods)->getMock();
 
+        return $this->proxyFor($testee);
+    }
+
+    /**
+     * Create a proxy for a mocked class
+     *
+     * @param PHPUnit_Framework_MockObject_MockObject $testee
+     * @return Reflection
+     */
+    protected function proxyFor(PHPUnit_Framework_MockObject_MockObject $testee)
+    {
         return $this->reflect($testee);
     }
 }

--- a/tests/php/Unit/Mollie_WC_Gateway_AbstractTest.php
+++ b/tests/php/Unit/Mollie_WC_Gateway_AbstractTest.php
@@ -1,0 +1,213 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace Mollie\WooCommerce\Tests\Unit;
+
+use Mollie\Api\Resources\Payment;
+use Mollie\WooCommerce\Tests\TestCase;
+use Mollie_WC_Gateway_Abstract as Testee;
+use Mollie_WC_Payment_Object;
+use UnexpectedValueException;
+
+/**
+ * Class Mollie_WC_Gateway_AbstractTest
+ * @package Mollie\WooCommerce\Tests\Unit
+ */
+class Mollie_WC_Gateway_AbstractTest extends TestCase
+{
+    /* -----------------------------------------------------------------------
+       Test activePaymentObject
+     ---------------------------------------------------------------------- */
+
+    /**
+     * Test activePaymentObject
+     */
+    public function testActivePaymentObjectNullUserRedirectedToCheckoutPageWithNotice()
+    {
+        /*
+         * Setup Stubs
+         */
+        $paymentObject = $this
+            ->getMockBuilder(Mollie_WC_Payment_Object::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getActiveMolliePayment'])
+            ->getMock();
+
+        $paymentResource = $this->createMock(Payment::class);
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this
+            ->buildTesteeMock(
+                Testee::class,
+                [],
+                ['paymentObject']
+            )
+            ->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+
+        /*
+         * Expect to retrieve the payment object
+         */
+        $testee
+            ->expects($this->once())
+            ->method('paymentObject')
+            ->willReturn($paymentObject);
+
+        /*
+         * Expect to get the active mollie payment and return a valid
+         *  Mollie\Api\Resources\Payment instance
+         */
+        $paymentObject
+            ->expects($this->once())
+            ->method('getActiveMolliePayment')
+            ->withAnyParameters()
+            ->willReturn($paymentResource);
+
+        /*
+         * Execute Test
+         */
+        $result = $testee->activePaymentObject(mt_rand(1, 10), false);
+
+        self::assertEquals($paymentResource, $result);
+    }
+
+    /**
+     * Test activePaymentObject throw exception because `getActiveMolliePayment` return null
+     */
+    public function testActivePaymentObjectThrowExceptionBecauseNotPossibleToGetThePaymentObject()
+    {
+        /*
+         * Setup Stubs
+         */
+        $paymentObject = $this
+            ->getMockBuilder(Mollie_WC_Payment_Object::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getActiveMolliePayment'])
+            ->getMock();
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this
+            ->buildTesteeMock(
+                Testee::class,
+                [],
+                ['paymentObject']
+            )
+            ->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+
+        /*
+         * Expect to retrieve the payment object
+         */
+        $testee
+            ->expects($this->once())
+            ->method('paymentObject')
+            ->willReturn($paymentObject);
+
+        /*
+         * Active Mollie Payment will return a null value and
+         * we expect exception
+         */
+        $paymentObject
+            ->expects($this->once())
+            ->method('getActiveMolliePayment')
+            ->withAnyParameters()
+            ->willReturn(null);
+
+        /*
+         * And we expect an UnexpectedValueException
+         */
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'Active Payment Object is not a valid Payment Resource instance'
+        );
+
+        /*
+         * Execute Test
+         */
+        $testee->activePaymentObject(mt_rand(1, 10), false);
+    }
+
+    /* -----------------------------------------------------------------------
+       Test wooCommerceOrderId
+     ---------------------------------------------------------------------- */
+
+    /**
+     * Test WooCommerce use Property if Wc < 3.0
+     */
+    public function testWooCommerceOrderIdUseProperty()
+    {
+        /*
+         * Setup Stabs
+         */
+        define('WC_VERSION', mt_rand(1, 2));
+        $orderId = mt_rand(1, 2);
+        $order = $this->getMockBuilder('\\WC_Order')->getMock();
+        $order->id = $orderId;
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this
+            ->buildTesteeMock(
+                Testee::class,
+                [],
+                []
+            )
+            ->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+
+        /*
+         * Execute Testee
+         */
+        $result = $testee->wooCommerceOrderId($order);
+
+        self::assertEquals($orderId, $result);
+    }
+
+    /**
+     * Test WooCommerce use Method if WC >= 3.0
+     */
+    public function testWooCommerceOrderIdCallMethod()
+    {
+        /*
+         * Setup Stabs
+         */
+        define('WC_VERSION', mt_rand(3, 4));
+        $orderId = mt_rand(1, 2);
+        $order = $this
+            ->getMockBuilder('\\WC_Order')
+            ->disableOriginalConstructor()
+            ->setMethods(['get_id'])
+            ->getMock();
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this
+            ->buildTesteeMock(
+                Testee::class,
+                [],
+                []
+            )
+            ->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+
+        /*
+         * Expect get_id is called
+         */
+        $order
+            ->expects($this->once())
+            ->method('get_id')
+            ->willReturn($orderId);
+
+        /*
+         * Execute Testee
+         */
+        $result = $testee->wooCommerceOrderId($order);
+
+        self::assertEquals($orderId, $result);
+    }
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,6 +1,7 @@
 <?php # -*- coding: utf-8 -*-
 
-$vendor = dirname(__DIR__, 2) . '/vendor/';
+$projectDir = dirname(__DIR__, 2);
+$vendor = "{$projectDir}/vendor/";
 if (!file_exists($vendor . 'autoload.php')) {
     die('Please install via Composer before running tests.');
 }
@@ -9,5 +10,9 @@ require_once $vendor . 'brain/monkey/inc/patchwork-loader.php';
 require_once $vendor . 'autoload.php';
 unset($vendor);
 
-putenv('PROJECT_DIR=' . dirname(__DIR__, 2));
+putenv('PROJECT_DIR=' . $projectDir);
 putenv('TESTS_PATH=' . __DIR__);
+
+require_once __DIR__ . '/stubs/woocommerce.php';
+
+unset($projectDir);

--- a/tests/php/stubs/woocommerce.php
+++ b/tests/php/stubs/woocommerce.php
@@ -1,0 +1,7 @@
+<?php
+if (!class_exists('WC_Payment_Gateway')) {
+    class WC_Payment_Gateway
+    {
+
+    }
+}


### PR DESCRIPTION
The method `getActiveMolliePayment` could return two different type of
values, this make the solution unpredictable and you have to add additional
conditional statement.

Instead a more correct approach would be throw an `UnexpectedValueException`.

The main problem was to set a different message for caller about the
return value of `getActiveMolliePayment` that could help debugging and
support and also solve a WSOD in production.

Problem was the impossibility to create an unit tested solution.
To do that I created a new method for `paymentObject` and `activePaymentObject`
which move the concern of create instances outside of a consumer method.

Since I while working on that I found some duplication code that could
be improved and I also changed the way the order id is retrieved in a more
DRY version.

Now instead of duplicate if/else we have a method that will encapsulate the
BC logic.

Some small improvements are made to the use of string interpolation over
concatenation and removing duplicated `WC_Order` assignments.