### PR TITLE
Remove apple pay only if the device does not support the payment method

### DIFF
--- a/mollie-payments-for-woocommerce/assets/js/applepay.js
+++ b/mollie-payments-for-woocommerce/assets/js/applepay.js
@@ -1,8 +1,10 @@
 (function (ApplePaySession) {
+
   document.addEventListener('DOMContentLoaded', function () {
     var applePayMethodElement = document.querySelector(
       '.payment_method_mollie_wc_gateway_applepay',
     )
+
     var woocommerceCheckoutForm = document.querySelector(
       'form.woocommerce-checkout',
     )
@@ -14,11 +16,12 @@
     if (!ApplePaySession || !ApplePaySession.canMakePayments()) {
       applePayMethodElement &&
       applePayMethodElement.parentNode.removeChild(applePayMethodElement)
-
-      woocommerceCheckoutForm.insertAdjacentHTML(
-        'beforeend',
-        '<input type="hidden" name="mollie_apple_pay_method_not_allowed" value="1" />',
-      )
+      return
     }
+
+    woocommerceCheckoutForm.insertAdjacentHTML(
+      'beforeend',
+      '<input type="hidden" name="mollie_apple_pay_method_allowed" value="1" />',
+    )
   })
 })(window.ApplePaySession)

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -426,6 +426,10 @@ class Mollie_WC_Plugin
      */
     public static function maybeDisableApplePayGateway(array $gateways)
     {
+        if (is_admin()) {
+            return $gateways;
+        }
+
         $applePayGatewayClassName = 'Mollie_WC_Gateway_Applepay';
         $applePayGatewayIndex = array_search($applePayGatewayClassName, $gateways, true);
         $postData = (string)filter_input(
@@ -436,10 +440,6 @@ class Mollie_WC_Plugin
         parse_str($postData, $postData);
 
         $applePayAllowed = isset($postData[self::POST_APPLE_PAY_METHOD_ALLOWED_KEY]) && $postData[self::POST_APPLE_PAY_METHOD_ALLOWED_KEY];
-
-        if (is_admin()) {
-            return $gateways;
-        }
 
         if ($applePayGatewayIndex !== false && !$applePayAllowed) {
             unset($gateways[$applePayGatewayIndex]);

--- a/tests/php/Unit/Mollie_WC_PluginTest.php
+++ b/tests/php/Unit/Mollie_WC_PluginTest.php
@@ -15,15 +15,17 @@ class Mollie_WC_PluginTest extends TestCase
 {
     /**
      * Test Disable Apple Pay Gateway
+     *
+     * @dataProvider allowingDataProvider
      */
-    public function testMaybeDisableApplePayGateway()
+    public function testMaybeDisableApplePayGateway($allowed, $expected)
     {
         /*
          * Setup stubs
          */
-        $postData = Testee::POST_APPLE_PAY_METHOD_NOT_ALLOWED_KEY . '=1';
+        $postData = Testee::POST_APPLE_PAY_METHOD_ALLOWED_KEY . "={$allowed}";
         $gateways = [
-            uniqid(),
+            'Mollie_WC_Gateway_Applepay',
             new stdClass(),
         ];
 
@@ -45,6 +47,14 @@ class Mollie_WC_PluginTest extends TestCase
          */
         $result = Testee::maybeDisableApplePayGateway($gateways);
 
-        self::assertEquals(false, isset($result[Testee::POST_APPLE_PAY_METHOD_NOT_ALLOWED_KEY]));
+        self::assertEquals($expected, in_array('Mollie_WC_Gateway_Applepay', $result, true));
+    }
+
+    public function allowingDataProvider()
+    {
+        return [
+            [1, true],
+            [0, false]
+        ];
     }
 }


### PR DESCRIPTION
This solve the problem where for a sec the gateway will display in the page
for then being removed during the payment methods update made by WooCommerce
via AJAX.