### PR TITLE
Refund chargeback the merchant for every order line item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
 
 script:
     - find mollie-payments-for-woocommerce -name '*.php' | xargs -n 1 -P4 php -l
-    - ./vendor/bin/phpunit --testdox --coverage-clover=coverage/report/coverage.xml
+    - ./vendor/bin/phpunit --testdox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ php:
 sudo: false
 
 install:
-    composer install
+    composer update
 
 script:
     - find mollie-payments-for-woocommerce -name '*.php' | xargs -n 1 -P4 php -l
-    - ./vendor/bin/phpunit --testdox
+    - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ php:
 
 sudo: false
 
+install:
+    composer install
+
 script:
-- find mollie-payments-for-woocommerce -name '*.php' | xargs -n 1 -P4 php -l
+    - find mollie-payments-for-woocommerce -name '*.php' | xargs -n 1 -P4 php -l
+    - ./vendor/bin/phpunit --testdox --coverage-clover=coverage/report/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
 - 7.1
 - 7.2
 - 7.3
-- 7.4
 - nightly
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: php
 
-php:
-- 5.6
-- 7.0
-- 7.1
-- 7.2
-- 7.3
-- 7.4snapshot
-- nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+  - php: nightly
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: nightly
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
 - 7.0
 - 7.1
 - 7.2
+- 7.3
+- 7.4
 - nightly
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
 - 7.1
 - 7.2
 - 7.3
+- 7.4snapshot
 - nightly
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^6.5 || ^7.1",
-        "brain/monkey": "~2.3",
+        "brain/monkey": "^2.0",
         "ptrofimov/xpmock": "^1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5",
+        "phpunit/phpunit": "^5 || ^6.5 || ^7.1",
         "brain/monkey": "~2.3",
         "ptrofimov/xpmock": "^1"
     },
@@ -21,6 +21,11 @@
             "Mollie\\WooCommerce\\Tests\\": "tests/php",
             "Mollie\\WooCommerce\\Tests\\Unit\\": "tests/php/Unit",
             "Mollie\\WooCommerce\\Tests\\Functional\\": "tests/php/Functional"
+        }
+    },
+    "config": {
+        "platform": {
+            "php": "5.6"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "autoload-dev": {
         "psr-4": {
             "Mollie\\WooCommerce\\Tests\\": "tests/php",
-            "Mollie\\WooCommerce\\Tests\\Unit\\": "tests/php/Unit"
+            "Mollie\\WooCommerce\\Tests\\Unit\\": "tests/php/Unit",
+            "Mollie\\WooCommerce\\Tests\\Functional\\": "tests/php/Functional"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5",
-        "brain/monkey": "^2.0@dev",
+        "brain/monkey": "~2.3",
         "ptrofimov/xpmock": "^1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^6.5 || ^7.1",
-        "brain/monkey": "^2.0",
+        "brain/monkey": "^2.3",
         "ptrofimov/xpmock": "^1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,5 @@
             "Mollie\\WooCommerce\\Tests\\Unit\\": "tests/php/Unit",
             "Mollie\\WooCommerce\\Tests\\Functional\\": "tests/php/Functional"
         }
-    },
-    "config": {
-        "platform": {
-            "php": "5.6"
-        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e1ca549854f85586472ff48f4b34b17",
+    "content-hash": "cb8b146e1a199e9ac3ef6c7644850a9b",
     "packages": [],
     "packages-dev": [
         {
@@ -1651,6 +1651,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6"
+        "php": "5.6.40"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3f0e6319f462f761c49b6e734a84a00",
+    "content-hash": "0a988b55fe14d4c554ff6937c43ecce7",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb8b146e1a199e9ac3ef6c7644850a9b",
+    "content-hash": "a3f0e6319f462f761c49b6e734a84a00",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03f3de82f4930150aef1e5ab2cbac985",
+    "content-hash": "ef13f4941cb0dabae39bce0d497e5e30",
     "packages": [],
     "packages-dev": [
         {
@@ -117,34 +117,32 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+                "reference": "83b5716aee90e1f733512942c635ac350cbd533c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/83b5716aee90e1f733512942c635ac350cbd533c",
+                "reference": "83b5716aee90e1f733512942c635ac350cbd533c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=5.3,<8.0-DEV"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -164,12 +162,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "homepage": "https://github.com/doctrine/instantiator",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "time": "2018-09-01T02:07:49+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -286,28 +284,25 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.x-dev",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/9012edbd1604a93cee7e7422d07a2c5776c56e0c",
-                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
@@ -330,37 +325,39 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-08-26T15:40:39+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -382,40 +379,38 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "dev-master",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
-                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "phpdocumentor/type-resolver": "^0",
-                "webmozart/assert": "^1"
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -429,39 +424,41 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-06-15T20:45:01+00:00"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.7.x-dev",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
-                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "phpdocumentor/reflection-common": "~2.0.0-beta1"
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "~6"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -474,8 +471,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T17:55:41+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -742,29 +738,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.x-dev",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "13eb9aba9626b1a3811c6a492acc9669d24bb85a"
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/13eb9aba9626b1a3811c6a492acc9669d24bb85a",
-                "reference": "13eb9aba9626b1a3811c6a492acc9669d24bb85a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/58bd196ce8bc49389307b3787934a5117db80fea",
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "~4.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -787,7 +783,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T08:47:38+00:00"
+            "time": "2017-12-04T15:11:28+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1537,27 +1533,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "4.4.x-dev",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8b24107fe8363d94ec6569217e0cc72664b8314c"
+                "reference": "dab657db15207879217fc81df4f875947bf68804"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8b24107fe8363d94ec6569217e0cc72664b8314c",
-                "reference": "8b24107fe8363d94ec6569217e0cc72664b8314c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/dab657db15207879217fc81df4f875947bf68804",
+                "reference": "dab657db15207879217fc81df4f875947bf68804",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "^3.4|^4.0|^5.0"
+                "symfony/console": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -1565,7 +1561,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1592,7 +1588,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-30T13:23:44+00:00"
+            "time": "2019-10-24T15:33:53+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1653,5 +1649,8 @@
     "platform": {
         "php": ">=5.6"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.40"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcf8e83e0b87f1d3d63746e814a9cff1",
+    "content-hash": "ef13f4941cb0dabae39bce0d497e5e30",
     "packages": [],
     "packages-dev": [
         {
@@ -963,12 +963,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e860800beea5ea4c8590df866338c09c20d3a48"
+                "reference": "5872e3737247e650995ac60e98611f69bfe8c556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e860800beea5ea4c8590df866338c09c20d3a48",
-                "reference": "5e860800beea5ea4c8590df866338c09c20d3a48",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5872e3737247e650995ac60e98611f69bfe8c556",
+                "reference": "5872e3737247e650995ac60e98611f69bfe8c556",
                 "shasum": ""
             },
             "require": {
@@ -1000,7 +1000,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2019-07-02T07:44:03+00:00"
+            "time": "2019-10-23T09:08:24+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1640,9 +1640,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "brain/monkey": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef13f4941cb0dabae39bce0d497e5e30",
+    "content-hash": "03f3de82f4930150aef1e5ab2cbac985",
     "packages": [],
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.9",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "1229bb22283177e196b572120de0772d9ee9baac"
+                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1229bb22283177e196b572120de0772d9ee9baac",
-                "reference": "1229bb22283177e196b572120de0772d9ee9baac",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
+                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -46,7 +49,7 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2019-08-18T15:18:18+00:00"
+            "time": "2019-10-26T07:10:56+00:00"
         },
         {
             "name": "brain/monkey",
@@ -114,32 +117,34 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "83b5716aee90e1f733512942c635ac350cbd533c"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/83b5716aee90e1f733512942c635ac350cbd533c",
-                "reference": "83b5716aee90e1f733512942c635ac350cbd533c",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -159,12 +164,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2018-09-01T02:07:49+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -220,12 +225,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "1da5d2af5a4be64253e2236d4c9510c6de7ffd0f"
+                "reference": "61d098f5ac3c92353cfb636c20c3633306ebe949"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/1da5d2af5a4be64253e2236d4c9510c6de7ffd0f",
-                "reference": "1da5d2af5a4be64253e2236d4c9510c6de7ffd0f",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/61d098f5ac3c92353cfb636c20c3633306ebe949",
+                "reference": "61d098f5ac3c92353cfb636c20c3633306ebe949",
                 "shasum": ""
             },
             "require": {
@@ -277,29 +282,32 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-10-22T20:08:13+00:00"
+            "time": "2019-10-24T13:49:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/9012edbd1604a93cee7e7422d07a2c5776c56e0c",
+                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -322,39 +330,37 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2019-08-26T15:40:39+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -376,38 +382,40 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
+                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
+                "php": ">=7.1",
+                "phpdocumentor/type-resolver": "^0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -421,41 +429,39 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
+            "time": "2019-06-15T20:45:01+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "0.7.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
+                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": ">=7.1",
+                "phpdocumentor/reflection-common": "~2.0.0-beta1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -468,7 +474,8 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T17:55:41+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -735,29 +742,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.x-dev",
+            "version": "2.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "58bd196ce8bc49389307b3787934a5117db80fea"
+                "reference": "13eb9aba9626b1a3811c6a492acc9669d24bb85a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/58bd196ce8bc49389307b3787934a5117db80fea",
-                "reference": "58bd196ce8bc49389307b3787934a5117db80fea",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/13eb9aba9626b1a3811c6a492acc9669d24bb85a",
+                "reference": "13eb9aba9626b1a3811c6a492acc9669d24bb85a",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -780,7 +787,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T15:11:28+00:00"
+            "time": "2017-11-27T08:47:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1530,27 +1537,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "3.4.x-dev",
+            "version": "4.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "768f817446da74a776a31eea335540f9dcb53942"
+                "reference": "8b24107fe8363d94ec6569217e0cc72664b8314c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/768f817446da74a776a31eea335540f9dcb53942",
-                "reference": "768f817446da74a776a31eea335540f9dcb53942",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8b24107fe8363d94ec6569217e0cc72664b8314c",
+                "reference": "8b24107fe8363d94ec6569217e0cc72664b8314c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~3.4|~4.0"
+                "symfony/console": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -1558,7 +1565,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -1585,7 +1592,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-09-10T10:38:46+00:00"
+            "time": "2019-10-30T13:23:44+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1646,8 +1653,5 @@
     "platform": {
         "php": ">=5.6"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "5.6.40"
-    }
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "799150a6b214853f5121cf70ab8de787",
+    "content-hash": "fcf8e83e0b87f1d3d63746e814a9cff1",
     "packages": [],
     "packages-dev": [
         {
@@ -92,9 +92,9 @@
             "authors": [
                 {
                     "name": "Giuseppe Mazzapica",
+                    "role": "Developer",
                     "email": "giuseppe.mazzapica@gmail.com",
-                    "homepage": "https://gmazzap.me",
-                    "role": "Developer"
+                    "homepage": "https://gmazzap.me"
                 }
             ],
             "description": "Mocking utility for PHP functions and WordPress plugin API",
@@ -114,34 +114,32 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+                "reference": "83b5716aee90e1f733512942c635ac350cbd533c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/83b5716aee90e1f733512942c635ac350cbd533c",
+                "reference": "83b5716aee90e1f733512942c635ac350cbd533c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=5.3,<8.0-DEV"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -161,12 +159,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "homepage": "https://github.com/doctrine/instantiator",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "time": "2018-09-01T02:07:49+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -222,12 +220,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "d9d4fd011608cfb1c3cf861b806ccc99a7c4a48d"
+                "reference": "1da5d2af5a4be64253e2236d4c9510c6de7ffd0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/d9d4fd011608cfb1c3cf861b806ccc99a7c4a48d",
-                "reference": "d9d4fd011608cfb1c3cf861b806ccc99a7c4a48d",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1da5d2af5a4be64253e2236d4c9510c6de7ffd0f",
+                "reference": "1da5d2af5a4be64253e2236d4c9510c6de7ffd0f",
                 "shasum": ""
             },
             "require": {
@@ -279,32 +277,29 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-10-09T11:44:54+00:00"
+            "time": "2019-10-22T20:08:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.x-dev",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/9012edbd1604a93cee7e7422d07a2c5776c56e0c",
-                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
@@ -327,37 +322,39 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-08-26T15:40:39+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -379,40 +376,38 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "dev-master",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
-                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "phpdocumentor/type-resolver": "^0",
-                "webmozart/assert": "^1"
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -426,39 +421,41 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-06-15T20:45:01+00:00"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.7.x-dev",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
-                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "phpdocumentor/reflection-common": "~2.0.0-beta1"
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "~6"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -471,8 +468,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T17:55:41+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -587,8 +583,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sb@sebastian-bergmann.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -635,8 +631,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sb@sebastian-bergmann.de"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -677,8 +673,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Simple template engine.",
@@ -726,8 +722,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sb@sebastian-bergmann.de"
                 }
             ],
             "description": "Utility class for timing",
@@ -739,29 +735,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.x-dev",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "13eb9aba9626b1a3811c6a492acc9669d24bb85a"
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/13eb9aba9626b1a3811c6a492acc9669d24bb85a",
-                "reference": "13eb9aba9626b1a3811c6a492acc9669d24bb85a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/58bd196ce8bc49389307b3787934a5117db80fea",
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "~4.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -784,7 +780,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T08:47:38+00:00"
+            "time": "2017-12-04T15:11:28+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -855,8 +851,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -1466,8 +1462,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -1534,27 +1530,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "4.4.x-dev",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b0b5b00cebaae53f64c240b7bc114de53ee5542c"
+                "reference": "768f817446da74a776a31eea335540f9dcb53942"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b0b5b00cebaae53f64c240b7bc114de53ee5542c",
-                "reference": "b0b5b00cebaae53f64c240b7bc114de53ee5542c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/768f817446da74a776a31eea335540f9dcb53942",
+                "reference": "768f817446da74a776a31eea335540f9dcb53942",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "^3.4|^4.0|^5.0"
+                "symfony/console": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -1562,7 +1558,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1589,7 +1585,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-18T11:24:32+00:00"
+            "time": "2019-09-10T10:38:46+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1652,5 +1648,8 @@
     "platform": {
         "php": ">=5.6"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.40"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.8",
+            "version": "2.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "3bb81ace3914c220aa273d1c0603d5e1b454c0d7"
+                "reference": "1229bb22283177e196b572120de0772d9ee9baac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/3bb81ace3914c220aa273d1c0603d5e1b454c0d7",
-                "reference": "3bb81ace3914c220aa273d1c0603d5e1b454c0d7",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1229bb22283177e196b572120de0772d9ee9baac",
+                "reference": "1229bb22283177e196b572120de0772d9ee9baac",
                 "shasum": ""
             },
             "require": {
@@ -46,20 +46,20 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2018-02-19T18:52:50+00:00"
+            "time": "2019-08-18T15:18:18+00:00"
         },
         {
             "name": "brain/monkey",
-            "version": "2.2.1",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "326a537bf518edd61bc57ab275e8b075ebb8a1a9"
+                "reference": "74cdccad5dbb7edc59f59e1ad6ef392f83a34776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/326a537bf518edd61bc57ab275e8b075ebb8a1a9",
-                "reference": "326a537bf518edd61bc57ab275e8b075ebb8a1a9",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/74cdccad5dbb7edc59f59e1ad6ef392f83a34776",
+                "reference": "74cdccad5dbb7edc59f59e1ad6ef392f83a34776",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2019-03-15T13:42:24+00:00"
+            "time": "2019-07-26T19:00:28+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -118,12 +118,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "7c71fc2932158d00f24f10635bf3b3b8b6ee5b68"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/7c71fc2932158d00f24f10635bf3b3b8b6ee5b68",
-                "reference": "7c71fc2932158d00f24f10635bf3b3b8b6ee5b68",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -166,7 +166,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-07-02T13:37:32+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -218,16 +218,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.2.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2"
+                "reference": "d9d4fd011608cfb1c3cf861b806ccc99a7c4a48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2",
-                "reference": "0eb0b48c3f07b3b89f5169ce005b7d05b18cf1d2",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/d9d4fd011608cfb1c3cf861b806ccc99a7c4a48d",
+                "reference": "d9d4fd011608cfb1c3cf861b806ccc99a7c4a48d",
                 "shasum": ""
             },
             "require": {
@@ -241,7 +241,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -279,7 +279,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-02-13T09:37:52+00:00"
+            "time": "2019-10-09T11:44:54+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -287,12 +287,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
+                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/9012edbd1604a93cee7e7422d07a2c5776c56e0c",
+                "reference": "9012edbd1604a93cee7e7422d07a2c5776c56e0c",
                 "shasum": ""
             },
             "require": {
@@ -327,39 +327,37 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-04-07T13:18:21+00:00"
+            "time": "2019-08-26T15:40:39+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -381,44 +379,40 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
+                "reference": "8fcadfe5f85c38705151c9ab23b4781f23e6a70e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
+                "php": ">=7.1",
+                "phpdocumentor/type-resolver": "^0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -432,41 +426,39 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-04-30T17:48:53+00:00"
+            "time": "2019-06-15T20:45:01+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "0.7.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
+                "reference": "6f6f66c1d4e14e9b0ad124cae85864dfa03104c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": ">=7.1",
+                "phpdocumentor/reflection-common": "~2.0.0-beta1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -479,26 +471,27 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T17:55:41+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "dev-master",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
                 "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -542,7 +535,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-06-13T12:50:23+00:00"
+            "time": "2019-10-03T11:07:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1487,12 +1480,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -1504,7 +1497,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1521,12 +1514,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1537,7 +1530,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1545,12 +1538,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b4d262d40ed43dd77ff3bd1fdc9919d8e237a3b5"
+                "reference": "b0b5b00cebaae53f64c240b7bc114de53ee5542c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b4d262d40ed43dd77ff3bd1fdc9919d8e237a3b5",
-                "reference": "b4d262d40ed43dd77ff3bd1fdc9919d8e237a3b5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b0b5b00cebaae53f64c240b7bc114de53ee5542c",
+                "reference": "b0b5b00cebaae53f64c240b7bc114de53ee5542c",
                 "shasum": ""
             },
             "require": {
@@ -1596,20 +1589,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-28T15:53:17+00:00"
+            "time": "2019-10-18T11:24:32+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "shasum": ""
             },
             "require": {
@@ -1617,8 +1610,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -1647,7 +1639,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef13f4941cb0dabae39bce0d497e5e30",
+    "content-hash": "9e1ca549854f85586472ff48f4b34b17",
     "packages": [],
     "packages-dev": [
         {
@@ -586,8 +586,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -634,8 +634,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -725,8 +725,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -854,8 +854,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -1651,6 +1651,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.40"
+        "php": "5.6"
     }
 }

--- a/mollie-payments-for-woocommerce/includes/mollie/OrderLineStatus.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/OrderLineStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+use Mollie\Api\Types\OrderLineStatus as ApiOrderLineStatus;
+
+/**
+ * Class OrderLineStatuses
+ */
+class OrderLineStatus extends ApiOrderLineStatus
+{
+    const CAN_BE_CANCELED = [
+        self::STATUS_CREATED,
+        self::STATUS_AUTHORIZED,
+    ];
+
+    const CAN_BE_REFUNDED = [
+        self::STATUS_PAID,
+        self::STATUS_SHIPPING,
+        self::STATUS_COMPLETED,
+    ];
+}

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstract.php
@@ -439,9 +439,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 		) {
 
             try {
-                $payment_object = Mollie_WC_Plugin::getPaymentFactoryHelper()->getPaymentObject(
-                    'payment'
-                );
+                $payment_object = Mollie_WC_Plugin::getPaymentFactoryHelper()
+                                                  ->getPaymentObject('payment');
                 $paymentRequestData = $payment_object->getPaymentRequestData($order, $customer_id);
                 $data = array_filter($paymentRequestData);
                 $data = apply_filters('woocommerce_' . $this->id . '_args', $data, $order);

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/gateway/abstractseparecurring.php
@@ -1,4 +1,7 @@
 <?php
+
+use Mollie\Api\Types\SequenceType;
+
 abstract class Mollie_WC_Gateway_AbstractSepaRecurring extends Mollie_WC_Gateway_AbstractSubscription
 {
 
@@ -133,42 +136,47 @@ abstract class Mollie_WC_Gateway_AbstractSepaRecurring extends Mollie_WC_Gateway
      */
     protected function handlePaidOrderWebhook($order, $payment)
     {
-	    if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-		    // Duplicate webhook call
-		    if (Mollie_WC_Plugin::getDataHelper()->isSubscription($order->id) && isset($payment->sequenceType) && $payment->sequenceType == \Mollie\Api\Types\SequenceType::SEQUENCETYPE_RECURRING ) {
-			    $payment_method_title = $this->getPaymentMethodTitle($payment);
+        $orderId = version_compare(WC_VERSION, '3.0', '<')
+            ? $order->id
+            : $order->get_id();
 
-			    $order->add_order_note(sprintf(
-			    /* translators: Placeholder 1: payment method title, placeholder 2: payment ID */
-				    __('Order completed using %s payment (%s).', 'mollie-payments-for-woocommerce'),
-				    $payment_method_title,
-				    $payment->id . ($payment->mode == 'test' ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce')) : '')
-			    ));
+        // Duplicate webhook call
+        if (Mollie_WC_Plugin::getDataHelper()->isSubscription($orderId)
+            && isset($payment->sequenceType)
+            && $payment->sequenceType == SequenceType::SEQUENCETYPE_RECURRING
+        ) {
+            $payment_method_title = $this->getPaymentMethodTitle($payment);
 
-			    $payment_object = Mollie_WC_Plugin::getPaymentFactoryHelper()->getPaymentObject( $payment );
-			    $payment_object->deleteSubscriptionOrderFromPendingPaymentQueue($order);
-			    return;
-		    }
-	    } else {
-		    // Duplicate webhook call
-		    if (Mollie_WC_Plugin::getDataHelper()->isSubscription($order->get_id()) && isset($payment->sequenceType) && $payment->sequenceType == \Mollie\Api\Types\SequenceType::SEQUENCETYPE_RECURRING ) {
-			    $payment_method_title = $this->getPaymentMethodTitle($payment);
+            $isTestMode = $payment->mode === 'test';
+            $paymentMessage = $payment->id . (
+                $isTestMode
+                    ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce'))
+                    : ''
+                );
+            $order->add_order_note(
+                sprintf(
+                /* translators: Placeholder 1: payment method title, placeholder 2: payment ID */
+                    __(
+                        'Order completed using %1$s payment (%2$s).',
+                        'mollie-payments-for-woocommerce'
+                    ),
+                    $payment_method_title,
+                    $paymentMessage
+                )
+            );
 
-			    $order->add_order_note(sprintf(
-			    /* translators: Placeholder 1: payment method title, placeholder 2: payment ID */
-				    __('Order completed using %s payment (%s).', 'mollie-payments-for-woocommerce'),
-				    $payment_method_title,
-				    $payment->id . ($payment->mode == 'test' ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce')) : '')
-			    ));
+            try {
+                $payment_object = Mollie_WC_Plugin::getPaymentFactoryHelper()
+                    ->getPaymentObject($payment);
+            } catch (ApiException $exception) {
+                Mollie_WC_Plugin::debug($exception->getMessage());
+                return;
+            }
 
-			    $payment_object = Mollie_WC_Plugin::getPaymentFactoryHelper()->getPaymentObject( $payment );
-			    $payment_object->deleteSubscriptionOrderFromPendingPaymentQueue($order);
-			    return;
-		    }
-	    }
+            $payment_object->deleteSubscriptionOrderFromPendingPaymentQueue($order);
+            return;
+        }
 
         parent::handlePaidOrderWebhook($order, $payment);
-
     }
-
 }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/api.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/api.php
@@ -41,22 +41,17 @@ class Mollie_WC_Helper_Api {
 			throw new \Mollie\Api\Exceptions\ApiException( sprintf(__( "Invalid API key(s). Get them on the %sDevelopers page in the Mollie dashboard%s. The API key(s) must start with 'live_' or 'test_', be at least 30 characters and can't further contain any special characters.", 'mollie-payments-for-woocommerce' ), '<a href="https://www.mollie.com/dashboard/developers/api-keys" target="_blank">', '</a>' ) );
 		}
 
-		if ( empty( self::$api_client ) ) {
-			try {
-				$client = new MollieApiClient();
-				$client->setApiKey( $api_key );
-				$client->setApiEndpoint( self::getApiEndpoint() );
-				$client->addVersionString( 'WordPress/' . ( isset( $wp_version ) ? $wp_version : 'Unknown' ) );
-				$client->addVersionString( 'WooCommerce/' . get_option( 'woocommerce_version', 'Unknown' ) );
-				$client->addVersionString( 'WooCommerceSubscriptions/' . get_option( 'woocommerce_subscriptions_active_version', 'Unknown' ) );
-				$client->addVersionString( 'MollieWoo/' . Mollie_WC_Plugin::PLUGIN_VERSION );
-			}
-			catch ( Mollie\Api\Exceptions\ApiException $e ) {
-				throw new \Mollie\Api\Exceptions\ApiException( $e->getMessage() );
-			}
+        if (empty(self::$api_client)) {
+            $client = new MollieApiClient();
+            $client->setApiKey( $api_key );
+            $client->setApiEndpoint( self::getApiEndpoint() );
+            $client->addVersionString( 'WordPress/' . ( isset( $wp_version ) ? $wp_version : 'Unknown' ) );
+            $client->addVersionString( 'WooCommerce/' . get_option( 'woocommerce_version', 'Unknown' ) );
+            $client->addVersionString( 'WooCommerceSubscriptions/' . get_option( 'woocommerce_subscriptions_active_version', 'Unknown' ) );
+            $client->addVersionString( 'MollieWoo/' . Mollie_WC_Plugin::PLUGIN_VERSION );
 
-			self::$api_client = $client;
-		}
+            self::$api_client = $client;
+        }
 
 		return self::$api_client;
 	}

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/helper/paymentfactory.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/helper/paymentfactory.php
@@ -1,19 +1,42 @@
 <?php
 
-class Mollie_WC_Helper_PaymentFactory {
+use Mollie\Api\Exceptions\ApiException;
 
-	public static function getPaymentObject( $data ) {
+class Mollie_WC_Helper_PaymentFactory
+{
+    /**
+     * @param $data
+     * @return bool|Mollie_WC_Payment_Order|Mollie_WC_Payment_Payment
+     * @throws ApiException
+     */
+    public static function getPaymentObject($data)
+    {
+        if ((!is_object($data) && $data == 'order')
+            || (!is_object($data) && strpos($data, 'ord_') !== false)
+            || (is_object($data) && $data->resource == 'order')
+        ) {
+            $dataHelper = Mollie_WC_Plugin::getDataHelper();
+            $refundLineItemsBuilder = new RefundLineItemsBuilder($dataHelper);
+            $apiHelper = Mollie_WC_Plugin::getApiHelper();
+            $settingsHelper = Mollie_WC_Plugin::getSettingsHelper();
 
-		if ( ( ! is_object( $data ) && $data == 'order' ) || ( ! is_object( $data ) && strpos( $data, 'ord_' ) !== false ) || ( is_object( $data ) && $data->resource == 'order' )  ) {
-			return new Mollie_WC_Payment_Order( $data );
-		}
+            $orderItemsRefunded = new OrderItemsRefunder(
+                $refundLineItemsBuilder,
+                $dataHelper,
+                $apiHelper->getApiClient($settingsHelper->isTestModeEnabled())->orders
+            );
 
-		if ( ( ! is_object( $data ) && $data == 'payment' ) || ( ! is_object( $data ) && strpos( $data, 'tr_' ) !== false ) || ( is_object( $data ) && $data->resource == 'payment' )  ) {
-			return new Mollie_WC_Payment_Payment( $data );
-		}
+            return new Mollie_WC_Payment_Order($orderItemsRefunded, $data);
+        }
 
-		return false;
-	}
+        if ((!is_object($data) && $data == 'payment')
+            || (!is_object($data) && strpos($data, 'tr_') !== false)
+            || (is_object($data) && $data->resource == 'payment')
+        ) {
+            return new Mollie_WC_Payment_Payment($data);
+        }
 
+        return false;
+    }
 }
 

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/OrderItemsRefunder.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/OrderItemsRefunder.php
@@ -1,0 +1,213 @@
+<?php
+
+use Mollie\Api\Endpoints\OrderEndpoint;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Resources\Order;
+use Mollie\Api\Resources\Refund;
+
+/**
+ * Class OrderItemsRefunder
+ */
+class OrderItemsRefunder
+{
+    const ACTION_AFTER_REFUND_ORDER_ITEMS = Mollie_WC_Plugin::PLUGIN_ID . '_refund_items_created';
+    const ACTION_AFTER_CANCELED_ORDER_ITEMS = Mollie_WC_Plugin::PLUGIN_ID . '_line_items_cancelled';
+
+    /**
+     * @var RefundLineItemsBuilder
+     */
+    private $refundLineItemsBuilder;
+
+    /**
+     * @var Mollie_WC_Helper_Data
+     */
+    private $dataHelper;
+
+    /**
+     * @var OrderEndpoint
+     */
+    private $ordersApiClient;
+
+    /**
+     * OrderItemsRefunder constructor.
+     * @param RefundLineItemsBuilder $refundLineItemsBuilder
+     * @param Mollie_WC_Helper_Data $dataHelper
+     * @param OrderEndpoint $ordersApiClient
+     */
+    public function __construct(
+        RefundLineItemsBuilder $refundLineItemsBuilder,
+        Mollie_WC_Helper_Data $dataHelper,
+        OrderEndpoint $ordersApiClient
+    ) {
+
+        $this->refundLineItemsBuilder = $refundLineItemsBuilder;
+        $this->dataHelper = $dataHelper;
+        $this->ordersApiClient = $ordersApiClient;
+    }
+
+    /**
+     * @param WC_Order $order
+     * @param array $items
+     * @param Order $remotePaymentObject
+     * @param $refundReason
+     * @return bool
+     * @throws ApiException
+     * @throws UnexpectedValueException
+     */
+    public function refund(
+        WC_Order $order,
+        array $items,
+        Order $remotePaymentObject,
+        $refundReason
+    ) {
+
+        $toRefundItems = $this->toRefundItems($items);
+        $toRefundRemoteItems = $this->toRefundRemoteItems(
+            $remotePaymentObject->lines,
+            $toRefundItems
+        );
+
+        $this->bailIfNoItemsToRefund($toRefundItems, $toRefundRemoteItems);
+
+        $lineItems = $this->refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $this->dataHelper->getOrderCurrency($order),
+            $refundReason
+        );
+
+        $remoteOrder = $this->ordersApiClient->get($remotePaymentObject->id);
+
+        if (!empty($lineItems['toCancel']['lines'])) {
+            $this->cancelOrderLines($lineItems['toCancel'], $remoteOrder, $order);
+        }
+
+        if (!empty($lineItems['toRefund']['lines'])) {
+            $this->refundOrderLines($lineItems['toRefund'], $remoteOrder, $order);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $items
+     * @return array
+     * @throws UnexpectedValueException
+     */
+    private function toRefundItems(array $items)
+    {
+        $toRefundItems = [];
+        /** @var WC_Order_Item $item */
+        foreach ($items as $key => $item) {
+            $toRefundItemId = $item->get_meta('_refunded_item_id', true);
+
+            if (!$toRefundItemId) {
+                throw new UnexpectedValueException(
+                    __(
+                        'One of the WooCommerce order items does not have the refund item id meta value associated to Mollie Order item.',
+                        'mollie-payments-for-woocommerce'
+                    )
+                );
+            }
+
+            $toRefundItems[$toRefundItemId] = $item;
+        }
+
+        return $toRefundItems;
+    }
+
+    /**
+     * @param array $remoteItems
+     * @param array $toRefundItems
+     * @return array
+     * @throws UnexpectedValueException
+     */
+    private function toRefundRemoteItems(array $remoteItems, array $toRefundItems)
+    {
+        return array_intersect_key(
+            $this->remoteItems($remoteItems),
+            $toRefundItems
+        );
+    }
+
+    /**
+     * @param array $remoteItems
+     * @return array
+     * @throws UnexpectedValueException
+     */
+    private function remoteItems(array $remoteItems)
+    {
+        $relatedRemoteItems = [];
+
+        foreach ($remoteItems as $remoteItem) {
+            $orderItemId = isset($remoteItem->metadata->order_item_id)
+                ? $remoteItem->metadata->order_item_id
+                : 0;
+
+            if (!$orderItemId) {
+                throw new UnexpectedValueException(
+                    "Impossible to retrieve the order item id related to the remote item: {$remoteItem->id}. Try to do a refund by amount."
+                );
+            }
+
+            $relatedRemoteItems[$orderItemId] = $remoteItem;
+        }
+
+        return $relatedRemoteItems;
+    }
+
+    /**
+     * @param array $items
+     * @param array $remoteItems
+     * @throws UnexpectedValueException
+     */
+    private function bailIfNoItemsToRefund(array $items, array $remoteItems)
+    {
+        if (empty($items) || empty($remoteItems)) {
+            throw new UnexpectedValueException(
+                __(
+                    'Empty woocommerce order items or mollie order lines.',
+                    'mollie-payments-for-woocommerce'
+                )
+            );
+        }
+    }
+
+    /**
+     * @param array $data
+     * @param Order $remoteOrder
+     * @param WC_Order $order
+     * @throws ApiException
+     */
+    private function cancelOrderLines(array $data, Order $remoteOrder, WC_Order $order)
+    {
+        $remoteOrder->cancelLines($data);
+
+        /**
+         * Canceled Order Lines
+         *
+         * @param array $data Data sent to Mollie cancel endpoint
+         * @param WC_Order $order
+         */
+        do_action(self::ACTION_AFTER_CANCELED_ORDER_ITEMS, $data, $order);
+    }
+
+    /**
+     * @param array $data
+     * @param Order $remoteOrder
+     * @param WC_Order $order
+     */
+    private function refundOrderLines(array $data, Order $remoteOrder, WC_Order $order)
+    {
+        $refund = $remoteOrder->refund($data);
+
+        /**
+         * Refund Orders Lines
+         *
+         * @param Refund $refund Refund instance
+         * @param WC_Order $order
+         * @param array $data Data sent to Mollie refund endpoint
+         */
+        do_action(self::ACTION_AFTER_REFUND_ORDER_ITEMS, $refund, $order, $data);
+    }
+}

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/OrderItemsRefunder.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/OrderItemsRefunder.php
@@ -146,7 +146,13 @@ class OrderItemsRefunder
 
             if (!$orderItemId) {
                 throw new UnexpectedValueException(
-                    "Impossible to retrieve the order item id related to the remote item: {$remoteItem->id}. Try to do a refund by amount."
+                    sprintf(
+                        __(
+                            'Impossible to retrieve the order item id related to the remote item: %1$s. Try to do a refund by amount.',
+                            'mollie-payments-for-woocommerce'
+                        ),
+                        $remoteItem->id
+                    )
                 );
             }
 

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/OrderItemsRefunder.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/OrderItemsRefunder.php
@@ -6,7 +6,7 @@ use Mollie\Api\Resources\Order;
 use Mollie\Api\Resources\Refund;
 
 /**
- * Class OrderItemsRefunder
+ * Refund a WooCommerce order by line items
  */
 class OrderItemsRefunder
 {
@@ -46,12 +46,12 @@ class OrderItemsRefunder
     }
 
     /**
-     * @param WC_Order $order
-     * @param array $items
-     * @param Order $remotePaymentObject
-     * @param $refundReason
+     * @param WC_Order $order WooCommerce Order
+     * @param array $items WooCommerce Order Items
+     * @param Order $remotePaymentObject Mollie Order service
+     * @param string $refundReason The reason of refunding
      * @return bool
-     * @throws ApiException
+     * @throws ApiException When the API call fails for any reason
      * @throws UnexpectedValueException
      */
     public function refund(
@@ -61,7 +61,7 @@ class OrderItemsRefunder
         $refundReason
     ) {
 
-        $toRefundItems = $this->toRefundItems($items);
+        $toRefundItems = $this->normalizedWooCommerceItemsList($items);
         $toRefundRemoteItems = $this->toRefundRemoteItems(
             $remotePaymentObject->lines,
             $toRefundItems
@@ -90,11 +90,13 @@ class OrderItemsRefunder
     }
 
     /**
-     * @param array $items
+     * Normalized version of WooCommerce order items where the key is the id of the item to refund
+     *
+     * @param array $items WooCommerce Order Items
      * @return array
      * @throws UnexpectedValueException
      */
-    private function toRefundItems(array $items)
+    private function normalizedWooCommerceItemsList(array $items)
     {
         $toRefundItems = [];
         /** @var WC_Order_Item $item */
@@ -117,6 +119,8 @@ class OrderItemsRefunder
     }
 
     /**
+     * Given remote items of an order extract the ones for which the refund was requested
+     *
      * @param array $remoteItems
      * @param array $toRefundItems
      * @return array
@@ -125,17 +129,19 @@ class OrderItemsRefunder
     private function toRefundRemoteItems(array $remoteItems, array $toRefundItems)
     {
         return array_intersect_key(
-            $this->remoteItems($remoteItems),
+            $this->normalizedRemoteItems($remoteItems),
             $toRefundItems
         );
     }
 
     /**
+     * Normalized version of remote items where the key is the id of the item to refund
+     *
      * @param array $remoteItems
      * @return array
      * @throws UnexpectedValueException
      */
-    private function remoteItems(array $remoteItems)
+    private function normalizedRemoteItems(array $remoteItems)
     {
         $relatedRemoteItems = [];
 
@@ -163,6 +169,8 @@ class OrderItemsRefunder
     }
 
     /**
+     * Throw an exception if one of the given items list is empty
+     *
      * @param array $items
      * @param array $remoteItems
      * @throws UnexpectedValueException

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/PartialRefundException.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/PartialRefundException.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Class PartialRefundException
+ */
+class PartialRefundException extends UnexpectedValueException
+{
+}

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/PartialRefundException.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/PartialRefundException.php
@@ -1,8 +1,5 @@
 <?php
 
-/**
- * Class PartialRefundException
- */
 class PartialRefundException extends UnexpectedValueException
 {
 }

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/RefundLineItemsBuilder.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/RefundLineItemsBuilder.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * Class RefundLineItemsBuilder
+ * Create the line items list to refund according to Mollie rest api documentation
+ *
+ * @link https://docs.mollie.com/reference/v2/orders-api/create-order-refund
  */
 class RefundLineItemsBuilder
 {
@@ -22,8 +24,8 @@ class RefundLineItemsBuilder
     /**
      * @param array $toRefundRemoteItems
      * @param array $toRefundItems
-     * @param $currency
-     * @param $reason
+     * @param string $currency
+     * @param string $refundReason
      * @return array
      * @throws PartialRefundException
      * @throws UnexpectedValueException
@@ -32,15 +34,15 @@ class RefundLineItemsBuilder
         array $toRefundRemoteItems,
         array $toRefundItems,
         $currency,
-        $reason
+        $refundReason
     ) {
 
         $toCancel = [
-            'description' => $reason,
+            'description' => $refundReason,
             'lines' => [],
         ];
         $toRefund = [
-            'description' => $reason,
+            'description' => $refundReason,
             'lines' => [],
         ];
 
@@ -80,8 +82,8 @@ class RefundLineItemsBuilder
     /**
      * @param WC_Order_Item $toRefundItem
      * @param stdClass $toRefundRemoteItem
-     * @param $currency
-     * @return array|null
+     * @param string $currency
+     * @return array
      * @throws PartialRefundException
      */
     private function buildLineItem(
@@ -90,7 +92,6 @@ class RefundLineItemsBuilder
         $currency
     ) {
 
-        $remoteClientData = null;
         $toRefundItemQuantity = abs($toRefundItem->get_quantity());
         $toRefundItemAmount = number_format(
             abs($toRefundItem->get_total() + $toRefundItem->get_total_tax()),
@@ -125,7 +126,6 @@ class RefundLineItemsBuilder
 
         if (!empty($toRefundRemoteItem->discountAmount)) {
             $remoteClientData['amount'] = [
-                // TODO The currency here shouldn't be the one defined in the remote item? It get passed one from woocommerce.
                 'value' => $this->dataHelper->formatCurrencyValue($toRefundItemAmount, $currency),
                 'currency' => $currency,
             ];

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/RefundLineItemsBuilder.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/RefundLineItemsBuilder.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Class RefundLineItemsBuilder
+ */
+class RefundLineItemsBuilder
+{
+    /**
+     * @var Mollie_WC_Helper_Data
+     */
+    private $dataHelper;
+
+    /**
+     * RefundLineItemsBuilder constructor.
+     * @param Mollie_WC_Helper_Data $dataHelper
+     */
+    public function __construct(Mollie_WC_Helper_Data $dataHelper)
+    {
+        $this->dataHelper = $dataHelper;
+    }
+
+    /**
+     * @param array $toRefundRemoteItems
+     * @param array $toRefundItems
+     * @param $currency
+     * @param $reason
+     * @return array
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     */
+    public function buildLineItems(
+        array $toRefundRemoteItems,
+        array $toRefundItems,
+        $currency,
+        $reason
+    ) {
+
+        $toCancel = [
+            'description' => $reason,
+            'lines' => [],
+        ];
+        $toRefund = [
+            'description' => $reason,
+            'lines' => [],
+        ];
+
+        foreach ($toRefundItems as $toRefundItemId => $toRefundItem) {
+            $toRefundRemoteItem = isset($toRefundRemoteItems[$toRefundItemId])
+                ? $toRefundRemoteItems[$toRefundItemId]
+                : null;
+
+            if ($toRefundRemoteItem === null) {
+                throw new UnexpectedValueException(
+                    "Cannot refund {$toRefundItemId} item because it was not found in Mollie order. Aborting refund process. Try to do a refund by amount."
+                );
+            }
+
+            $lineItem = $this->buildLineItem(
+                $toRefundItem,
+                $toRefundRemoteItem,
+                $currency
+            );
+
+            if (!$lineItem) {
+                continue;
+            }
+
+            if (in_array($toRefundRemoteItem->status, OrderLineStatus::CAN_BE_CANCELED, true)) {
+                $toCancel['lines'][] = $lineItem;
+            }
+
+            if (in_array($toRefundRemoteItem->status, OrderLineStatus::CAN_BE_REFUNDED, true)) {
+                $toRefund['lines'][] = $lineItem;
+            }
+        }
+
+        return compact('toCancel', 'toRefund');
+    }
+
+    /**
+     * @param WC_Order_Item $toRefundItem
+     * @param stdClass $toRefundRemoteItem
+     * @param $currency
+     * @return array|null
+     * @throws PartialRefundException
+     */
+    private function buildLineItem(
+        WC_Order_Item $toRefundItem,
+        stdClass $toRefundRemoteItem,
+        $currency
+    ) {
+
+        $remoteClientData = null;
+        $toRefundItemQuantity = abs($toRefundItem->get_quantity());
+        $toRefundItemAmount = number_format(
+            abs($toRefundItem->get_total() + $toRefundItem->get_total_tax()),
+            2
+        );
+        $toRefundRemoteItemPrice = isset($toRefundRemoteItem->unitPrice->value)
+            ? $toRefundRemoteItem->unitPrice->value
+            : 0;
+
+        if ($toRefundItemAmount <= 0 || $toRefundItemQuantity < 1 || $toRefundRemoteItemPrice <= 0) {
+            return [];
+        }
+
+        $toRefundRemoteItemAmount = number_format(
+            $toRefundItemQuantity * $toRefundRemoteItemPrice,
+            2
+        );
+
+        if ($toRefundRemoteItemAmount !== $toRefundItemAmount) {
+            throw new PartialRefundException(
+                __(
+                    'Mollie doesn\'t allow a partial refund of the full amount or quantity of at least one order line. Trying to process this as an amount refund instead.',
+                    'mollie-payments-for-woocommerce'
+                )
+            );
+        }
+
+        $remoteClientData = [
+            'id' => $toRefundRemoteItem->id,
+            'quantity' => $toRefundItemQuantity,
+        ];
+
+        if (!empty($toRefundRemoteItem->discountAmount)) {
+            $remoteClientData['amount'] = [
+                // TODO The currency here shouldn't be the one defined in the remote item? It get passed one from woocommerce.
+                'value' => $this->dataHelper->formatCurrencyValue($toRefundItemAmount, $currency),
+                'currency' => $currency,
+            ];
+        }
+
+        return $remoteClientData;
+    }
+}

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/object.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/object.php
@@ -396,7 +396,14 @@ class Mollie_WC_Payment_Object {
 		// If there is no payment ID, try to get order ID and if it's stored, try getting payment ID from API
 		if ( $this->hasActiveMollieOrder( $order_id ) ) {
 			$mollie_order = $this->getPaymentObjectOrder($this->getActiveMollieOrderId( $order_id ));
-			$mollie_order = Mollie_WC_Plugin::getPaymentFactoryHelper()->getPaymentObject( $mollie_order );
+
+            try {
+                $mollie_order = Mollie_WC_Plugin::getPaymentFactoryHelper()
+                    ->getPaymentObject($mollie_order);
+            } catch (ApiException $exception) {
+                Mollie_WC_Plugin::debug($exception->getMessage());
+                return;
+            }
 
 			return $this->getPaymentObjectPayment(
 				$mollie_order->getMolliePaymentIdFromPaymentObject(),

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/order.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/order.php
@@ -1,6 +1,11 @@
 <?php
 
+use Mollie\Api\Resources\Refund;
+
 class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
+
+    const ACTION_AFTER_REFUND_AMOUNT_CREATED = Mollie_WC_Plugin::PLUGIN_ID . '_refund_amount_created';
+    const ACTION_AFTER_REFUND_ORDER_CREATED = Mollie_WC_Plugin::PLUGIN_ID . '_refund_order_created';
 
 	public static $paymentId;
 	public static $customerId;
@@ -8,9 +13,21 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 	public static $payment;
 	public static $shop_country;
 
-	public function __construct( $data ) {
-		$this->data = $data;
-	}
+    /**
+     * @var OrderItemsRefunder
+     */
+    private $orderItemsRefunder;
+
+    /**
+     * Mollie_WC_Payment_Order constructor.
+     * @param OrderItemsRefunder $orderItemsRefunder
+     * @param $data
+     */
+    public function __construct(OrderItemsRefunder $orderItemsRefunder, $data)
+    {
+        $this->data = $data;
+        $this->orderItemsRefunder = $orderItemsRefunder;
+    }
 
 	public function getPaymentObject( $payment_id, $test_mode = false, $use_cache = true ) {
 		try {
@@ -762,52 +779,58 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 			// Get order items from refund
 			$items = $woocommerce_refund->get_items( array ( 'line_item', 'fee', 'shipping' ) );
 
+            if (empty ($items)) {
+                return $this->refund_amount($order, $amount, $payment_object, $reason);
+            }
 
-			// If the refund contains items, it's a refund for individual order lines
-			if ( ! empty ( $items ) ) {
+            // Compare total amount of the refund to the combined totals of all refunded items,
+            // if the refund total is greater than sum of refund items, merchant is also doing a
+            // 'Refund amount', which the Mollie API does not support. In that case, stop entire
+            // process and warn the merchant.
 
-				// Compare total amount of the refund to the combined totals of all refunded items,
-				// if the refund total is greater than sum of refund items, merchant is also doing a
-				// 'Refund amount', which the Mollie API does not support. In that case, stop entire
-				// process and warn the merchant.
+            $totals = 0;
 
-				$totals = 0;
+            foreach ($items as $item_id => $item_data) {
+                $totals += $item_data->get_total() + $item_data->get_total_tax();
+            }
 
-				foreach ( $items as $item_id => $item_data ) {
+            $totals = number_format(abs($totals), 2); // WooCommerce - sum of all refund items
+            $amount = number_format($amount, 2); // WooCommerce - refund amount
 
-					$totals += $item_data->get_total() + $item_data->get_total_tax(); // Get the item line total
+            if ($amount !== $totals) {
+                $error_message = "The sum of refunds for all order lines is not identical to the refund amount, so this refund will be processed as a payment amount refund, not an order line refund.";
+                $order->add_order_note($error_message);
+                Mollie_WC_Plugin::debug(__METHOD__ . ' - ' . $error_message);
 
-				}
+                return $this->refund_amount($order, $amount, $payment_object, $reason);
+            }
 
-				$totals = number_format(abs($totals), 2); // WooCommerce - sum of all refund items
-				$amount = number_format($amount, 2); // WooCommerce - refund amount
+            Mollie_WC_Plugin::debug('Try to process individual order item refunds or cancels.');
 
-				if ( $amount !== $totals ) {
-					$error_message = "The sum of refunds for all order lines is not identical to the refund amount, so this refund will be processed as a payment amount refund, not an order line refund.";
-					$order->add_order_note( $error_message );
-					Mollie_WC_Plugin::debug( __METHOD__ . ' - ' . $error_message );
+            try {
+                return $this->orderItemsRefunder->refund(
+                    $order,
+                    $items,
+                    $payment_object,
+                    $reason
+                );
+            } catch (PartialRefundException $exception) {
+                Mollie_WC_Plugin::debug(__METHOD__ . ' - ' . $exception->getMessage());
+                return $this->refund_amount(
+                    $order,
+                    $amount,
+                    $payment_object,
+                    $reason
+                );
+            }
+        } catch (Exception $exception) {
+            $exceptionMessage = $exception->getMessage();
+            Mollie_WC_Plugin::debug(__METHOD__ . ' - ' . $exceptionMessage);
+            return new WP_Error(1, $exceptionMessage);
+        }
 
-					return $this->refund_amount( $order, $order_id, $amount, $payment_object, $reason );
-				}
-
-				return $this->refund_order_items( $order, $order_id, $amount, $items, $payment_object, $reason );
-
-			}
-
-			// If the refund does not contain items, only refund the amount
-			if ( empty ( $items ) ) {
-
-				return $this->refund_amount( $order, $order_id, $amount, $payment_object, $reason );
-
-			}
-		}
-		catch ( Exception $e ) {
-			return new WP_Error( 1, $e->getMessage() );
-		}
-
-		return false;
-
-	}
+        return false;
+    }
 
 	/**
 	 * @param $order
@@ -840,12 +863,10 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 
 				// If there is no metadata wth the order item ID, this order can't process individual order lines
 				if ( empty( $line->metadata->order_item_id ) ) {
-
 					$note_message = 'Refunds for this specific order can not be processed per order line. Trying to process this as an amount refund instead.';
 					Mollie_WC_Plugin::debug( __METHOD__ . " - " . $note_message );
 
-					return $this->refund_amount( $order, $order_id, $amount, $payment_object, $reason );
-
+					return $this->refund_amount( $order, $amount, $payment_object, $reason );
 				}
 
 				// Get the Mollie order line information that we need later
@@ -937,7 +958,18 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 						);
 					}
 
-					do_action( Mollie_WC_Plugin::PLUGIN_ID . '_refund_created', $refund, $order );
+                    do_action(
+                        Mollie_WC_Plugin::PLUGIN_ID . '_refund_order_created',
+                        $refund,
+                        $order
+                    );
+
+                    do_action_deprecated(
+                        Mollie_WC_Plugin::PLUGIN_ID . '_refund_created',
+                        [$refund, $order],
+                        '[next-version]',
+                        self::ACTION_AFTER_REFUND_PAYMENT_CREATED
+                    );
 
 					$order->add_order_note( $note_message );
 					Mollie_WC_Plugin::debug( $note_message );
@@ -968,11 +1000,15 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 	 * @return bool
 	 * @throws \Mollie\Api\Exceptions\ApiException|Exception
 	 */
-	public function refund_amount( $order, $order_id, $amount, $payment_object, $reason ) {
+    public function refund_amount($order, $amount, $payment_object, $reason)
+    {
+        $orderId = version_compare(WC_VERSION, '3.0', '<') ? $order->id : $order->get_id();
 
 		Mollie_WC_Plugin::debug( 'Try to process an amount refund (not individual order line)' );
 
-		$payment_object_payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment( $order_id );
+        $payment_object_payment = Mollie_WC_Plugin::getPaymentObject()->getActiveMolliePayment(
+            $orderId
+        );
 
 		// Is test mode enabled?
 		$test_mode = Mollie_WC_Plugin::getSettingsHelper()->isTestModeEnabled();
@@ -1005,7 +1041,21 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 			$order->add_order_note( $note_message );
 			Mollie_WC_Plugin::debug( $note_message );
 
-			do_action( Mollie_WC_Plugin::PLUGIN_ID . '_refund_created', $refund, $order );
+            /**
+             * After Refund Amount Created
+             *
+             * @param Refund $refund
+             * @param WC_Order $order
+             * @param string $amount
+             */
+            do_action(self::ACTION_AFTER_REFUND_AMOUNT_CREATED, $refund, $order, $amount);
+
+            do_action_deprecated(
+                Mollie_WC_Plugin::PLUGIN_ID . '_refund_created',
+                [$refund, $order],
+                '[next-version]',
+                self::ACTION_AFTER_REFUND_AMOUNT_CREATED
+            );
 
 			return true;
 

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/order.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/order.php
@@ -200,78 +200,59 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 		return parent::setActiveMolliePayment( $order_id );
 	}
 
-	public function getMolliePaymentIdFromPaymentObject() {
+    public function getMolliePaymentIdFromPaymentObject()
+    {
+        $payment = $this->getPaymentObject($this->data->id);
 
-		// TODO David: Quick fix, make sure payment object has payments embedded, there needs to be a better way to do this!
-		$payment = $this->getPaymentObject($this->data->id);
+        if (isset($payment->_embedded->payments[0]->id)) {
+            return $payment->_embedded->payments[0]->id;
+        }
+    }
 
-		if ( isset( $payment->_embedded->payments{0}->id ) ) {
+    public function getMollieCustomerIdFromPaymentObject($payment = null)
+    {
+        if ($payment == null) {
+            $payment = $this->data->id;
+        }
 
-			return $payment->_embedded->payments{0}->id;
+        $payment = $this->getPaymentObject($payment);
 
-		}
+        if (isset($payment->_embedded->payments[0]->customerId)) {
+            return $payment->_embedded->payments[0]->customerId;
+        }
+    }
 
-		return null;
-	}
+    public function getSequenceTypeFromPaymentObject($payment = null)
+    {
+        if ($payment == null) {
+            $payment = $this->data->id;
+        }
 
-	public function getMollieCustomerIdFromPaymentObject( $payment = null ) {
+        $payment = $this->getPaymentObject($payment);
 
-		// TODO David: Quick fix, make sure payment object has payments embedded, there needs to be a better way to do this!
-		if ( $payment == null ) {
-			$payment = $this->data->id;
-		}
+        if (isset($payment->_embedded->payments[0]->sequenceType)) {
+            return $payment->_embedded->payments[0]->sequenceType;
+        }
+    }
 
-		$payment = $this->getPaymentObject( $payment );
+    public function getMollieCustomerIbanDetailsFromPaymentObject($payment = null)
+    {
+        if ($payment == null) {
+            $payment = $this->data->id;
+        }
 
-		if ( isset( $payment->_embedded->payments{0}->customerId ) ) {
+        $payment = $this->getPaymentObject($payment);
 
-			return $payment->_embedded->payments{0}->customerId;
+        if (isset($payment->_embedded->payments[0]->id)) {
+            $actual_payment = new Mollie_WC_Payment_Payment($payment->_embedded->payments[0]->id);
+            $actual_payment = $actual_payment->getPaymentObject($actual_payment->data);
 
-		}
+            $iban_details['consumerName'] = $actual_payment->details->consumerName;
+            $iban_details['consumerAccount'] = $actual_payment->details->consumerAccount;
+        }
 
-		return null;
-	}
-
-	public function getSequenceTypeFromPaymentObject( $payment = null ) {
-
-		// TODO David: Quick fix, make sure payment object has payments embedded, there needs to be a better way to do this!
-		if ( $payment == null ) {
-			$payment = $this->data->id;
-		}
-
-		$payment = $this->getPaymentObject( $payment );
-
-		if ( isset( $payment->_embedded->payments{0}->sequenceType ) ) {
-
-			return $payment->_embedded->payments{0}->sequenceType;
-
-		}
-
-		return null;
-	}
-
-	public function getMollieCustomerIbanDetailsFromPaymentObject( $payment = null ) {
-
-		// TODO David: Quick fix, make sure payment object has payments embedded, there needs to be a better way to do this!
-		if ( $payment == null ) {
-			$payment = $this->data->id;
-		}
-
-		$payment = $this->getPaymentObject( $payment );
-
-		if ( isset( $payment->_embedded->payments{0}->id ) ) {
-
-			$actual_payment = new Mollie_WC_Payment_Payment( $payment->_embedded->payments{0}->id );
-			$actual_payment = $actual_payment->getPaymentObject( $actual_payment->data );
-
-			$iban_details['consumerName']    = $actual_payment->details->consumerName;
-			$iban_details['consumerAccount'] = $actual_payment->details->consumerAccount;
-
-		}
-
-		return $iban_details;
-
-	}
+        return $iban_details;
+    }
 
 	/**
 	 * @param WC_Order                   $order

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/order.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/order.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Refund;
 
 class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
@@ -40,7 +41,7 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 
 			return parent::getPaymentObject( $payment_id, $test_mode = false, $use_cache = true );
 		}
-		catch ( \Mollie\Api\Exceptions\ApiException $e ) {
+		catch ( ApiException $e ) {
 			Mollie_WC_Plugin::debug( __CLASS__ . __FUNCTION__ . ": Could not load payment $payment_id (" . ( $test_mode ? 'test' : 'live' ) . "): " . $e->getMessage() . ' (' . get_class( $e ) . ')' );
 		}
 
@@ -832,17 +833,18 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
         return false;
     }
 
-	/**
-	 * @param $order
-	 * @param $order_id
-	 * @param $amount
-	 * @param $items
-	 * @param $payment_object
-	 * @param $reason
-	 *
-	 * @return bool
-	 * @throws \Mollie\Api\Exceptions\ApiException|Exception
-	 */
+    /**
+     * @param $order
+     * @param $order_id
+     * @param $amount
+     * @param $items
+     * @param $payment_object
+     * @param $reason
+     *
+     * @return bool
+     * @throws ApiException
+     * @deprecated Not recommended because merchant will be charged for every refunded item, use OrderItemsRefunder instead.
+     */
 	public function refund_order_items( $order, $order_id, $amount, $items, $payment_object, $reason ) {
 
 		Mollie_WC_Plugin::debug( 'Try to process individual order item refunds or cancels.' );
@@ -998,7 +1000,7 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 	 * @param $reason
 	 *
 	 * @return bool
-	 * @throws \Mollie\Api\Exceptions\ApiException|Exception
+	 * @throws ApiException|Exception
 	 */
     public function refund_amount($order, $amount, $payment_object, $reason)
     {

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/payment/payment.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/payment/payment.php
@@ -1,6 +1,10 @@
 <?php
 
+use Mollie\Api\Resources\Refund;
+
 class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
+
+    const ACTION_AFTER_REFUND_PAYMENT_CREATED = Mollie_WC_Plugin::PLUGIN_ID . '_refund_payment_created';
 
 	public function __construct( $data ) {
 		$this->data = $data;
@@ -560,7 +564,20 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
 
 			Mollie_WC_Plugin::debug( __METHOD__ . ' - Refund created - refund: ' . $refund->id . ', payment: ' . $payment_object->id . ', order: ' . $order_id . ', amount: ' . Mollie_WC_Plugin::getDataHelper()->getOrderCurrency( $order ) . $amount . ( ! empty( $reason ) ? ', reason: ' . $reason : '' ) );
 
-			do_action( Mollie_WC_Plugin::PLUGIN_ID . '_refund_created', $refund, $order );
+            /**
+             * After Payment Refund has been created
+             *
+             * @param Refund $refund
+             * @param WC_Order $order
+             */
+            do_action(self::ACTION_AFTER_REFUND_PAYMENT_CREATED, $refund, $order);
+
+            do_action_deprecated(
+                Mollie_WC_Plugin::PLUGIN_ID . '_refund_created',
+                [$refund, $order],
+                '[next-version]',
+                self::ACTION_AFTER_REFUND_PAYMENT_CREATED
+            );
 
 			$order->add_order_note( sprintf(
 			/* translators: Placeholder 1: currency, placeholder 2: refunded amount, placeholder 3: optional refund reason, placeholder 4: payment ID, placeholder 5: refund ID */

--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -1,5 +1,7 @@
 <?php
 // Require WooCommerce fallback functions
+use Mollie\Api\Resources\Refund;
+
 require_once dirname(dirname(dirname(__FILE__))) . '/woocommerce_functions.php';
 require_once dirname(dirname(dirname(__FILE__))) . '/subscriptions_status_check_functions.php';
 
@@ -226,6 +228,20 @@ class Mollie_WC_Plugin
         // Enqueue Scripts
         add_action('wp_enqueue_scripts', [__CLASS__, 'enqueueFrontendScripts']);
 
+        // Debug
+        add_action(
+            OrderItemsRefunder::ACTION_AFTER_REFUND_ORDER_ITEMS,
+            [__CLASS__, 'addOrderNoteForRefundCreated'],
+            10,
+            3
+        );
+        add_action(
+            OrderItemsRefunder::ACTION_AFTER_CANCELED_ORDER_ITEMS,
+            [__CLASS__, 'addOrderNoteForCancelledLineItems'],
+            10,
+            2
+        );
+
 		self::initDb();
 		self::schedulePendingPaymentOrdersExpirationCheck();
         self::registerFrontendScripts();
@@ -233,6 +249,47 @@ class Mollie_WC_Plugin
 		// Mark plugin initiated
 		self::$initiated = true;
 	}
+
+    /**
+     * @param Refund $refund
+     * @param WC_Order $order
+     * @param array $data
+     */
+    public static function addOrderNoteForRefundCreated(
+        Refund $refund,
+        WC_Order $order,
+        array $data
+    ) {
+
+        $orderNote = sprintf(
+            __(
+                '%1$s items refunded in WooCommerce and at Mollie.',
+                'mollie-payments-for-woocommerce'
+            ),
+            self::extractRemoteItemsIds($data)
+        );
+
+        $order->add_order_note($orderNote);
+        Mollie_WC_Plugin::debug($orderNote);
+    }
+
+    /**
+     * @param array $data
+     * @param WC_Order $order
+     */
+    public static function addOrderNoteForCancelledLineItems(array $data, WC_Order $order)
+    {
+        $orderNote = sprintf(
+            __(
+                '%1$s items cancelled in WooCommerce and at Mollie.',
+                'mollie-payments-for-woocommerce'
+            ),
+            self::extractRemoteItemsIds($data)
+        );
+
+        $order->add_order_note($orderNote);
+        Mollie_WC_Plugin::debug($orderNote);
+    }
 
     /**
      * Register Scripts
@@ -919,5 +976,13 @@ class Mollie_WC_Plugin
 
 	}
 
+    private static function extractRemoteItemsIds(array $data)
+    {
+        if (empty($data['lines'])) {
+            return [];
+        }
+
+        return implode(',', wp_list_pluck($data['lines'], 'id'));
+    }
 }
 

--- a/mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php
@@ -75,6 +75,13 @@ add_action( 'plugins_loaded', 'mollie_wc_check_woocommerce_status' );
  */
 function mollie_wc_plugin_init() {
 
+    $pluginDir = untrailingslashit(plugin_dir_path(__FILE__));
+
+    require_once $pluginDir . '/includes/mollie/OrderLineStatus.php';
+    require_once $pluginDir . '/includes/mollie/wc/payment/OrderItemsRefunder.php';
+    require_once $pluginDir . '/includes/mollie/wc/payment/PartialRefundException.php';
+    require_once $pluginDir . '/includes/mollie/wc/payment/RefundLineItemsBuilder.php';
+
 	// Register Mollie autoloader
 	Mollie_WC_Autoload::register();
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <testsuite name="Test">
             <directory suffix="Test.php">./tests/php/Unit/</directory>
             <directory suffix="Test.php">./tests/php/Integration/</directory>
+            <directory suffix="Test.php">./tests/php/Functional/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/php/Functional/wc/payment/OrderItemsRefunderTest.php
+++ b/tests/php/Functional/wc/payment/OrderItemsRefunderTest.php
@@ -2,6 +2,7 @@
 
 namespace Mollie\WooCommerce\Tests\Functional;
 
+use Brain\Monkey\Expectation\Exception\ExpectationArgsRequired;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mollie\Api\Endpoints\OrderEndpoint;
 use Mollie\Api\Exceptions\ApiException;
@@ -49,6 +50,7 @@ class OrderItemsRefunderTest extends TestCase
      * @throws PHPUnit_Framework_Exception
      * @throws PHPUnit_Framework_MockObject_RuntimeException
      * @throws UnexpectedValueException
+     * @throws ExpectationArgsRequired
      */
     public function testRefund()
     {
@@ -137,6 +139,7 @@ class OrderItemsRefunderTest extends TestCase
                 'id' => uniqid(),
             ]
         );
+        /** @var Order $remoteOrder */
         $remoteOrder = $this->remoteOrder([$orderLineItem]);
         $refundReason = uniqid();
         $lineItems = $this->buildLineItems($refundReason);

--- a/tests/php/Functional/wc/payment/OrderItemsRefunderTest.php
+++ b/tests/php/Functional/wc/payment/OrderItemsRefunderTest.php
@@ -1,0 +1,436 @@
+<?php
+
+namespace Mollie\WooCommerce\Tests\Functional;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mollie\Api\Endpoints\OrderEndpoint;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Resources\Order;
+use Mollie\Api\Resources\Refund;
+use Mollie\WooCommerce\Tests\TestCase;
+use Mollie_WC_Helper_Data;
+use OrderItemsRefunder;
+use PHPUnit_Framework_Exception;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_MockObject_RuntimeException;
+use RefundLineItemsBuilder;
+use stdClass;
+use UnexpectedValueException;
+use WC_Order;
+use WC_Order_Item;
+use function Brain\Monkey\Actions\expectDone as expectedActionDone;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Class OrderItemsRefunderTest
+ * @package Mollie\WooCommerce\Tests\Unit
+ */
+class OrderItemsRefunderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject|RefundLineItemsBuilder
+     */
+    private $refundLineItemsBuilder;
+
+    /**
+     * @var Mollie_WC_Helper_Data
+     */
+    private $dataHelper;
+
+    /**
+     * @var OrderEndpoint
+     */
+    private $ordersApiClient;
+
+    /**
+     * @throws ApiException
+     * @throws PHPUnit_Framework_Exception
+     * @throws PHPUnit_Framework_MockObject_RuntimeException
+     * @throws UnexpectedValueException
+     */
+    public function testRefund()
+    {
+        /*
+         * Stubs
+         */
+        $order = new WC_Order();
+        /** @var WC_Order_Item $orderItem */
+        $orderItem = $this->orderItem(['meta' => uniqid()]);
+        $orderLineItem = $this->orderLineItem(
+            [
+                'metadata' => ['order_item_id' => $orderItem->get_meta()],
+                'id' => uniqid(),
+            ]
+        );
+        $remoteOrder = $this->remoteOrder([$orderLineItem]);
+        $refundReason = uniqid();
+        $lineItems = $this->buildLineItems($refundReason);
+        $refund = \Mockery::type(Refund::class);
+
+        /*
+         * Sut
+         */
+        $orderItemsRefunder = new OrderItemsRefunder(
+            $this->refundLineItemsBuilder,
+            $this->dataHelper,
+            $this->ordersApiClient
+        );
+
+        /*
+         * Stubbing
+         */
+        $this->refundLineItemsBuilder
+            ->method('buildLineItems')
+            ->willReturn($lineItems);
+
+        $this->ordersApiClient
+            ->method('get')
+            ->willReturn($remoteOrder);
+
+        /*
+         * Expectations
+         */
+        $remoteOrder
+            ->expects($this->once())
+            ->method('cancelLines')
+            ->with($lineItems['toCancel']);
+
+        $remoteOrder
+            ->expects($this->once())
+            ->method('refund')
+            ->with($lineItems['toRefund'])
+            ->willReturn($refund);
+
+        expectedActionDone(OrderItemsRefunder::ACTION_AFTER_CANCELED_ORDER_ITEMS)
+            ->once()
+            ->with($lineItems['toCancel'], $order);
+
+        expectedActionDone(OrderItemsRefunder::ACTION_AFTER_REFUND_ORDER_ITEMS)
+            ->once()
+            ->with($refund, $order, $lineItems['toRefund']);
+
+        /*
+         * Execute Test
+         */
+        $orderItemsRefunder->refund($order, [$orderItem], $remoteOrder, $refundReason);
+    }
+
+    /**
+     * @throws ApiException
+     * @throws PHPUnit_Framework_Exception
+     * @throws PHPUnit_Framework_MockObject_RuntimeException
+     * @throws UnexpectedValueException
+     */
+    public function testRefundDoesNotRefundNorCancelOrderLineItems()
+    {
+        /*
+         * Stubs
+         */
+        $order = new WC_Order();
+        /** @var WC_Order_Item $orderItem */
+        $orderItem = $this->orderItem(['meta' => uniqid()]);
+        $orderLineItem = $this->orderLineItem(
+            [
+                'metadata' => ['order_item_id' => $orderItem->get_meta()],
+                'id' => uniqid(),
+            ]
+        );
+        $remoteOrder = $this->remoteOrder([$orderLineItem]);
+        $refundReason = uniqid();
+        $lineItems = $this->buildLineItems($refundReason);
+
+        /*
+         * Sut
+         */
+        $orderItemsRefunder = new OrderItemsRefunder(
+            $this->refundLineItemsBuilder,
+            $this->dataHelper,
+            $this->ordersApiClient
+        );
+
+        /*
+         * Stubbing
+         */
+
+        /*
+         * Force lines for cancel and refund items to be empty.
+         * This should prevent to call `cancelLines` and `refund`
+         */
+        $lineItems['toCancel']['lines'] = [];
+        $lineItems['toRefund']['lines'] = [];
+        $this->refundLineItemsBuilder->method('buildLineItems')->willReturn($lineItems);
+
+        $this->ordersApiClient->method('get')->willReturn($remoteOrder);
+
+        /*
+         * Expectations
+         */
+        $remoteOrder->expects($this->never())->method('cancelLines');
+        $remoteOrder->expects($this->never())->method('refund');
+
+        expectedActionDone(OrderItemsRefunder::ACTION_AFTER_CANCELED_ORDER_ITEMS)->never();
+        expectedActionDone(OrderItemsRefunder::ACTION_AFTER_REFUND_ORDER_ITEMS)->never();
+
+        /*
+         * Execute Test
+         */
+        $orderItemsRefunder->refund($order, [$orderItem], $remoteOrder, $refundReason);
+    }
+
+    /**
+     * @throws ApiException
+     * @throws UnexpectedValueException
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function testUnexpectedValueExceptionWhenBuildRefundItems()
+    {
+        /*
+         * Stubs
+         */
+        $order = new WC_Order();
+        // Passing null is the key here, this will throw the exception because of invalid value.
+        /** @var WC_Order_Item $orderItem */
+        $orderItem = $this->orderItem(['meta' => null]);
+        $orderLineItem = $this->orderLineItem(
+            [
+                'metadata' => ['order_item_id' => $orderItem->get_meta()],
+                'id' => uniqid(),
+            ]
+        );
+        $remoteOrder = $this->remoteOrder([$orderLineItem]);
+        $refundReason = uniqid();
+
+        /*
+         * Sut
+         */
+        $orderItemsRefunder = new OrderItemsRefunder(
+            $this->refundLineItemsBuilder,
+            $this->dataHelper,
+            $this->ordersApiClient
+        );
+
+        /*
+         * Expectations
+         */
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'One of the WooCommerce order items does not have the refund item id meta value associated to Mollie Order item.'
+        );
+
+        /*
+         * Execute Test
+         */
+        $orderItemsRefunder->refund($order, [$orderItem], $remoteOrder, $refundReason);
+    }
+
+    /**
+     * @throws ApiException
+     * @throws PHPUnit_Framework_Exception
+     * @throws UnexpectedValueException
+     */
+    public function testUnexpectedValueExceptionWhenBuildRemoteItems()
+    {
+        /*
+         * Stubs
+         */
+        $order = new WC_Order();
+        /** @var WC_Order_Item $orderItem */
+        $orderItem = $this->orderItem(['meta' => uniqid()]);
+        $orderLineItem = $this->orderLineItem(
+            [
+                'metadata' => null,
+                'id' => uniqid(),
+            ]
+        );
+        $remoteOrder = $this->remoteOrder([$orderLineItem]);
+        $refundReason = uniqid();
+
+        /*
+         * Sut
+         */
+        $orderItemsRefunder = new OrderItemsRefunder(
+            $this->refundLineItemsBuilder,
+            $this->dataHelper,
+            $this->ordersApiClient
+        );
+
+        /*
+        * Expectations
+        */
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            "Impossible to retrieve the order item id related to the remote item: {$orderLineItem->id}. Try to do a refund by amount."
+        );
+
+        /*
+         * Execute Test
+         */
+        $orderItemsRefunder->refund($order, [$orderItem], $remoteOrder, $refundReason);
+    }
+
+    /**
+     * @throws ApiException
+     * @throws PHPUnit_Framework_Exception
+     * @throws UnexpectedValueException
+     */
+    public function testBailIfNoItemsToRefund()
+    {
+        /*
+         * Stubs
+         */
+        $order = new WC_Order();
+        $remoteOrder = $this->remoteOrder([]);
+        $refundReason = uniqid();
+
+        /*
+         * Sut
+         */
+        $orderItemsRefunder = new OrderItemsRefunder(
+            $this->refundLineItemsBuilder,
+            $this->dataHelper,
+            $this->ordersApiClient
+        );
+
+        /*
+        * Expectations
+        */
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Empty woocommerce order items or mollie order lines.');
+
+        /*
+         * Execute Test
+         */
+        $orderItemsRefunder->refund($order, [], $remoteOrder, $refundReason);
+    }
+
+    /**
+     * @param array $config
+     * @return PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    private function orderItem(array $config)
+    {
+        $item = $this->createConfiguredMock(
+            'WC_Order_Item',
+            [
+                'get_meta' => $config['meta'],
+            ]
+        );
+
+        return $item;
+    }
+
+    /**
+     * @param array $config
+     * @return stdClass
+     */
+    private function orderLineItem(array $config)
+    {
+        $orderLineItem = new stdClass();
+        $orderLineItem->metadata = (object)$config['metadata'];
+        $orderLineItem->id = $config['id'];
+
+        return $orderLineItem;
+    }
+
+    /**
+     * @param array $orderLineItems
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function remoteOrder(array $orderLineItems)
+    {
+        $mock = $this
+            ->getMockBuilder(Order::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['cancelLines', 'refund'])
+            ->getMock();
+
+        $mock->lines = $orderLineItems;
+
+        return $mock;
+    }
+
+    /**
+     * @param $refundReason
+     * @return array
+     */
+    private function buildLineItems($refundReason)
+    {
+        return [
+            'toCancel' => [
+                'description' => $refundReason,
+                'lines' => [true],
+            ],
+            'toRefund' => [
+                'description' => $refundReason,
+                'lines' => [true],
+            ],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        when('__')->returnArg(1);
+
+        $this->initializeDependencies();
+    }
+
+    /**
+     * @return void
+     */
+    private function initializeDependencies()
+    {
+        $this->refundLineItemsBuilder = $this->refundLineItemsBuilder();
+        $this->dataHelper = $this->dataHelper();
+        $this->ordersApiClient = $this->ordersApiClient();
+    }
+
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function refundLineItemsBuilder()
+    {
+        $mock = $this
+            ->getMockBuilder(RefundLineItemsBuilder::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['buildLineItems'])
+            ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function dataHelper()
+    {
+        $mock = $this
+            ->getMockBuilder(Mollie_WC_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getOrderCurrency'])
+            ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function ordersApiClient()
+    {
+        $mock = $this
+            ->getMockBuilder(OrderEndpoint::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMock();
+
+        return $mock;
+    }
+}

--- a/tests/php/Functional/wc/payment/RefundLineItemsBuilderTest.php
+++ b/tests/php/Functional/wc/payment/RefundLineItemsBuilderTest.php
@@ -1,0 +1,446 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace Mollie\WooCommerce\Tests\Functional;
+
+use Mollie\WooCommerce\Tests\TestCase;
+use Mollie_WC_Helper_Data;
+use OrderLineStatus;
+use PartialRefundException;
+use PHPUnit_Framework_Exception;
+use PHPUnit_Framework_MockObject_MockObject;
+use RefundLineItemsBuilder;
+use stdClass;
+use UnexpectedValueException;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Class RefundLineItemsBuilderTest
+ * @package Mollie\WooCommerce\Tests\Unit
+ */
+class RefundLineItemsBuilderTest extends TestCase
+{
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject|Mollie_WC_Helper_Data
+     */
+    private $dataHelper;
+
+    /**
+     * Expect to build correct line items to perform the api call for refund
+     *
+     * @throws PHPUnit_Framework_Exception
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     */
+    public function testBuildlLineItems()
+    {
+        /*
+         * Stubs
+         */
+        $reason = uniqid();
+        $currency = uniqid();
+
+        /** @var WC_Order_Item $toCancelItem */
+        $toCancelItem = $this->wooCommerceOrderItem(-1, mt_rand(-100, -1), 0);
+        $toCancelRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_CANCELED[0],
+            [
+                'value' => abs($toCancelItem->get_total()),
+                'currency' => $currency,
+            ],
+            [
+                'value' => 1,
+                'currency' => $currency,
+            ]
+        );
+
+        /** @var WC_Order_Item $toRefundItem */
+        $toRefundItem = $this->wooCommerceOrderItem(-1, mt_rand(-100, -1), 0);
+        $toRefundRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_REFUNDED[0],
+            [
+                'value' => abs($toRefundItem->get_total()),
+                'currency' => $currency,
+            ],
+            [
+                'value' => 1,
+                'currency' => $currency,
+            ]
+        );
+        $toRefundRemoteItems = [$toCancelRemoteItem, $toRefundRemoteItem];
+        $toRefundItems = [$toCancelItem, $toRefundItem];
+
+        /*
+         * Sut
+         */
+        $refundLineItemsBuilder = new RefundLineItemsBuilder(
+            $this->dataHelper
+        );
+
+        $this->dataHelper->method('formatCurrencyValue')->willReturn(1);
+
+        /*
+         * Execute Test
+         */
+        $result = $refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $currency,
+            $reason
+        );
+
+        $this->assertEquals(
+            [
+                'toCancel' => [
+                    'description' => $reason,
+                    'lines' => [
+                        [
+                            'id' => $toCancelRemoteItem->id,
+                            'quantity' => abs($toCancelItem->get_quantity()),
+                            'amount' => [
+                                'value' => 1,
+                                'currency' => $currency,
+                            ],
+                        ],
+                    ],
+                ],
+                'toRefund' => [
+                    'description' => $reason,
+                    'lines' => [
+                        [
+                            'id' => $toRefundRemoteItem->id,
+                            'quantity' => abs($toRefundItem->get_quantity()),
+                            'amount' => [
+                                'value' => 1,
+                                'currency' => $currency,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @throws PHPUnit_Framework_Exception
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     */
+    public function testBuildLineItemsSkipItemBecauseNoRefoundAmountSpecified()
+    {
+        /*
+         * Stubs
+         */
+        $reason = uniqid();
+        $currency = uniqid();
+
+        // Will generate a $toRefundItemAmount equal to zero.
+        $toRefundItem = $this->wooCommerceOrderItem(-1, 0, 0);
+        $toRefundRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_REFUNDED[0],
+            [
+                'value' => abs($toRefundItem->get_total()),
+                'currency' => $currency,
+            ]
+        );
+        $toRefundRemoteItems = [$toRefundRemoteItem];
+        $toRefundItems = [$toRefundItem];
+
+        /*
+         * Sut
+         */
+        $refundLineItemsBuilder = new RefundLineItemsBuilder(
+            $this->dataHelper
+        );
+
+        /*
+         * Execute Test
+         */
+        $result = $refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $currency,
+            $reason
+        );
+
+        $this->assertEquals(true, empty($result['toRefund']['lines']));
+    }
+
+    /**
+     * @throws PHPUnit_Framework_Exception
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     */
+    public function testBuildLineItemsSkipItemBecauseNoRefundItemQuantity()
+    {
+        /*
+         * Stubs
+         */
+        $reason = uniqid();
+        $currency = uniqid();
+
+        // Will generate a $toRefundItemQuantity equal to zero.
+        $toRefundItem = $this->wooCommerceOrderItem(0, mt_rand(-100, -1), 0);
+        $toRefundRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_REFUNDED[0],
+            [
+                'value' => abs($toRefundItem->get_total()),
+                'currency' => $currency,
+            ]
+        );
+        $toRefundRemoteItems = [$toRefundRemoteItem];
+        $toRefundItems = [$toRefundItem];
+
+        /*
+         * Sut
+         */
+        $refundLineItemsBuilder = new RefundLineItemsBuilder(
+            $this->dataHelper
+        );
+
+        /*
+         * Execute Test
+         */
+        $result = $refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $currency,
+            $reason
+        );
+
+        $this->assertEquals(true, empty($result['toRefund']['lines']));
+    }
+
+    /**
+     * @throws PHPUnit_Framework_Exception
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     */
+    public function testBuildLineItemsSkipItemBecauseNoRemoteItemPrice()
+    {
+        /*
+         * Stubs
+         */
+        $reason = uniqid();
+        $currency = uniqid();
+
+        $toRefundItem = $this->wooCommerceOrderItem(-1, mt_rand(-100, -1), 0);
+        $toRefundRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_REFUNDED[0],
+            [
+                // Will generate a order line item price equal to zero.
+                'value' => 0,
+                'currency' => $currency,
+            ]
+        );
+        $toRefundRemoteItems = [$toRefundRemoteItem];
+        $toRefundItems = [$toRefundItem];
+
+        /*
+         * Sut
+         */
+        $refundLineItemsBuilder = new RefundLineItemsBuilder(
+            $this->dataHelper
+        );
+
+        /*
+         * Execute Test
+         */
+        $result = $refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $currency,
+            $reason
+        );
+
+        $this->assertEquals(true, empty($result['toRefund']['lines']));
+    }
+
+    /**
+     * When a refund for order items is performed Mollie need to have a match against the refunded
+     * item value and the order item price stored in the Mollie service.
+     *
+     * If this value does not match a PartialRefundException is thrown
+     *
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function testBuildLineItemsThrowPartialRefundExceptionBecauseRefundPriceDoesNotMatch()
+    {
+        /*
+         * Stubs
+         */
+        $reason = uniqid();
+        $currency = uniqid();
+
+        $toRefundItem = $this->wooCommerceOrderItem(-1, mt_rand(-100, -1), 0);
+        $toRefundRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_REFUNDED[0],
+            [
+                // The value here do the trick, infact the value to refund is different than the remote item price.
+                'value' => mt_rand(101, 200),
+                'currency' => uniqid(),
+            ]
+        );
+        $toRefundRemoteItems = [$toRefundRemoteItem];
+        $toRefundItems = [$toRefundItem];
+
+        /*
+         * Sut
+         */
+        $refundLineItemsBuilder = new RefundLineItemsBuilder(
+            $this->dataHelper
+        );
+
+        $this->expectException(PartialRefundException::class);
+        $this->expectExceptionMessage(
+            'Mollie doesn\'t allow a partial refund of the full amount or quantity of at least one order line. Trying to process this as an amount refund instead.',
+        );
+
+        /*
+         * Execute Test
+         */
+        $refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $currency,
+            $reason
+        );
+    }
+
+    /**
+     * When performing a refund for order items should there be a match against the refunding items
+     * and the order items retrieved by Mollie service.
+     *
+     * If the refunding item does not exists in mollie service an UnexpectedValueException is thrown
+     *
+     * @throws PHPUnit_Framework_Exception
+     * @throws PartialRefundException
+     * @throws UnexpectedValueException
+     */
+    public function testBuildLineItemsThrowUnexpectedValueExceptionBecauseRemoteItemNotFound()
+    {
+        /*
+         * Stubs
+         */
+        $reason = uniqid();
+        $currency = uniqid();
+
+        $toRefundItemId = uniqid();
+        $toRefundItem = $this->wooCommerceOrderItem(-1, mt_rand(-100, -1), 0);
+        $toRefundRemoteItem = $this->orderLineItem(
+            uniqid(),
+            OrderLineStatus::CAN_BE_REFUNDED[0],
+            [
+                // The value here do the trick, infact the value to refund is different than the remote item price.
+                'value' => mt_rand(101, 200),
+                'currency' => uniqid(),
+            ]
+        );
+        $toRefundRemoteItems = [uniqid() => $toRefundRemoteItem];
+        $toRefundItems = [$toRefundItemId => $toRefundItem];
+
+        /*
+         * Sut
+         */
+        $refundLineItemsBuilder = new RefundLineItemsBuilder(
+            $this->dataHelper
+        );
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            "Cannot refund {$toRefundItemId} item because it was not found in Mollie order. Aborting refund process. Try to do a refund by amount."
+        );
+
+        /*
+         * Execute Test
+         */
+        $refundLineItemsBuilder->buildLineItems(
+            $toRefundRemoteItems,
+            $toRefundItems,
+            $currency,
+            $reason
+        );
+    }
+
+    /**
+     * @param $quantity
+     * @param $total
+     * @param $totalTax
+     * @return PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    private function wooCommerceOrderItem($quantity, $total, $totalTax)
+    {
+        $orderItem = $this->createConfiguredMock(
+            'WC_Order_Item',
+            [
+                'get_quantity' => $quantity,
+                'get_total' => $total,
+                'get_total_tax' => $totalTax,
+            ]
+        );
+
+        return $orderItem;
+    }
+
+    /**
+     * @param $id
+     * @param $status
+     * @param array $price
+     * @param array|null $discountAmount
+     * @return stdClass
+     */
+    private function orderLineItem($id, $status, array $price, array $discountAmount = null)
+    {
+        $orderLineItem = new stdClass();
+
+        $orderLineItem->id = $id;
+        $orderLineItem->status = $status;
+        $orderLineItem->unitPrice = (object)$price;
+        $orderLineItem->discountAmount = $discountAmount ? (object)$discountAmount : null;
+
+        return $orderLineItem;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        when('__')->returnArg(1);
+
+        $this->initializeDependencies();
+    }
+
+    /**
+     * @return void
+     */
+    private function initializeDependencies()
+    {
+        $this->dataHelper = $this->dataHelper();
+    }
+
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function dataHelper()
+    {
+        $mock = $this
+            ->getMockBuilder(Mollie_WC_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['formatCurrencyValue'])
+            ->getMock();
+
+        return $mock;
+    }
+}

--- a/tests/php/Functional/wc/payment/RefundLineItemsBuilderTest.php
+++ b/tests/php/Functional/wc/payment/RefundLineItemsBuilderTest.php
@@ -302,7 +302,7 @@ class RefundLineItemsBuilderTest extends TestCase
 
         $this->expectException(PartialRefundException::class);
         $this->expectExceptionMessage(
-            'Mollie doesn\'t allow a partial refund of the full amount or quantity of at least one order line. Trying to process this as an amount refund instead.',
+            'Mollie doesn\'t allow a partial refund of the full amount or quantity of at least one order line. Trying to process this as an amount refund instead.'
         );
 
         /*

--- a/tests/php/Functional/wc/payment/RefundLineItemsBuilderTest.php
+++ b/tests/php/Functional/wc/payment/RefundLineItemsBuilderTest.php
@@ -11,6 +11,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use RefundLineItemsBuilder;
 use stdClass;
 use UnexpectedValueException;
+use WC_Order_Item;
 use function Brain\Monkey\Functions\when;
 
 /**
@@ -128,7 +129,7 @@ class RefundLineItemsBuilderTest extends TestCase
      * @throws PartialRefundException
      * @throws UnexpectedValueException
      */
-    public function testBuildLineItemsSkipItemBecauseNoRefoundAmountSpecified()
+    public function testBuildLineItemsSkipItemBecauseNoRefundAmountSpecified()
     {
         /*
          * Stubs

--- a/tests/php/Stubs/stubs.php
+++ b/tests/php/Stubs/stubs.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/woocommerce.php';

--- a/tests/php/Stubs/woocommerce.php
+++ b/tests/php/Stubs/woocommerce.php
@@ -1,0 +1,26 @@
+<?php
+class WC_Order
+{
+    public function add_order_note($note)
+    {
+    }
+}
+
+class WC_Order_Item
+{
+    public function get_quantity()
+    {
+    }
+
+    public function get_total()
+    {
+    }
+
+    public function get_total_tax()
+    {
+    }
+
+    public function get_meta()
+    {
+    }
+}

--- a/tests/php/Unit/MollieWCHelperSettingsTest.php
+++ b/tests/php/Unit/MollieWCHelperSettingsTest.php
@@ -1,5 +1,7 @@
 <?php # -*- coding: utf-8 -*-
 
+namespace Mollie\WooCommerce\Tests\Unit;
+
 use function Brain\Monkey\Filters\expectApplied as expectFilterApplied;
 use function Brain\Monkey\Functions\expect;
 use Mollie\WooCommerce\Tests\TestCase;

--- a/tests/php/Unit/wc/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/wc/Mollie_WC_Plugin_Test.php
@@ -9,9 +9,9 @@ use Mollie_WC_Plugin as Testee;
 use stdClass;
 
 /**
- * Class Mollie_WC_PluginTest
+ * Class Mollie_WC_Plugin_Test
  */
-class Mollie_WC_PluginTest extends TestCase
+class Mollie_WC_Plugin_Test extends TestCase
 {
     /**
      * Test Disable Apple Pay Gateway

--- a/tests/php/Unit/wc/helper/Mollie_WC_Helper_Settings_Test.php
+++ b/tests/php/Unit/wc/helper/Mollie_WC_Helper_Settings_Test.php
@@ -2,6 +2,7 @@
 
 namespace Mollie\WooCommerce\Tests\Unit;
 
+use Brain\Monkey\Expectation\Exception\NotAllowedMethod;
 use function Brain\Monkey\Filters\expectApplied as expectFilterApplied;
 use function Brain\Monkey\Functions\expect;
 use Mollie\WooCommerce\Tests\TestCase;
@@ -9,9 +10,9 @@ use Mollie\WooCommerce\Tests\TestCase;
 use Mollie_WC_Helper_Settings as Testee;
 
 /**
- * Class MollieWCHelperSettingsTest
+ * Class Mollie_WC_Helper_Settings_Test
  */
-class MollieWCHelperSettingsTest extends TestCase
+class Mollie_WC_Helper_Settings_Test extends TestCase
 {
     /* -----------------------------------------------------------------
        getPaymentLocale Tests
@@ -179,7 +180,7 @@ class MollieWCHelperSettingsTest extends TestCase
          * Then expect to retrieve the value from a call to `get_option` but
          * that value is a falsy value because of problem in retrieving the option.
          */
-        Brain\Monkey\Functions\expect('get_option')
+        expect('get_option')
             ->once()
             ->with($settingId, Testee::SETTING_LOCALE_WP_LANGUAGE)
             ->andReturn(false);
@@ -425,8 +426,7 @@ class MollieWCHelperSettingsTest extends TestCase
      * @dataProvider extractValidLanguageCodeDataProvider
      * @param array $languageCodes
      * @param $expectedResult
-     * @throws ReflectionException
-     * @throws \Brain\Monkey\Expectation\Exception\NotAllowedMethod
+     * @throws NotAllowedMethod
      */
     public function testExtractValidLanguageCode(array $languageCodes, $expectedResult)
     {

--- a/tests/php/Unit/wc/helper/Mollie_WC_Helper_Settings_Test.php
+++ b/tests/php/Unit/wc/helper/Mollie_WC_Helper_Settings_Test.php
@@ -242,7 +242,7 @@ class Mollie_WC_Helper_Settings_Test extends TestCase
      * Test Default language code is returned because the browser languages
      * doesn't include any allowed language.
      */
-    public function testeeBrowserLanguageReturnDefaultLanguage()
+    public function testBrowserLanguageReturnDefaultLanguage()
     {
         /*
          * Stubs

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -6,6 +6,7 @@ if (!file_exists($vendor . 'autoload.php')) {
 }
 
 require_once $vendor . 'brain/monkey/inc/patchwork-loader.php';
+require_once __DIR__ . '/Stubs/stubs.php';
 require_once $vendor . 'autoload.php';
 unset($vendor);
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -5,8 +5,8 @@ if (!file_exists($vendor . 'autoload.php')) {
     die('Please install via Composer before running tests.');
 }
 
-require_once $vendor . 'brain/monkey/inc/patchwork-loader.php';
 require_once __DIR__ . '/Stubs/stubs.php';
+require_once $vendor . 'brain/monkey/inc/patchwork-loader.php';
 require_once $vendor . 'autoload.php';
 unset($vendor);
 


### PR DESCRIPTION
The issue also solve a problem when the amount to refund for an item
is different than the price per unit defined in the mollie order.

## Deprecate action
Deprecate `Mollie_WC_Plugin::PLUGIN_ID . '_refund_created'` action, in
place of that there are multiple different actions performed based on
a specific context.

## Wrap getPaymentObject in a try/catch block
The changes introduce some DI expecially for `orders` endpoint.
Since `orders` endpoing are retrieved from the `ApiClient` when the
`paymentObject` is constructed it's possible that some of the internals
will throw an `ApiException`, for this reason I wrap the construction
of the object in a try/catch block.

Every catch block will log the exception but the returned value depends
by the context.

## Improve handle Paid Order WebHook
Method: `Mollie_WC_Gateway_AbstractSepaRecurring::handlePaidOrderWebhook`
Prevent useless and complicated to maintain code duplication just for
BC compatibility for WooCommerce.

## Avoid useless try/catch block
There's a try/catch block which just throw again the same exception
without doing nothing useful in `Helper::getApiClient`.