### PR TITLE
WooCommerce Session instance is lazy initialized

### DIFF
--- a/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
+++ b/mollie-payments-for-woocommerce/includes/mollie/wc/plugin.php
@@ -200,7 +200,10 @@ class Mollie_WC_Plugin
         add_action(
             'woocommerce_after_order_object_save',
             function () {
-                mollieWooCommerceSession()->__unset(self::APPLE_PAY_METHOD_ALLOWED_KEY);
+                $mollieWooCommerceSession = mollieWooCommerceSession();
+                if ($mollieWooCommerceSession instanceof WC_Session) {
+                    $mollieWooCommerceSession->__unset(self::APPLE_PAY_METHOD_ALLOWED_KEY);
+                }
             }
         );
 
@@ -489,6 +492,10 @@ class Mollie_WC_Plugin
     public static function maybeDisableApplePayGateway(array $gateways)
     {
         $wooCommerceSession = mollieWooCommerceSession();
+
+        if (!$wooCommerceSession instanceof WC_Session) {
+            return $gateways;
+        }
 
         if (is_admin()) {
             return $gateways;


### PR DESCRIPTION
WooCommerce Session instance is not created at configuration time,
there is a specific action we have to wait until the instance is
available through WooCommerce instance.

A check is needed in this case to ensure to execute our actions