### PR TITLE
Mol 86 code for review

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "brain/monkey": "^2.3",
     "ptrofimov/xpmock": "^1",
     "johnpbloch/wordpress-core": "^3.8 || ^4.0 || ^5.0",
-    "woocommerce/woocommerce": "^2.2 || ^3.0"
+    "woocommerce/woocommerce": "^2.2 || ^3.0",
+    "fzaninotto/faker": "^1.9@dev"
   },
   "autoload": {
     "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae6068d22f0dfc2f5ee8c0f797a147de",
+    "content-hash": "878ee5d5ac0c65ab7ad27d044baae694",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -64,16 +64,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "400cefd25a23a3098486bfb52685b5367a464171"
+                "reference": "df36d8dae3979cf927d5bbbed6f0427f39aadfec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/400cefd25a23a3098486bfb52685b5367a464171",
-                "reference": "400cefd25a23a3098486bfb52685b5367a464171",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/df36d8dae3979cf927d5bbbed6f0427f39aadfec",
+                "reference": "df36d8dae3979cf927d5bbbed6f0427f39aadfec",
                 "shasum": ""
             },
             "require": {
@@ -88,7 +88,6 @@
                 "psr/log": "^1.1"
             },
             "suggest": {
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
@@ -127,7 +126,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2019-12-30T04:52:42+00:00"
+            "time": "2019-10-30T11:22:04+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -750,6 +749,56 @@
                 "instantiate"
             ],
             "time": "2018-09-01T02:07:49+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "04c47e38dbc68d7261c88446598bbf509d37c77a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/04c47e38dbc68d7261c88446598bbf509d37c77a",
+                "reference": "04c47e38dbc68d7261c88446598bbf509d37c77a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^2.9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2019-12-31T10:44:52+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2408,14 +2457,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "fzaninotto/faker": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^5.6.40 | ^7.0"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "5.6.40"
-    }
+    "platform-dev": []
 }

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -139,5 +139,14 @@ function notice($message, $type = 'notice')
 {
     Mollie_WC_Plugin::addNotice($message, $type);
 }
+/**
+ * Isolates static getDataHelper calls.
+ *
+ * @return Mollie_WC_Helper_Data
+ */
+function getDataHelper()
+{
+    return Mollie_WC_Plugin::getDataHelper();
+}
 
 

--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -453,7 +453,7 @@ class Mollie_WC_Plugin
         $order = $dataHelper->getWcOrder($orderId);
 
         if (!$order) {
-            $order = $dataHelper->getWcOrder(wc_get_order_id_by_order_key ($key));
+            $order = $dataHelper->getWcOrder(wc_get_order_id_by_order_key($key));
         }
 
         if (!$order) {
@@ -481,9 +481,9 @@ class Mollie_WC_Plugin
 
         try {
             $order = self::orderByRequest();
-        } catch(RuntimeException $exc) {
+        } catch (RuntimeException $exc) {
             self::setHttpResponseCode($exc->getCode());
-            debug(__METHOD__ . $exc->getMessage());
+            debug(__METHOD__ . ": " . $exc->getMessage());
             return;
         }
 

--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -444,21 +444,21 @@ class Mollie_WC_Plugin
      */
     public static function onMollieReturn ()
     {
-        $dataHelper = self::getDataHelper();
+        $dataHelper = getDataHelper();
 
         $orderId = filter_input(INPUT_GET, 'order_id', FILTER_SANITIZE_NUMBER_INT) ?: null;
         $key = filter_input(INPUT_GET, 'key', FILTER_SANITIZE_STRING) ?: null;
-        $order = $dataHelper->getWcOrder($orderId);
+        $order = $dataHelper->getWcOrder (wc_get_order_id_by_order_key ($key));
 
         if (!$order) {
             self::setHttpResponseCode(404);
-            self::debug(__METHOD__ . ":  Could not find order $orderId.");
+            debug(__METHOD__ . ":  Could not find order $orderId.");
             return;
         }
 
         if (!$order->key_is_valid($key)) {
             self::setHttpResponseCode(401);
-            self::debug(__METHOD__ . ":  Invalid key $key for order $orderId.");
+            debug(__METHOD__ . ":  Invalid key $key for order $orderId.");
             return;
         }
 
@@ -468,7 +468,7 @@ class Mollie_WC_Plugin
             $gatewayName = $order->get_payment_method();
 
             self::setHttpResponseCode(404);
-            self::debug(
+            debug(
                 __METHOD__ . ":  Could not find gateway {$gatewayName} for order {$orderId}."
             );
             return;
@@ -476,7 +476,7 @@ class Mollie_WC_Plugin
 
         if (!($gateway instanceof Mollie_WC_Gateway_Abstract)) {
             self::setHttpResponseCode(400);
-            self::debug(__METHOD__ . ": Invalid gateway " . get_class($gateway) . " for this plugin. Order $orderId.");
+            debug(__METHOD__ . ": Invalid gateway " . get_class($gateway) . " for this plugin. Order $orderId.");
             return;
         }
 
@@ -485,7 +485,7 @@ class Mollie_WC_Plugin
         // Add utm_nooverride query string
         $redirect_url = add_query_arg(['utm_nooverride' => 1], $redirect_url);
 
-        self::debug(__METHOD__ . ": Redirect url on return order " . $gateway->id . ", order $orderId: $redirect_url");
+        debug(__METHOD__ . ": Redirect url on return order " . $gateway->id . ", order $orderId: $redirect_url");
 
         wp_safe_redirect($redirect_url);
     }

--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -457,14 +457,14 @@ class Mollie_WC_Plugin
         }
 
         if (!$order) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 "Could not find order by order Id {$orderId}",
                 404
             );
         }
 
         if (!$order->key_is_valid($key)) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 "Invalid key given. Key {$key} does not match the order id: {$orderId}",
                 401
             );
@@ -483,7 +483,7 @@ class Mollie_WC_Plugin
             $order = self::orderByRequest();
         } catch (RuntimeException $exc) {
             self::setHttpResponseCode($exc->getCode());
-            debug(__METHOD__ . ": " . $exc->getMessage());
+            debug(__METHOD__ . ":  {$exc->getMessage()}");
             return;
         }
 
@@ -502,7 +502,7 @@ class Mollie_WC_Plugin
 
         if (!($gateway instanceof Mollie_WC_Gateway_Abstract)) {
             self::setHttpResponseCode(400);
-            debug(__METHOD__ . ": Invalid gateway " . get_class($gateway) . " for this plugin. Order $orderId.");
+            debug(__METHOD__ . ": Invalid gateway {get_class($gateway)} for this plugin. Order {$orderId}.");
             return;
         }
 
@@ -511,7 +511,7 @@ class Mollie_WC_Plugin
         // Add utm_nooverride query string
         $redirect_url = add_query_arg(['utm_nooverride' => 1], $redirect_url);
 
-        debug(__METHOD__ . ": Redirect url on return order " . $gateway->id . ", order $orderId: $redirect_url");
+        debug(__METHOD__ . ": Redirect url on return order {$gateway->id}, order {$orderId}: {$redirect_url}");
 
         wp_safe_redirect($redirect_url);
     }

--- a/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
@@ -290,7 +290,7 @@ class Mollie_WC_Plugin_Test extends TestCase
             [],
             ['getReturnRedirectUrlForOrder']
         )->setMockClassName('Mollie_WC_Gateway_Abstract')->getMock();
-
+        $gateway->id = 'creditcard';
         $order = $this->buildTesteeMock(
             WC_Order::class,
             [],
@@ -324,7 +324,8 @@ class Mollie_WC_Plugin_Test extends TestCase
             ->once()
             ->andReturn(true);
         expect('debug')
-            ->withAnyArgs();
+            ->withAnyArgs()
+            ->andReturn(true);
         /*
          * Execute Test
          */

--- a/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
@@ -290,7 +290,7 @@ class Mollie_WC_Plugin_Test extends TestCase
             [],
             ['getReturnRedirectUrlForOrder']
         )->setMockClassName('Mollie_WC_Gateway_Abstract')->getMock();
-        $gateway->id = 'creditcard';
+        $gateway->id = "creditcard";
         $order = $this->buildTesteeMock(
             WC_Order::class,
             [],
@@ -323,9 +323,8 @@ class Mollie_WC_Plugin_Test extends TestCase
         expect('wp_safe_redirect')
             ->once()
             ->andReturn(true);
-        expect('debug')
-            ->withAnyArgs()
-            ->andReturn(true);
+        when('debug')
+            ->justReturn(true);
         /*
          * Execute Test
          */

--- a/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
@@ -298,22 +298,20 @@ class Mollie_WC_Plugin_Test extends TestCase
         )->getMock();
 
         expect('getDataHelper')
-            ->once()
             ->andReturn($dataHelper);
         when('wc_get_order_id_by_order_key')
             ->justReturn([4927]);
         $dataHelper
-            ->expects($this->once())
             ->method('getWcOrder')
             ->willReturn($order);
         $order
-            ->expects($this->once())
             ->method('key_is_valid')
             ->willReturn(true);
         $dataHelper
-            ->expects($this->once())
             ->method('getWcPaymentGatewayByOrder')
             ->willReturn($gateway);
+        when('wooCommerceOrderId')
+            ->justReturn([4927]);
         $gateway
             ->expects($this->once())
             ->method('getReturnRedirectUrlForOrder')

--- a/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
@@ -290,7 +290,7 @@ class Mollie_WC_Plugin_Test extends TestCase
             [],
             ['getReturnRedirectUrlForOrder']
         )->setMockClassName('Mollie_WC_Gateway_Abstract')->getMock();
-        $gateway->id = "creditcard";
+        $gateway->id = 98;
         $order = $this->buildTesteeMock(
             WC_Order::class,
             [],
@@ -319,7 +319,7 @@ class Mollie_WC_Plugin_Test extends TestCase
             ->method('getReturnRedirectUrlForOrder')
             ->willReturn($redirectUrl);
         when('add_query_arg')
-            ->justReturn(['https://website.org/language/order-received/4927/?key=wc_order_zUHGhd2f4fGc9&utm_nooverride=1']);
+            ->justReturn('https://website.org/language/order-received/4927/?key=wc_order_zUHGhd2f4fGc9&utm_nooverride=1');
         expect('wp_safe_redirect')
             ->once()
             ->andReturn(true);

--- a/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
@@ -311,7 +311,7 @@ class Mollie_WC_Plugin_Test extends TestCase
             ->method('getWcPaymentGatewayByOrder')
             ->willReturn($gateway);
         when('wooCommerceOrderId')
-            ->justReturn([4927]);
+            ->justReturn(4927);
         $gateway
             ->expects($this->once())
             ->method('getReturnRedirectUrlForOrder')

--- a/tests/php/Stubs/woocommerce.php
+++ b/tests/php/Stubs/woocommerce.php
@@ -27,12 +27,25 @@ class WC_Payment_Gateway
 
 }
 
+class Mollie_WC_Helper_Data
+{
+    public function getWcOrder()
+    {
+    }
+    public function getWcPaymentGatewayByOrder()
+    {
+    }
+}
+
 class WC_Order
 {
     public function get_id()
     {
     }
     public function add_order_note($note)
+    {
+    }
+    public function key_is_valid()
     {
     }
 }

--- a/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
@@ -409,32 +409,33 @@ class Mollie_WC_Plugin_Test extends TestCase
         self::expectExceptionMessage($message);
         self::expectExceptionCode($code);
     }
+
     /**
      * @return PHPUnit_Framework_MockObject_MockObject
      */
     private function mockOrder()
     {
-        $mock = $this->buildTesteeMock(
-            WC_Order::class,
-            [],
-            ['key_is_valid']
-        )->getMock();
+        $mock = $this->getMockBuilder(WC_Order::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['key_is_valid'])
+            ->getMock();
 
         return $mock;
     }
+
     /**
      * @return PHPUnit_Framework_MockObject_MockObject
      */
     private function mockDataHelper()
     {
-        $mock = $this->buildTesteeMock(
-            Mollie_WC_Helper_Data::class,
-            [],
-            ['getWcOrder', 'getWcPaymentGatewayByOrder']
-        )->getMock();
+        $mock = $this->getMockBuilder(Mollie_WC_Helper_Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getWcOrder', 'getWcPaymentGatewayByOrder'])
+            ->getMock();
 
         return $mock;
     }
+
     /**
      * Data Provider for orderByRequest
      *

--- a/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
@@ -10,8 +10,10 @@ use Mollie\WooCommerceTests\TestCase;
 use Mollie_WC_Plugin;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_MockObject_RuntimeException;
+use RuntimeException;
 use stdClass;
 use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
 
 class Mollie_WC_Plugin_Test extends TestCase
 {
@@ -282,5 +284,162 @@ class Mollie_WC_Plugin_Test extends TestCase
             ->getMock();
 
         return $mock;
+    }
+    /**
+     * Given orderByRequest is called
+     * when id and key are valid in the request
+     * then we get an order by id
+     * @test
+     */
+    public function orderByRequest_returnOrder_byId(){
+        /*
+         * Setup Stubs
+         */
+        $dataHelper = $this->mockDataHelper();
+        $order = $this->mockOrder();
+
+        //functions called
+        expect('getDataHelper')
+            ->andReturn($dataHelper);
+
+        $dataHelper
+            ->method('getWcOrder')
+            ->willReturn($order);
+        $order
+            ->method('key_is_valid')
+            ->willReturn(true);
+        /*
+         * Execute Test
+         */
+        $result = Mollie_WC_Plugin::orderByRequest();
+        self::assertEquals($order, $result);
+    }
+    /**
+     * Given orderByRequest is called
+     * when key is valid but not id in the request
+     * then we get an order by key
+     * @test
+     */
+    public function orderByRequest_returnOrder_byKey(){
+        /*
+         * Setup Stubs
+         */
+        $dataHelper = $this->mockDataHelper();
+        $order = $this->mockOrder();
+        $id = '';
+        $key = 'asj23';
+
+        //functions called
+        expect('getDataHelper')
+            ->andReturn($dataHelper);
+        when('wc_get_order_id_by_order_key')
+            ->justReturn($key);
+
+        //so first time id retrieving fails
+        //and we pass key to retrieve order
+        $dataHelper
+            ->method('getWcOrder')
+            ->withConsecutive([$id],[$key])
+            ->willReturn(false,$order);
+
+        $order
+            ->method('key_is_valid')
+            ->willReturn(true);
+        /*
+         * Execute Test
+         */
+        $result = Mollie_WC_Plugin::orderByRequest();
+        self::assertEquals($order, $result);
+    }
+    /**
+     * Given orderByRequest is called
+     * when id nor key are valid
+     * then we get an exception
+     *
+     * @test
+     *
+     * @param $returned wether we get or not the order
+     * @param $message  the message of the runtimeException
+     * @param $code  the code of the runtimeException
+     * @dataProvider orderByRequestDataProvider
+     * @expectedException RuntimeException
+     */
+    public function orderByRequest_returnException($returned, $message, $code){
+        /*
+         * Setup Stubs
+         */
+        $dataHelper = $this->mockDataHelper();
+        $order = $this->mockOrder();
+        $id = '';
+        $key = '';
+        if($returned){
+            $returned = $order;
+        }
+
+        //functions called
+        expect('getDataHelper')
+            ->andReturn($dataHelper);
+        when('wc_get_order_id_by_order_key')
+            ->justReturn($key);
+
+        // retrieving fails
+        $dataHelper
+            ->method('getWcOrder')
+            ->withConsecutive([$id],[$key])
+            ->willReturn(false,$returned);
+
+        $order
+            ->method('key_is_valid')
+            ->willReturn(false);
+        /*
+         * Execute Test
+         */
+        Mollie_WC_Plugin::orderByRequest();
+
+        self::expectExceptionMessage($message);
+        self::expectExceptionCode($code);
+    }
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function mockOrder()
+    {
+        $mock = $this->buildTesteeMock(
+            WC_Order::class,
+            [],
+            ['key_is_valid']
+        )->getMock();
+
+        return $mock;
+    }
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function mockDataHelper()
+    {
+        $mock = $this->buildTesteeMock(
+            Mollie_WC_Helper_Data::class,
+            [],
+            ['getWcOrder', 'getWcPaymentGatewayByOrder']
+        )->getMock();
+
+        return $mock;
+    }
+    /**
+     * Data Provider for orderByRequest
+     *
+     * @return array
+     */
+    public function orderByRequestDataProvider()
+    {
+        return [
+            [false,
+                "Could not find order by order Id {$orderId}",
+                404],
+            [true,
+                "Invalid key given. Key {$key} does not match the order id: {$orderId}",
+                401
+            ],
+        ];
     }
 }

--- a/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
@@ -334,7 +334,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         $dataHelper = $this->mockDataHelper();
         $order = $this->mockOrder();
         $faker = Faker\Factory::create();
-        $id = $faker->uuid;
+        $id = null;
         $key = $faker->word;
 
         //functions called
@@ -445,12 +445,12 @@ class Mollie_WC_Plugin_Test extends TestCase
         return [
             [
                 false,
-                "Could not find order by order Id {$orderId}",
+                "Could not find order by order Id ",
                 404
             ],
             [
                 true,
-                "Invalid key given. Key {$key} does not match the order id: {$orderId}",
+                "Invalid key given. Key  does not match the order id: ",
                 401
             ],
         ];

--- a/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
@@ -14,6 +14,7 @@ use RuntimeException;
 use stdClass;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
+use Faker;
 
 class Mollie_WC_Plugin_Test extends TestCase
 {
@@ -285,13 +286,16 @@ class Mollie_WC_Plugin_Test extends TestCase
 
         return $mock;
     }
+
     /**
      * Given orderByRequest is called
      * when id and key are valid in the request
      * then we get an order by id
+     *
      * @test
      */
-    public function orderByRequest_returnOrder_byId(){
+    public function orderByRequest_returnOrder_byId()
+    {
         /*
          * Setup Stubs
          */
@@ -314,20 +318,24 @@ class Mollie_WC_Plugin_Test extends TestCase
         $result = Mollie_WC_Plugin::orderByRequest();
         self::assertEquals($order, $result);
     }
+
     /**
      * Given orderByRequest is called
      * when key is valid but not id in the request
      * then we get an order by key
+     *
      * @test
      */
-    public function orderByRequest_returnOrder_byKey(){
+    public function orderByRequest_returnOrder_byKey()
+    {
         /*
          * Setup Stubs
          */
         $dataHelper = $this->mockDataHelper();
         $order = $this->mockOrder();
-        $id = '';
-        $key = 'asj23';
+        $faker = Faker\Factory::create();
+        $id = $faker->uuid;
+        $key = $faker->word;
 
         //functions called
         expect('getDataHelper')
@@ -339,8 +347,8 @@ class Mollie_WC_Plugin_Test extends TestCase
         //and we pass key to retrieve order
         $dataHelper
             ->method('getWcOrder')
-            ->withConsecutive([$id],[$key])
-            ->willReturn(false,$order);
+            ->withConsecutive([$id], [$key])
+            ->willReturn(false, $order);
 
         $order
             ->method('key_is_valid')
@@ -351,6 +359,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         $result = Mollie_WC_Plugin::orderByRequest();
         self::assertEquals($order, $result);
     }
+
     /**
      * Given orderByRequest is called
      * when id nor key are valid
@@ -360,7 +369,8 @@ class Mollie_WC_Plugin_Test extends TestCase
      *
      * @param $returned wether we get or not the order
      * @param $message  the message of the runtimeException
-     * @param $code  the code of the runtimeException
+     * @param $code     the code of the runtimeException
+     *
      * @dataProvider orderByRequestDataProvider
      * @expectedException RuntimeException
      */
@@ -372,7 +382,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         $order = $this->mockOrder();
         $id = '';
         $key = '';
-        if($returned){
+        if ($returned) {
             $returned = $order;
         }
 
@@ -385,8 +395,8 @@ class Mollie_WC_Plugin_Test extends TestCase
         // retrieving fails
         $dataHelper
             ->method('getWcOrder')
-            ->withConsecutive([$id],[$key])
-            ->willReturn(false,$returned);
+            ->withConsecutive([$id], [$key])
+            ->willReturn(false, $returned);
 
         $order
             ->method('key_is_valid')
@@ -433,10 +443,13 @@ class Mollie_WC_Plugin_Test extends TestCase
     public function orderByRequestDataProvider()
     {
         return [
-            [false,
+            [
+                false,
                 "Could not find order by order Id {$orderId}",
-                404],
-            [true,
+                404
+            ],
+            [
+                true,
                 "Invalid key given. Key {$key} does not match the order id: {$orderId}",
                 401
             ],


### PR DESCRIPTION
When onMollieReturn now we get the order by key, not by id. 
`$order = $dataHelper->getWcOrder (wc_get_order_id_by_order_key ($key));`
This change will assure if some users use different order_ids to secure their website instead of the WC order ids, they will be able to retrieve the order. To test this method some static method calls (debug, dataHelper) were wrapped into functions (inc/utils)
Addresses [MOL-86][].

[MOL-86]: https://inpsyde.atlassian.net/browse/MOL-86