### PR TITLE
Mol 63 woocommerce order status can be m

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "brain/monkey": "^2.3",
     "ptrofimov/xpmock": "^1",
     "johnpbloch/wordpress-core": "^3.8 || ^4.0 || ^5.0",
-    "woocommerce/woocommerce": "^2.2 || ^3.0"
+    "woocommerce/woocommerce": "^2.2 || ^3.0",
+    "fzaninotto/faker": "^1.9@dev"
   },
   "autoload": {
     "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae6068d22f0dfc2f5ee8c0f797a147de",
+    "content-hash": "878ee5d5ac0c65ab7ad27d044baae694",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -64,16 +64,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "400cefd25a23a3098486bfb52685b5367a464171"
+                "reference": "df36d8dae3979cf927d5bbbed6f0427f39aadfec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/400cefd25a23a3098486bfb52685b5367a464171",
-                "reference": "400cefd25a23a3098486bfb52685b5367a464171",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/df36d8dae3979cf927d5bbbed6f0427f39aadfec",
+                "reference": "df36d8dae3979cf927d5bbbed6f0427f39aadfec",
                 "shasum": ""
             },
             "require": {
@@ -88,7 +88,6 @@
                 "psr/log": "^1.1"
             },
             "suggest": {
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
@@ -127,7 +126,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2019-12-30T04:52:42+00:00"
+            "time": "2019-10-30T11:22:04+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -752,6 +751,56 @@
             "time": "2018-09-01T02:07:49+00:00"
         },
         {
+            "name": "fzaninotto/faker",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "04c47e38dbc68d7261c88446598bbf509d37c77a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/04c47e38dbc68d7261c88446598bbf509d37c77a",
+                "reference": "04c47e38dbc68d7261c88446598bbf509d37c77a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^2.9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2019-12-31T10:44:52+00:00"
+        },
+        {
             "name": "hamcrest/hamcrest-php",
             "version": "dev-master",
             "source": {
@@ -845,12 +894,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
+                "reference": "46fadaa0f5b8e4a290521a5340ada69701a70a20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
-                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/46fadaa0f5b8e4a290521a5340ada69701a70a20",
+                "reference": "46fadaa0f5b8e4a290521a5340ada69701a70a20",
                 "shasum": ""
             },
             "require": {
@@ -902,7 +951,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-12-26T09:49:15+00:00"
+            "time": "2020-01-16T09:16:38+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1101,20 +1150,20 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5 || ^3.2",
@@ -1156,7 +1205,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-22T21:05:45+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2408,14 +2457,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "fzaninotto/faker": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^5.6.40 | ^7.0"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "5.6.40"
-    }
+    "platform-dev": []
 }

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -139,5 +139,14 @@ function notice($message, $type = 'notice')
 {
     Mollie_WC_Plugin::addNotice($message, $type);
 }
+/**
+ * Isolates static getDataHelper calls.
+ *
+ * @return Mollie_WC_Helper_Data
+ */
+function getDataHelper()
+{
+    return Mollie_WC_Plugin::getDataHelper();
+}
 
 

--- a/src/Mollie/WC/Payment/Object.php
+++ b/src/Mollie/WC/Payment/Object.php
@@ -2,7 +2,9 @@
 
 class Mollie_WC_Payment_Object {
 
-	public static $paymentId;
+    const FINAL_STATUSES = ['completed', 'refunded', 'canceled'];
+
+    public static $paymentId;
 	public static $customerId;
 	public static $order;
 	public static $payment;
@@ -642,6 +644,7 @@ class Mollie_WC_Payment_Object {
 
 		}
 	}
+
     /**
      * @param WC_Order $order
      *
@@ -649,13 +652,14 @@ class Mollie_WC_Payment_Object {
      */
     protected function isFinalOrderStatus(WC_Order $order)
     {
-        $data_helper = getDataHelper();
-        $orderStatus = $data_helper->getOrderStatus($order);
-        $isFinalOrderStatus = \in_array(
+        $dataHelper = getDataHelper();
+        $orderStatus = $dataHelper->getOrderStatus($order);
+        $isFinalOrderStatus = in_array(
             $orderStatus,
-            ['completed', 'refunded', 'canceled'],
+            self::FINAL_STATUSES,
             true
         );
+
         return $isFinalOrderStatus;
     }
 

--- a/src/Mollie/WC/Payment/Object.php
+++ b/src/Mollie/WC/Payment/Object.php
@@ -642,5 +642,21 @@ class Mollie_WC_Payment_Object {
 
 		}
 	}
+    /**
+     * @param WC_Order $order
+     *
+     * @return bool
+     */
+    protected function isFinalOrderStatus(WC_Order $order)
+    {
+        $data_helper = getDataHelper();
+        $orderStatus = $data_helper->getOrderStatus($order);
+        $isFinalOrderStatus = \in_array(
+            $orderStatus,
+            ['completed', 'refunded', 'canceled'],
+            true
+        );
+        return $isFinalOrderStatus;
+    }
 
 }

--- a/src/Mollie/WC/Payment/Order.php
+++ b/src/Mollie/WC/Payment/Order.php
@@ -489,13 +489,11 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 		debug( __METHOD__ . ' called for order ' . $order_id );
 
 		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
-        $data_helper = getDataHelper();
-        $isCompleted = $data_helper->hasOrderStatus($order, 'completed');
-        $isRefunded = $data_helper->hasOrderStatus($order, 'refunded');
-        $isCancelled = $data_helper->hasOrderStatus($order, 'cancelled');
-
-        if ( $isCompleted || $isRefunded || $isCancelled){
-            debug( __METHOD__ . ' called for payment ' . $order_id . ' has final status. Nothing to be done' );
+        if ($this->isFinalOrderStatus($order)) {
+            debug(
+                __METHOD__ . ' called for payment ' . $order_id
+                . ' has final status. Nothing to be done'
+            );
 
             return;
         }
@@ -1060,5 +1058,4 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 
 		return false;
 	}
-
 }

--- a/src/Mollie/WC/Payment/Order.php
+++ b/src/Mollie/WC/Payment/Order.php
@@ -483,15 +483,22 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 	public function onWebhookCanceled( WC_Order $order, $payment, $payment_method_title ) {
 
 		// Get order ID in the correct way depending on WooCommerce version
-		if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
-			$order_id = $order->id;
-		} else {
-			$order_id = $order->get_id();
-		}
+        $order_id = wooCommerceOrderId($order);
 
 		// Add messages to log
-		Mollie_WC_Plugin::debug( __METHOD__ . ' called for order ' . $order_id );
+		debug( __METHOD__ . ' called for order ' . $order_id );
 
+		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
+        $data_helper = getDataHelper();
+        $isCompleted = $data_helper->hasOrderStatus($order, 'completed');
+        $isRefunded = $data_helper->hasOrderStatus($order, 'refunded');
+        $isCancelled = $data_helper->hasOrderStatus($order, 'cancelled');
+
+        if ( $isCompleted || $isRefunded || $isCancelled){
+            return;
+        }
+
+        //status is Pending|Failed|Processing|On-hold so Cancel
 		$this->unsetActiveMolliePayment( $order_id, $payment->id );
 		$this->setCancelledMolliePaymentId( $order_id, $payment->id );
 

--- a/src/Mollie/WC/Payment/Order.php
+++ b/src/Mollie/WC/Payment/Order.php
@@ -495,6 +495,8 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
         $isCancelled = $data_helper->hasOrderStatus($order, 'cancelled');
 
         if ( $isCompleted || $isRefunded || $isCancelled){
+            debug( __METHOD__ . ' called for payment ' . $order_id . ' has final status. Nothing to be done' );
+
             return;
         }
 

--- a/src/Mollie/WC/Payment/Order.php
+++ b/src/Mollie/WC/Payment/Order.php
@@ -486,13 +486,13 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
         $order_id = wooCommerceOrderId($order);
 
 		// Add messages to log
-		debug( __METHOD__ . ' called for order ' . $order_id );
+		debug( __METHOD__ . " called for order {$order_id}" );
 
 		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
         if ($this->isFinalOrderStatus($order)) {
             debug(
-                __METHOD__ . ' called for payment ' . $order_id
-                . ' has final status. Nothing to be done'
+                __METHOD__
+                . " called for payment {$order_id} has final status. Nothing to be done"
             );
 
             return;

--- a/src/Mollie/WC/Payment/Payment.php
+++ b/src/Mollie/WC/Payment/Payment.php
@@ -291,13 +291,11 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
 		debug( __METHOD__ . ' called for payment ' . $order_id );
 
 		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
-        $data_helper = getDataHelper();
-        $isCompleted = $data_helper->hasOrderStatus($order, 'completed');
-        $isRefunded = $data_helper->hasOrderStatus($order, 'refunded');
-        $isCancelled = $data_helper->hasOrderStatus($order, 'cancelled');
-
-        if ( $isCompleted || $isRefunded || $isCancelled){
-            debug( __METHOD__ . ' called for payment ' . $order_id . ' has final status. Nothing to be done' );
+        if ($this->isFinalOrderStatus($order)) {
+            debug(
+                __METHOD__ . ' called for payment ' . $order_id
+                . ' has final status. Nothing to be done'
+            );
 
             return;
         }

--- a/src/Mollie/WC/Payment/Payment.php
+++ b/src/Mollie/WC/Payment/Payment.php
@@ -288,13 +288,13 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
         $order_id = wooCommerceOrderId($order);
 
 		// Add messages to log
-		debug( __METHOD__ . ' called for payment ' . $order_id );
+		debug( __METHOD__ . " called for payment {$order_id}" );
 
 		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
         if ($this->isFinalOrderStatus($order)) {
             debug(
-                __METHOD__ . ' called for payment ' . $order_id
-                . ' has final status. Nothing to be done'
+                __METHOD__
+                . " called for payment {$order_id} has final status. Nothing to be done"
             );
 
             return;
@@ -365,7 +365,6 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
 				}
 			}
 		}
-
 	}
 
 	/**

--- a/src/Mollie/WC/Payment/Payment.php
+++ b/src/Mollie/WC/Payment/Payment.php
@@ -297,6 +297,8 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
         $isCancelled = $data_helper->hasOrderStatus($order, 'cancelled');
 
         if ( $isCompleted || $isRefunded || $isCancelled){
+            debug( __METHOD__ . ' called for payment ' . $order_id . ' has final status. Nothing to be done' );
+
             return;
         }
 

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Order_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Order_Test.php
@@ -4,13 +4,12 @@ namespace Mollie\WooCommerceTests\Functional\Payment;
 
 use Mollie\Api\Resources\Order;
 use Mollie\WooCommerceTests\TestCase;
-
 use Mollie_WC_Helper_Data;
 use Mollie_WC_Payment_Order;
 use Mollie_WC_Payment_OrderItemsRefunder;
 use WC_Order;
-
 use function Brain\Monkey\Functions\when;
+use Faker;
 
 
 class Mollie_WC_Payment_Order_Test extends TestCase
@@ -30,27 +29,16 @@ class Mollie_WC_Payment_Order_Test extends TestCase
         /*
         * Setup Stubs
         */
-        $orderItemsRefunded = $this->buildTesteeMock(
-            Mollie_WC_Payment_OrderItemsRefunder::class,
-            [],
-            []
-        )->getMock();
-
-        $payment = $this->buildTesteeMock(
-            Order::class,
-            [],
-            []
-        )->getMock();
-        $order = $this->buildTesteeMock(
-            WC_Order::class,
-            [],
-            []
-        )->getMock();
-        $dataHelper = $this->buildTesteeMock(
+        $orderItemsRefunded = $this->createMock(
+                Mollie_WC_Payment_OrderItemsRefunder::class
+            );
+        $payment = $this->createMock(Order::class);
+        $order = $this->createMock(WC_Order::class);
+        $dataHelper = $this->createConfiguredMock(
             Mollie_WC_Helper_Data::class,
-            [],
-            ['hasOrderStatus']
-        )->getMock();
+            ['getOrderStatus' => 'completed']
+        );
+        $faker = Faker\Factory::create();
         $payment_method_title = 'creditcard';
 
         /*
@@ -63,22 +51,15 @@ class Mollie_WC_Payment_Order_Test extends TestCase
          * Expectations
          */
         when('wooCommerceOrderId')
-            ->justReturn(89);
+            ->justReturn($faker->randomNumber(2));
         when('debug')
-            ->justReturn(true);
+            ->justReturn($faker->word);
         when('getDataHelper')
             ->justReturn($dataHelper);
-        $dataHelper
-            ->expects($this->exactly(3))
-            ->method('hasOrderStatus')
-            ->willReturn(true);
 
         /*
          * Execute test
          */
         $testee->onWebhookCanceled($order, $payment, $payment_method_title);
-
     }
-
-
 }

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Order_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Order_Test.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Mollie\WooCommerceTests\Functional\Payment;
+
+use Mollie\Api\Resources\Order;
+use Mollie\WooCommerceTests\TestCase;
+
+use Mollie_WC_Helper_Data;
+use Mollie_WC_Payment_Order;
+use Mollie_WC_Payment_OrderItemsRefunder;
+use WC_Order;
+
+use function Brain\Monkey\Functions\when;
+
+
+class Mollie_WC_Payment_Order_Test extends TestCase
+{
+    /* -----------------------------------------------------------------
+       onWebhookCanceled Tests
+       -------------------------------------------------------------- */
+
+    /**
+     * given onWebhookCanceled is called
+     * when order has status of Completed|Refunded|Cancelled
+     * then status does NOT change and we exit the method.
+     *
+     * @test
+     */
+    public function onWebHookCanceled_Returns_whenFinalStatus(){
+        /*
+        * Setup Stubs
+        */
+        $orderItemsRefunded = $this->buildTesteeMock(
+            Mollie_WC_Payment_OrderItemsRefunder::class,
+            [],
+            []
+        )->getMock();
+
+        $payment = $this->buildTesteeMock(
+            Order::class,
+            [],
+            []
+        )->getMock();
+        $order = $this->buildTesteeMock(
+            WC_Order::class,
+            [],
+            []
+        )->getMock();
+        $dataHelper = $this->buildTesteeMock(
+            Mollie_WC_Helper_Data::class,
+            [],
+            ['hasOrderStatus']
+        )->getMock();
+        $payment_method_title = 'creditcard';
+
+        /*
+        * Setup Testee
+        */
+        $data = 'order';
+        $testee = new Mollie_WC_Payment_Order($orderItemsRefunded, $data);
+
+        /*
+         * Expectations
+         */
+        when('wooCommerceOrderId')
+            ->justReturn(89);
+        when('debug')
+            ->justReturn(true);
+        when('getDataHelper')
+            ->justReturn($dataHelper);
+        $dataHelper
+            ->expects($this->exactly(3))
+            ->method('hasOrderStatus')
+            ->willReturn(true);
+
+        /*
+         * Execute test
+         */
+        $testee->onWebhookCanceled($order, $payment, $payment_method_title);
+
+    }
+
+
+}

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Mollie\WooCommerceTests\Functional\Payment;
+
+use Mollie\Api\Resources\Payment;
+use Mollie\WooCommerceTests\TestCase;
+
+use Mollie_WC_Helper_Data;
+use WC_Order;
+
+use function Brain\Monkey\Functions\when;
+
+
+class Mollie_WC_Payment_Payment_Test extends TestCase
+{
+    /* -----------------------------------------------------------------
+       onWebhookCanceled Tests
+       -------------------------------------------------------------- */
+
+    /**
+     * given onWebhookCanceled is called
+     * when payment has status of Completed|Refunded|Cancelled
+     * then status does NOT change and we exit the method.
+     *
+     * @test
+     */
+    public function onWebHookCanceled_Returns_whenFinalStatus(){
+        /*
+        * Setup Stubs
+        */
+
+        $payment = $this->buildTesteeMock(
+            Payment::class,
+            [],
+            []
+        )->getMock();
+        $order = $this->buildTesteeMock(
+            WC_Order::class,
+            [],
+            []
+        )->getMock();
+        $dataHelper = $this->buildTesteeMock(
+            Mollie_WC_Helper_Data::class,
+            [],
+            ['hasOrderStatus']
+        )->getMock();
+        $payment_method_title = 'creditcard';
+
+        /*
+        * Setup Testee
+        */
+        $data = 'order';
+        $testee = new \Mollie_WC_Payment_Payment($data);
+
+        /*
+         * Expectations
+         */
+        when('wooCommerceOrderId')
+            ->justReturn(89);
+        when('debug')
+            ->justReturn(true);
+        when('getDataHelper')
+            ->justReturn($dataHelper);
+        $dataHelper
+            ->expects($this->exactly(3))
+            ->method('hasOrderStatus')
+            ->willReturn(true);
+
+        /*
+         * Execute test
+         */
+        $testee->onWebhookCanceled($order, $payment, $payment_method_title);
+
+    }
+
+
+}

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
@@ -4,12 +4,10 @@ namespace Mollie\WooCommerceTests\Functional\Payment;
 
 use Mollie\Api\Resources\Payment;
 use Mollie\WooCommerceTests\TestCase;
-
 use Mollie_WC_Helper_Data;
 use WC_Order;
-
 use function Brain\Monkey\Functions\when;
-
+use Faker;
 
 class Mollie_WC_Payment_Payment_Test extends TestCase
 {
@@ -28,23 +26,11 @@ class Mollie_WC_Payment_Payment_Test extends TestCase
         /*
         * Setup Stubs
         */
-
-        $payment = $this->buildTesteeMock(
-            Payment::class,
-            [],
-            []
-        )->getMock();
-        $order = $this->buildTesteeMock(
-            WC_Order::class,
-            [],
-            []
-        )->getMock();
-        $dataHelper = $this->buildTesteeMock(
-            Mollie_WC_Helper_Data::class,
-            [],
-            ['hasOrderStatus']
-        )->getMock();
+        $payment = $this->createMock(Payment::class);
+        $order = $this->createMock(WC_Order::class);
+        $dataHelper = $this->createConfiguredMock(Mollie_WC_Helper_Data::class, ['getOrderStatus'=>'completed']);
         $payment_method_title = 'creditcard';
+        $faker = Faker\Factory::create();
 
         /*
         * Setup Testee
@@ -56,22 +42,15 @@ class Mollie_WC_Payment_Payment_Test extends TestCase
          * Expectations
          */
         when('wooCommerceOrderId')
-            ->justReturn(89);
+            ->justReturn($faker->randomNumber(2));
         when('debug')
-            ->justReturn(true);
+            ->justReturn($faker->word);
         when('getDataHelper')
             ->justReturn($dataHelper);
-        $dataHelper
-            ->expects($this->exactly(3))
-            ->method('hasOrderStatus')
-            ->willReturn(true);
 
         /*
          * Execute test
          */
         $testee->onWebhookCanceled($order, $payment, $payment_method_title);
-
     }
-
-
 }

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
@@ -5,6 +5,7 @@ namespace Mollie\WooCommerceTests\Functional\Payment;
 use Mollie\Api\Resources\Payment;
 use Mollie\WooCommerceTests\TestCase;
 use Mollie_WC_Helper_Data;
+use Mollie_WC_Payment_Payment;
 use WC_Order;
 use function Brain\Monkey\Functions\when;
 use Faker;
@@ -36,7 +37,7 @@ class Mollie_WC_Payment_Payment_Test extends TestCase
         * Setup Testee
         */
         $data = 'order';
-        $testee = new \Mollie_WC_Payment_Payment($data);
+        $testee = new Mollie_WC_Payment_Payment($data);
 
         /*
          * Expectations


### PR DESCRIPTION
When onWebhookCanceled is called, we do nothing if order or payment has final status (completed|refunded|canceled), if not we proceed as usual.
Addresses [MOL-63][].

[MOL-63]: https://inpsyde.atlassian.net/browse/MOL-63