### PR TITLE
Rename utils functions to avoid collisions

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -8,7 +8,7 @@ use Mollie\Api\Resources\CurrentProfile;
  *
  * @return bool
  */
-function isCheckoutContext()
+function mollieWooCommerceIsCheckoutContext()
 {
     return is_checkout() || is_checkout_pay_page();
 }
@@ -18,7 +18,7 @@ function isCheckoutContext()
  *
  * @return array
  */
-function mollieComponentsStylesForAvailableGateways()
+function mollieWooCommerceComponentsStylesForAvailableGateways()
 {
     $mollieComponentsStyles = new Mollie_WC_Components_Styles(
         new Mollie_WC_Settings_Components(),
@@ -33,7 +33,7 @@ function mollieComponentsStylesForAvailableGateways()
  *
  * @return bool
  */
-function isTestModeEnabled()
+function mollieWooCommerceIsTestModeEnabled()
 {
     $settingsHelper = Mollie_WC_Plugin::getSettingsHelper();
     $isTestModeEnabled = $settingsHelper->isTestModeEnabled();
@@ -45,12 +45,12 @@ function isTestModeEnabled()
  * @return CurrentProfile
  * @throws ApiException
  */
-function merchantProfile()
+function mollieWooCommerceMerchantProfile()
 {
     static $profile = null;
 
     if ($profile === null) {
-        $isTestMode = isTestModeEnabled();
+        $isTestMode = mollieWooCommerceIsTestModeEnabled();
 
         $apiHelper = Mollie_WC_Plugin::getApiHelper();
         $profile = $apiHelper->getApiClient($isTestMode)->profiles->getCurrent();
@@ -65,7 +65,7 @@ function merchantProfile()
  * @return int|string
  * @throws ApiException
  */
-function merchantProfileId()
+function mollieWooCommerceMerchantProfileId()
 {
     static $merchantProfileId = null;
     $merchantProfileIdOptionKey = Mollie_WC_Plugin::PLUGIN_ID . '_profile_merchant_id';
@@ -79,7 +79,7 @@ function merchantProfileId()
          */
         if (!$merchantProfileId) {
             try {
-                $merchantProfile = merchantProfile();
+                $merchantProfile = mollieWooCommerceMerchantProfile();
                 $merchantProfileId = isset($merchantProfile->id) ? $merchantProfile->id : '';
             } catch (ApiException $exception) {
                 $merchantProfileId = '';
@@ -99,7 +99,7 @@ function merchantProfileId()
  *
  * @return string
  */
-function cardToken()
+function mollieWooCommerceCardToken()
 {
     return $cardToken = filter_input(INPUT_POST, 'cardToken', FILTER_SANITIZE_STRING) ?: '';
 }
@@ -109,9 +109,9 @@ function cardToken()
  *
  * @return array|bool|mixed|\Mollie\Api\Resources\BaseCollection|\Mollie\Api\Resources\MethodCollection
  */
-function availablePaymentMethods()
+function mollieWooCommerceAvailablePaymentMethods()
 {
-    $testMode = isTestModeEnabled();
+    $testMode = mollieWooCommerceIsTestModeEnabled();
     $dataHelper = Mollie_WC_Plugin::getDataHelper();
     $methods = $dataHelper->getApiPaymentMethods($testMode, $use_cache = true);
 
@@ -124,7 +124,7 @@ function availablePaymentMethods()
  * @param  string $message
  * @param bool  $set_debug_header Set X-Mollie-Debug header (default false)
  */
-function debug($message, $set_debug_header = false)
+function mollieWooCommerceDebug($message, $set_debug_header = false)
 {
     Mollie_WC_Plugin::debug($message, $set_debug_header);
 }
@@ -135,7 +135,7 @@ function debug($message, $set_debug_header = false)
  * @param  string $message
  * @param string $type    One of notice, error or success (default notice)
  */
-function notice($message, $type = 'notice')
+function mollieWooCommerceNotice($message, $type = 'notice')
 {
     Mollie_WC_Plugin::addNotice($message, $type);
 }
@@ -144,7 +144,7 @@ function notice($message, $type = 'notice')
  *
  * @return Mollie_WC_Helper_Data
  */
-function getDataHelper()
+function mollieWooCommerceGetDataHelper()
 {
     return Mollie_WC_Plugin::getDataHelper();
 }

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -40,7 +40,7 @@ function mollieWooCommerceSession()
  * @param WC_Order $order
  * @return int
  */
-function wooCommerceOrderId(WC_Order $order)
+function mollieWooCommerceOrderId(WC_Order $order)
 {
     return version_compare(WC_VERSION, '3.0', '<')
         ? $order->id
@@ -52,7 +52,7 @@ function wooCommerceOrderId(WC_Order $order)
  * @param WC_Order $order
  * @return string
  */
-function wooCommerceOrderKey(WC_Order $order)
+function mollieWooCommerceOrderKey(WC_Order $order)
 {
     return version_compare(WC_VERSION, '3.0', '<')
         ? $order->order_key

--- a/src/Mollie/WC/Gateway/Abstract.php
+++ b/src/Mollie/WC/Gateway/Abstract.php
@@ -1247,9 +1247,9 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 	 */
 	public function getReturnRedirectUrlForOrder( WC_Order $order )
     {
-        $order_id = wooCommerceOrderId($order);
+        $order_id = mollieWooCommerceOrderId($order);
         $debugLine = __METHOD__ . " {$order_id}: Determine what the redirect URL in WooCommerce should be.";
-        debug($debugLine);
+        mollieWooCommerceDebug($debugLine);
 
         if ( $this->orderNeedsPayment( $order ) ) {
 
@@ -1287,7 +1287,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
             try {
                 $payment = $this->activePaymentObject($order_id, false);
                 if ( ! $payment->isOpen() && ! $payment->isPending() && ! $payment->isPaid() && ! $payment->isAuthorized() ) {
-                    notice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'));
+                    mollieWooCommerceNotice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'));
                     // Return to order payment page
                     if ( method_exists( $order, 'get_checkout_payment_url' ) ) {
                         return $order->get_checkout_payment_url( false );
@@ -1295,10 +1295,10 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
                 }
                 do_action( Mollie_WC_Plugin::PLUGIN_ID . '_customer_return_payment_success', $order );
             } catch (UnexpectedValueException $exc) {
-                notice( __('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce' ));
+                mollieWooCommerceNotice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce' ));
                 $exceptionMessage = $exc->getMessage();
                 $debugLine = __METHOD__ . " Problem processing the payment. {$exceptionMessage}";
-                debug($debugLine);
+                mollieWooCommerceDebug($debugLine);
                 do_action( Mollie_WC_Plugin::PLUGIN_ID . '_customer_return_payment_failed', $order );
             }
 		}
@@ -1725,8 +1725,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $returnUrl = WC()->api_request_url( 'mollie_return' );
 	    $returnUrl = untrailingslashit($returnUrl);
         $returnUrl = idn_to_ascii($returnUrl);
-        $orderId = wooCommerceOrderId($order);
-        $orderKey = wooCommerceOrderKey($order);
+        $orderId = mollieWooCommerceOrderId($order);
+        $orderKey = mollieWooCommerceOrderKey($order);
         $returnUrl = $this->appendOrderArgumentsToUrl(
             $orderId,
             $orderKey,
@@ -1740,7 +1740,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 		    $langUrlParams = substr( $langUrl, strpos( $langUrl, "/?" ) + 2 );
 		    $returnUrl = $returnUrl . '&' . $langUrlParams;
 	    }
-        debug("{$this->id} : Order {$orderId} returnUrl: {$returnUrl}", true);
+        mollieWooCommerceDebug("{$this->id} : Order {$orderId} returnUrl: {$returnUrl}", true);
         return apply_filters(Mollie_WC_Plugin::PLUGIN_ID . '_return_url', $returnUrl, $order);
     }
 
@@ -1759,8 +1759,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $webhookUrl = WC()->api_request_url(strtolower(get_class($this)));
         $webhookUrl = untrailingslashit($webhookUrl);
         $webhookUrl = idn_to_ascii($webhookUrl);
-        $orderId = wooCommerceOrderId($order);
-        $orderKey = wooCommerceOrderKey($order);
+        $orderId = mollieWooCommerceOrderId($order);
+        $orderKey = mollieWooCommerceOrderKey($order);
         $webhookUrl = $this->appendOrderArgumentsToUrl(
             $orderId,
             $orderKey,
@@ -1781,7 +1781,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         // Some (multilanguage) plugins will add a extra slash to the url (/nl//) causing the URL to redirect and lose it's data.
 	    // Status updates via webhook will therefor not be processed. The below regex will find and remove those double slashes.
 	    $webhookUrl = preg_replace('/([^:])(\/{2,})/', '$1/', $webhookUrl);
-        debug("{$this->id} : Order {$orderId} webhookUrl: {$webhookUrl}", true);
+        mollieWooCommerceDebug("{$this->id} : Order {$orderId} webhookUrl: {$webhookUrl}", true);
 
         return apply_filters(Mollie_WC_Plugin::PLUGIN_ID . '_webhook_url', $webhookUrl, $order);
     }
@@ -2091,7 +2091,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
     {
         static $factory = null;
         if ($factory === null){
-            $paymentMethods = array_filter((array)availablePaymentMethods());
+            $paymentMethods = array_filter((array)mollieWooCommerceAvailablePaymentMethods());
             $paymentMethodsImages = $this->associativePaymentMethodsImages($paymentMethods);
             $factory = new Mollie_WC_Helper_PaymentMethodsIconUrl($paymentMethodsImages);
         }

--- a/src/Mollie/WC/Helper/Settings.php
+++ b/src/Mollie/WC/Helper/Settings.php
@@ -163,7 +163,7 @@ class Mollie_WC_Helper_Settings
         $merchantProfileIdOptionKey = Mollie_WC_Plugin::PLUGIN_ID . '_profile_merchant_id';
 
         try {
-            $merchantProfile = merchantProfile();
+            $merchantProfile = mollieWooCommerceMerchantProfile();
             $merchantProfileId = isset($merchantProfile->id) ? $merchantProfile->id : '';
         } catch (ApiException $exception) {
             $merchantProfileId = '';

--- a/src/Mollie/WC/Payment/Object.php
+++ b/src/Mollie/WC/Payment/Object.php
@@ -652,7 +652,7 @@ class Mollie_WC_Payment_Object {
      */
     protected function isFinalOrderStatus(WC_Order $order)
     {
-        $dataHelper = getDataHelper();
+        $dataHelper = mollieWooCommerceGetDataHelper();
         $orderStatus = $dataHelper->getOrderStatus($order);
         $isFinalOrderStatus = in_array(
             $orderStatus,

--- a/src/Mollie/WC/Payment/Order.php
+++ b/src/Mollie/WC/Payment/Order.php
@@ -184,7 +184,7 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 			$paymentRequestData['payment']['customerId'] = $customer_id;
 		}
 
-        $cardToken = cardToken();
+        $cardToken = mollieWooCommerceCardToken();
         if ($cardToken && isset($paymentRequestData['payment'])) {
             $paymentRequestData['payment']['cardToken'] = $cardToken;
         }
@@ -483,14 +483,14 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
 	public function onWebhookCanceled( WC_Order $order, $payment, $payment_method_title ) {
 
 		// Get order ID in the correct way depending on WooCommerce version
-        $order_id = wooCommerceOrderId($order);
+        $order_id = mollieWooCommerceOrderId($order);
 
 		// Add messages to log
-		debug( __METHOD__ . " called for order {$order_id}" );
+		mollieWooCommerceDebug(__METHOD__ . " called for order {$order_id}" );
 
 		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
         if ($this->isFinalOrderStatus($order)) {
-            debug(
+            mollieWooCommerceDebug(
                 __METHOD__
                 . " called for payment {$order_id} has final status. Nothing to be done"
             );

--- a/src/Mollie/WC/Payment/Payment.php
+++ b/src/Mollie/WC/Payment/Payment.php
@@ -120,7 +120,7 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
 			$paymentRequestData['customerId'] = $customer_id;
 		}
 
-        $cardToken = cardToken();
+        $cardToken = mollieWooCommerceCardToken();
         if ($cardToken) {
             $paymentRequestData['cardToken'] = $cardToken;
         }
@@ -285,14 +285,14 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
 	public function onWebhookCanceled( WC_Order $order, $payment, $payment_method_title ) {
 
 		// Get order ID in the correct way depending on WooCommerce version
-        $order_id = wooCommerceOrderId($order);
+        $order_id = mollieWooCommerceOrderId($order);
 
 		// Add messages to log
-		debug( __METHOD__ . " called for payment {$order_id}" );
+		mollieWooCommerceDebug(__METHOD__ . " called for payment {$order_id}" );
 
 		// if the status is Completed|Refunded|Cancelled  DONT change the status to cancelled
         if ($this->isFinalOrderStatus($order)) {
-            debug(
+            mollieWooCommerceDebug(
                 __METHOD__
                 . " called for payment {$order_id} has final status. Nothing to be done"
             );

--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -361,7 +361,7 @@ class Mollie_WC_Plugin
      */
     public static function enqueueFrontendScripts()
     {
-        if (is_admin() || !isCheckoutContext()) {
+        if (is_admin() || !mollieWooCommerceIsCheckoutContext()) {
             return;
         }
 
@@ -373,17 +373,17 @@ class Mollie_WC_Plugin
      */
     public static function enqueueComponentsAssets()
     {
-        if (is_admin() || !isCheckoutContext()) {
+        if (is_admin() || !mollieWooCommerceIsCheckoutContext()) {
             return;
         }
         
         try {
-            $merchantProfileId = merchantProfileId();
+            $merchantProfileId = mollieWooCommerceMerchantProfileId();
         } catch (ApiException $exception) {
             return;
         }
 
-        $mollieComponentsStylesGateways = mollieComponentsStylesForAvailableGateways();
+        $mollieComponentsStylesGateways = mollieWooCommerceComponentsStylesForAvailableGateways();
         $gatewayNames = array_keys($mollieComponentsStylesGateways);
 
         if (!$merchantProfileId || !$mollieComponentsStylesGateways) {
@@ -402,7 +402,7 @@ class Mollie_WC_Plugin
                 'merchantProfileId' => $merchantProfileId,
                 'options' => [
                     'locale' => $locale,
-                    'testmode' => isTestModeEnabled(),
+                    'testmode' => mollieWooCommerceIsTestModeEnabled(),
                 ],
                 'enabledGateways' => $gatewayNames,
                 'componentsSettings' => $mollieComponentsStylesGateways,
@@ -446,7 +446,7 @@ class Mollie_WC_Plugin
      */
     public static function orderByRequest()
     {
-        $dataHelper = getDataHelper();
+        $dataHelper = mollieWooCommerceGetDataHelper();
 
         $orderId = filter_input(INPUT_GET, 'order_id', FILTER_SANITIZE_NUMBER_INT) ?: null;
         $key = filter_input(INPUT_GET, 'key', FILTER_SANITIZE_STRING) ?: null;
@@ -477,24 +477,24 @@ class Mollie_WC_Plugin
      */
     public static function onMollieReturn ()
     {
-        $dataHelper = getDataHelper();
+        $dataHelper = mollieWooCommerceGetDataHelper();
 
         try {
             $order = self::orderByRequest();
         } catch (RuntimeException $exc) {
             self::setHttpResponseCode($exc->getCode());
-            debug(__METHOD__ . ":  {$exc->getMessage()}");
+            mollieWooCommerceDebug(__METHOD__ . ":  {$exc->getMessage()}");
             return;
         }
 
         $gateway = $dataHelper->getWcPaymentGatewayByOrder($order);
-        $orderId = wooCommerceOrderId($order);
+        $orderId = mollieWooCommerceOrderId($order);
 
         if (!$gateway) {
             $gatewayName = $order->get_payment_method();
 
             self::setHttpResponseCode(404);
-            debug(
+            mollieWooCommerceDebug(
                 __METHOD__ . ":  Could not find gateway {$gatewayName} for order {$orderId}."
             );
             return;
@@ -502,7 +502,7 @@ class Mollie_WC_Plugin
 
         if (!($gateway instanceof Mollie_WC_Gateway_Abstract)) {
             self::setHttpResponseCode(400);
-            debug(__METHOD__ . ": Invalid gateway {get_class($gateway)} for this plugin. Order {$orderId}.");
+            mollieWooCommerceDebug(__METHOD__ . ": Invalid gateway {get_class($gateway)} for this plugin. Order {$orderId}.");
             return;
         }
 
@@ -511,7 +511,7 @@ class Mollie_WC_Plugin
         // Add utm_nooverride query string
         $redirect_url = add_query_arg(['utm_nooverride' => 1], $redirect_url);
 
-        debug(__METHOD__ . ": Redirect url on return order {$gateway->id}, order {$orderId}: {$redirect_url}");
+        mollieWooCommerceDebug(__METHOD__ . ": Redirect url on return order {$gateway->id}, order {$orderId}: {$redirect_url}");
 
         wp_safe_redirect($redirect_url);
     }
@@ -928,7 +928,7 @@ class Mollie_WC_Plugin
 		}
 
 		// Is test mode enabled?
-        $test_mode = isTestModeEnabled();
+        $test_mode = mollieWooCommerceIsTestModeEnabled();
 
 		try {
 			// Get the order from the Mollie API
@@ -1013,7 +1013,7 @@ class Mollie_WC_Plugin
 		}
 
 		// Is test mode enabled?
-        $test_mode = isTestModeEnabled();
+        $test_mode = mollieWooCommerceIsTestModeEnabled();
 
 		try {
 			// Get the order from the Mollie API

--- a/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Functional/WC/Mollie_WC_Plugin_Test.php
@@ -165,7 +165,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         stubs(
             [
                 'is_admin' => false,
-                'isCheckoutContext' => true,
+                'mollieWooCommerceIsCheckoutContext' => true,
             ]
         );
 
@@ -198,7 +198,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         stubs(
             [
                 'is_admin' => $isAdmin,
-                'isCheckoutContext' => $isCheckoutContext,
+                'mollieWooCommerceIsCheckoutContext' => $isCheckoutContext,
             ]
         );
 
@@ -214,12 +214,12 @@ class Mollie_WC_Plugin_Test extends TestCase
     {
         stubs(
             [
-                'merchantProfileId' => uniqid(),
-                'mollieComponentsStylesForAvailableGateways' => [uniqid()],
+                'mollieWooCommerceMerchantProfileId' => uniqid(),
+                'mollieWooCommerceComponentsStylesForAvailableGateways' => [uniqid()],
                 'is_admin' => false,
-                'isCheckoutContext' => true,
+                'mollieWooCommerceIsCheckoutContext' => true,
                 'get_locale' => uniqid(),
-                'isTestModeEnabled' => true,
+                'mollieWooCommerceIsTestModeEnabled' => true,
                 'esc_html__' => '',
                 'is_checkout' => true,
                 'is_checkout_pay_page' => false,
@@ -310,11 +310,11 @@ class Mollie_WC_Plugin_Test extends TestCase
         /*
         * Expectations
         */
-        expect('getDataHelper')
+        expect('mollieWooCommerceGetDataHelper')
             ->andReturn($dataHelper);
         when('wc_get_order_id_by_order_key')
             ->justReturn($id);
-        when('wooCommerceOrderId')
+        when('mollieWooCommerceOrderId')
             ->justReturn($id);
         $gateway
             ->expects($this->once())
@@ -327,7 +327,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         expect('wp_safe_redirect')
             ->once()
             ->andReturn(true);
-        when('debug')
+        when('mollieWooCommerceDebug')
             ->justReturn(true);
 
         /*

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Order_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Order_Test.php
@@ -50,9 +50,9 @@ class Mollie_WC_Payment_Order_Test extends TestCase
         /*
          * Expectations
          */
-        when('wooCommerceOrderId')
+        when('mollieWooCommerceOrderId')
             ->justReturn($faker->randomNumber(2));
-        when('debug')
+        when('mollieWooCommerceDebug')
             ->justReturn($faker->word);
         when('getDataHelper')
             ->justReturn($dataHelper);

--- a/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
+++ b/tests/php/Functional/WC/Payment/Mollie_WC_Payment_Payment_Test.php
@@ -42,9 +42,9 @@ class Mollie_WC_Payment_Payment_Test extends TestCase
         /*
          * Expectations
          */
-        when('wooCommerceOrderId')
+        when('mollieWooCommerceOrderId')
             ->justReturn($faker->randomNumber(2));
-        when('debug')
+        when('mollieWooCommerceDebug')
             ->justReturn($faker->word);
         when('getDataHelper')
             ->justReturn($dataHelper);

--- a/tests/php/Functional/inc/Functions_Test.php
+++ b/tests/php/Functional/inc/Functions_Test.php
@@ -24,7 +24,7 @@ class Functions_Test extends TestCase
         /*
          * Execute Test
          */
-        $result = isCheckoutContext();
+        $result = mollieWooCommerceIsCheckoutContext();
 
         self::assertEquals($expected, $result);
     }
@@ -82,7 +82,7 @@ class Functions_Test extends TestCase
         /*
          * Execute Testee
          */
-        $result = wooCommerceOrderId($order);
+        $result = mollieWooCommerceOrderId($order);
         self::assertEquals($orderId, $result);
     }
 
@@ -102,7 +102,7 @@ class Functions_Test extends TestCase
         /*
          * Execute Testee
          */
-        $result = wooCommerceOrderId($order);
+        $result = mollieWooCommerceOrderId($order);
 
         self::assertEquals($orderId, $result);
     }
@@ -128,7 +128,7 @@ class Functions_Test extends TestCase
         /*
          * Execute Testee
          */
-        $result = wooCommerceOrderKey($order);
+        $result = mollieWooCommerceOrderKey($order);
         self::assertEquals($orderKey, $result);
     }
 
@@ -148,7 +148,7 @@ class Functions_Test extends TestCase
         /*
          * Execute Testee
          */
-        $result = wooCommerceOrderKey($order);
+        $result = mollieWooCommerceOrderKey($order);
 
         self::assertEquals($orderKey, $result);
     }

--- a/tests/php/Unit/WC/Gateway/Mollie_WC_Gateway_AbstractTest.php
+++ b/tests/php/Unit/WC/Gateway/Mollie_WC_Gateway_AbstractTest.php
@@ -58,7 +58,7 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
         /*
         * Expect to call availablePaymentMethods() function and return a mock of one method with id 'ideal'
         */
-        expect('availablePaymentMethods')
+        expect('mollieWooCommerceAvailablePaymentMethods')
             ->once()
             ->withNoArgs()
             ->andReturn($methods);
@@ -101,7 +101,7 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
         /*
         * Expect to call availablePaymentMethods() function and return false from the API
         */
-        expect('availablePaymentMethods')
+        expect('mollieWooCommerceAvailablePaymentMethods')
             ->once()
             ->withNoArgs()
             ->andReturn(false);
@@ -260,9 +260,9 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
         expect('idn_to_ascii')
             ->andReturn($varStubs->untrailedUrl);
         //get order id and key and append to the the url
-        expect('wooCommerceOrderId')
+        expect('mollieWooCommerceOrderId')
             ->andReturn($varStubs->orderId);
-        expect('wooCommerceOrderKey')
+        expect('mollieWooCommerceOrderKey')
             ->andReturn($varStubs->orderKey);
         $testee
             ->expects($this->once())
@@ -276,7 +276,7 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
             ->method('getSiteUrlWithLanguage')
             ->willReturn("{$varStubs->apiRequestUrl}/nl");
 
-        expect('debug')
+        expect('mollieWooCommerceDebug')
             ->withAnyArgs();
 
         /*
@@ -330,9 +330,9 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
         expect('idn_to_ascii')
             ->andReturn($varStubs->untrailedUrl);
         //get order id and key and append to the the url
-        expect('wooCommerceOrderId')
+        expect('mollieWooCommerceOrderId')
             ->andReturn($varStubs->orderId);
-        expect('wooCommerceOrderKey')
+        expect('mollieWooCommerceOrderKey')
             ->andReturn($varStubs->orderKey);
         $testee
             ->expects($this->once())
@@ -344,7 +344,7 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
             ->expects($this->once())
             ->method('getSiteUrlWithLanguage')
             ->willReturn("{$varStubs->homeUrl}/nl");
-        expect('debug')
+        expect('mollieWooCommerceDebug')
             ->withAnyArgs();
 
         /*
@@ -361,7 +361,7 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function testPolylangTestee()
+    public function testPolylangTestee()
     {
         $testee = $this
             ->buildTesteeMock(
@@ -377,7 +377,7 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
     /**
      * @return array
      */
-    protected function testPolylangVariables()
+    public function testPolylangVariables()
     {
         $orderId = $this->faker->randomDigit;
         $orderKey = $this->faker->word;

--- a/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
@@ -303,7 +303,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         $order = $this->mockOrder();
 
         //functions called
-        expect('getDataHelper')
+        expect('mollieWooCommerceGetDataHelper')
             ->andReturn($dataHelper);
 
         $dataHelper
@@ -338,7 +338,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         $key = $faker->word;
 
         //functions called
-        expect('getDataHelper')
+        expect('mollieWooCommerceGetDataHelper')
             ->andReturn($dataHelper);
         when('wc_get_order_id_by_order_key')
             ->justReturn($key);
@@ -387,7 +387,7 @@ class Mollie_WC_Plugin_Test extends TestCase
         }
 
         //functions called
-        expect('getDataHelper')
+        expect('mollieWooCommerceGetDataHelper')
             ->andReturn($dataHelper);
         when('wc_get_order_id_by_order_key')
             ->justReturn($key);


### PR DESCRIPTION
Rename of the inc/utils and inc/woocommerce
functions to avoid collisions with other functions
Tests are changed accordingly
Addresses [MOL-102][].

[MOL-102]: https://inpsyde.atlassian.net/browse/MOL-102
