### PR TITLE
Tweaked the hook placement to run in every scenario

### DIFF
--- a/src/Mollie/WC/Gateway/Abstract.php
+++ b/src/Mollie/WC/Gateway/Abstract.php
@@ -1301,7 +1301,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
                 do_action( Mollie_WC_Plugin::PLUGIN_ID . '_customer_return_payment_failed', $order );
             }
 		}
-
+        do_action( Mollie_WC_Plugin::PLUGIN_ID . '_customer_return_payment_success', $order );
 		/*
 		 * Return to order received page
 		 */


### PR DESCRIPTION
Resolves #347 

Here is the PR in response to change we suggested to be rolled back in order to make Upstroke  One-click upsells WooCommerrce addon compatible with Mollie addon. 

Please check #347 for details info about the main issue. 