### PR TITLE
Optimize transients

### DIFF
--- a/src/Mollie/WC/Helper/Data.php
+++ b/src/Mollie/WC/Helper/Data.php
@@ -318,18 +318,15 @@ class Mollie_WC_Helper_Data
 
 		try {
 
-			$transient_id = Mollie_WC_Plugin::getDataHelper()->getTransientId( md5(http_build_query($filters_key))  );
+			$transient_id = Mollie_WC_Plugin::getDataHelper()->getTransientId( http_build_query($filters).$filters_key['api'].$filters_key['mode'] );
 
 			if ($use_cache) {
 				// When no cache exists $methods will be `false`
-				$methods = unserialize( get_transient( $transient_id ) );
+				$methods =  get_transient( $transient_id );
 			}
 
 			// No cache exists, call the API and cache the result
 			if ( $methods === false ) {
-
-				// Remove existing expired transients
-				delete_transient( $transient_id );
 
 				$filters['resource'] = 'orders';
 				$filters['includeWallets'] = 'applepay';
@@ -347,12 +344,9 @@ class Mollie_WC_Helper_Data
 				$methods = $methods_cleaned;
 
 				// Set new transients (as cache)
-				try {
-					set_transient( $transient_id, serialize( $methods ), MINUTE_IN_SECONDS * 5 );
-				}
-				catch ( Exception $e ) {
-					Mollie_WC_Plugin::debug( __FUNCTION__ . ": No caching because serialization failed." );
-				}
+                if($use_cache){
+                    set_transient( $transient_id, $methods, HOUR_IN_SECONDS );
+                }
 			}
 
 			return $methods;
@@ -400,27 +394,18 @@ class Mollie_WC_Helper_Data
 			$transient_id = Mollie_WC_Plugin::getDataHelper()->getTransientId( $method . '_issuers_' . ( $test_mode ? 'test' : 'live' ) );
 
 			// When no cache exists $cached_issuers will be `false`
-			$issuers = unserialize( get_transient( $transient_id ) );
+			$issuers = get_transient( $transient_id );
 
 			if ( $issuers === false ) {
-
-				// Remove existing expired transients
-				delete_transient( $transient_id );
 
 				$method  = $this->api_helper->getApiClient( $test_mode )->methods->get( "$method", array ( "include" => "issuers" ) );
 				$issuers = $method->issuers;
 
 				// Set new transients (as cache)
-				try {
-					set_transient( $transient_id, serialize( $issuers ), MINUTE_IN_SECONDS * 5 );
-				}
-				catch ( Exception $e ) {
-					Mollie_WC_Plugin::debug( __FUNCTION__ . ": No caching because serialization failed." );
-				}
+                set_transient( $transient_id, $issuers, HOUR_IN_SECONDS );
 			}
 
 			return $issuers;
-
 		}
 		catch ( \Mollie\Api\Exceptions\ApiException $e ) {
 			Mollie_WC_Plugin::debug( __FUNCTION__ . ": Could not load " . $method . " issuers (" . ( $test_mode ? 'test' : 'live' ) . "): " . $e->getMessage() . ' (' . get_class( $e ) . ')' );

--- a/src/Mollie/WC/Helper/Data.php
+++ b/src/Mollie/WC/Helper/Data.php
@@ -318,7 +318,7 @@ class Mollie_WC_Helper_Data
 
 		try {
 
-			$transient_id = Mollie_WC_Plugin::getDataHelper()->getTransientId( http_build_query($filters).$filters_key['api'].$filters_key['mode'] );
+			$transient_id = Mollie_WC_Plugin::getDataHelper()->getTransientId( md5(http_build_query($filters_key)));
 
 			if ($use_cache) {
 				// When no cache exists $methods will be `false`


### PR DESCRIPTION
Addresses [MOL-128][].
Name built directly from filters, no hash needed,
so we can find them easily afterwards.
No need to unserialize, get_transient already does
the job.
Set_transient overrides the existent one, so no
need to delete it manually.
No need to serialize the set_transient parameter
so the try/catch is useless.
Transient expiration increased to one hour

[MOL-128]: https://inpsyde.atlassian.net/browse/MOL-128