### PR TITLE
Add check to order-pay page

### DIFF
--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -629,7 +629,7 @@ class Mollie_WC_Plugin
         if ($isWcApiRequest ||
             !$wooCommerceSession instanceof WC_Session ||
             !doing_action('woocommerce_payment_gateways') ||
-            !wp_doing_ajax() ||
+            !wp_doing_ajax() && ! is_wc_endpoint_url( 'order-pay' )||
             is_admin()
         ) {
             return $gateways;

--- a/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
+++ b/tests/php/Unit/WC/Mollie_WC_Plugin_Test.php
@@ -204,6 +204,9 @@ class Mollie_WC_Plugin_Test extends TestCase
         expect('wp_doing_ajax')
             ->once()
             ->andReturn(false);
+        expect('is_wc_endpoint_url')
+            ->once()
+            ->andReturn(false);
 
         /*
          * Execute Test


### PR DESCRIPTION
Addresses [MOL-138][].
We can't show apple pay on order-pay if is not a
 suitable device, so we need to filter it as we
 do on checkout

[MOL-138]: https://inpsyde.atlassian.net/browse/MOL-138