### PR TITLE
Fixes #356, correctly refunds amount > 1000

### DIFF
--- a/src/Mollie/WC/Payment/Order.php
+++ b/src/Mollie/WC/Payment/Order.php
@@ -788,10 +788,10 @@ class Mollie_WC_Payment_Order extends Mollie_WC_Payment_Object {
                 $totals += $item_data->get_total() + $item_data->get_total_tax();
             }
 
-            $totals = number_format(abs($totals), 2); // WooCommerce - sum of all refund items
-            $amount = number_format($amount, 2); // WooCommerce - refund amount
+            $totals       = number_format(abs($totals), 2); // WooCommerce - sum of all refund items
+            $check_amount = number_format($amount, 2); // WooCommerce - refund amount
 
-            if ($amount !== $totals) {
+            if ($check_amount !== $totals) {
                 $error_message = "The sum of refunds for all order lines is not identical to the refund amount, so this refund will be processed as a payment amount refund, not an order line refund.";
                 $order->add_order_note($error_message);
                 Mollie_WC_Plugin::debug(__METHOD__ . ' - ' . $error_message);


### PR DESCRIPTION
Instead of overwriting the `$amount` value, this allows for the check to happen without editing the variable, so later on in processing the refund it is not incorrectly put through `number_format()` a second time.