### PR TITLE
Use mollieWooCommerceStringToBoolOption instead of wc_string_to_bool

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -155,7 +155,7 @@ function mollieWooCommerceGetDataHelper()
 function mollieWooCommerceisApplePayDirectEnabled()
 {
     $applePaySettings = get_option('mollie_wc_gateway_applepay_settings');
-    return wc_string_to_bool(
+    return mollieWooCommerceStringToBoolOption(
         checkIndexExistOrDefault($applePaySettings, 'mollie_apple_pay_button_enabled', 'no')
     );
 }

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -58,21 +58,9 @@ function mollieWooCommerceOrderKey(WC_Order $order)
         ? $order->order_key
         : $order->get_order_key();
 }
-if (!function_exists('wc_string_to_bool'))
-{
-    /**
-     * Converts a string (e.g. 'yes' or 'no') to a bool.
-     *
-     * @since 3.0.0
-     * @param string $string String to convert.
-     * @return bool
-     */
-    function wc_string_to_bool( $string ) {
-        return is_bool( $string ) ? $string : ( 'yes' === strtolower( $string ) || 1 === $string || 'true' === strtolower( $string ) || '1' === $string );
-    }
-}
+
 /**
- * Mimics wc_string_to_bool
+ * Mimics wc_string_to_bool. Converts a string (e.g. 'yes' or 'no') to a bool.
  * @param $string
  *
  * @return bool

--- a/src/Mollie/WC/Components/Styles.php
+++ b/src/Mollie/WC/Components/Styles.php
@@ -62,7 +62,7 @@ class Mollie_WC_Components_Styles
 
         /** @var WC_Payment_Gateway $gateway */
         foreach ($gateways as $gateway) {
-            $isGatewayEnabled = wc_string_to_bool($gateway->enabled);
+            $isGatewayEnabled = mollieWooCommerceStringToBoolOption($gateway->enabled);
             if ($isGatewayEnabled && $this->isMollieComponentsEnabledForGateway($gateway)) {
                 $gatewaysWithMollieComponentsEnabled[] = $gateway;
             }
@@ -83,7 +83,7 @@ class Mollie_WC_Components_Styles
             return false;
         }
 
-        return wc_string_to_bool($gateway->settings['mollie_components_enabled']);
+        return mollieWooCommerceStringToBoolOption($gateway->settings['mollie_components_enabled']);
     }
 
     /**

--- a/src/Mollie/WC/Gateway/Abstract.php
+++ b/src/Mollie/WC/Gateway/Abstract.php
@@ -2207,7 +2207,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
             ? $this->settings['mollie_components_enabled']
             : 'no';
 
-        $option = wc_string_to_bool($option);
+        $option = mollieWooCommerceStringToBoolOption($option);
 
         return $option;
     }

--- a/src/Mollie/WC/Gateway/Creditcard.php
+++ b/src/Mollie/WC/Gateway/Creditcard.php
@@ -130,7 +130,7 @@ class Mollie_WC_Gateway_Creditcard extends Mollie_WC_Gateway_AbstractSubscriptio
         $iconEnabledOption = Mollie_WC_Helper_PaymentMethodsIconUrl::MOLLIE_CREDITCARD_ICONS_ENABLER;
         $creditCardSettings = get_option('mollie_wc_gateway_creditcard_settings', false) ?: [];
         $enabled = isset($creditCardSettings[$iconEnabledOption])
-            ? wc_string_to_bool($creditCardSettings[$iconEnabledOption])
+            ? mollieWooCommerceStringToBoolOption($creditCardSettings[$iconEnabledOption])
             : false;
 
         if (!$enabled) {
@@ -141,7 +141,7 @@ class Mollie_WC_Gateway_Creditcard extends Mollie_WC_Gateway_AbstractSubscriptio
 
         $creditcardSettings = get_option('mollie_wc_gateway_creditcard_settings', []) ?: [];
         foreach ($creditcardsAvailable as $card) {
-            if (wc_string_to_bool($creditcardSettings[$optionLexem . $card])) {
+            if (mollieWooCommerceStringToBoolOption($creditcardSettings[$optionLexem . $card])) {
                 $enabledCreditcards[] = $card . $svgFileName;
             }
         }

--- a/tests/php/Stubs/woocommerce.php
+++ b/tests/php/Stubs/woocommerce.php
@@ -1,27 +1,5 @@
 <?php
 
-function wc_string_to_bool($string)
-{
-    return is_bool($string) ? $string : ('yes' === strtolower(
-            $string
-        ) || 1 === $string || 'true' === strtolower($string) || '1' === $string);
-}
-
-/**
- * Converts a bool to a 'yes' or 'no'.
- *
- * @param bool $bool String to convert.
- * @return string
- * @since 3.0.0
- */
-function wc_bool_to_string($bool)
-{
-    if (!is_bool($bool)) {
-        $bool = wc_string_to_bool($bool);
-    }
-    return true === $bool ? 'yes' : 'no';
-}
-
 class WooCommerce
 {
     public $cart = null;


### PR DESCRIPTION
Fixes Fatal error: Cannot redeclare wc_string_to_bool() (previously declared in /var/web/site/public_html/wp-content/plugins/mollie-payments-for-woocommerce/inc/woocommerce.php:70) in /var/web/site/public_html/wp-content/plugins/woocommerce/includes/wc-formatting-functions.php on line 22