### PR TITLE
Fix 'no category' and set default option

### DIFF
--- a/src/Mollie/WC/Gateway/Mealvoucher.php
+++ b/src/Mollie/WC/Gateway/Mealvoucher.php
@@ -35,11 +35,12 @@ class Mollie_WC_Gateway_Mealvoucher extends Mollie_WC_Gateway_Abstract
 				'title'       => __('Select the default products category', 'mollie-payments-for-woocommerce'),
                 'type'        => 'select',
                 'options'     => array(
+                    self::NO_CATEGORY => $this->categoryName(self::NO_CATEGORY),
                     self::MEAL => $this->categoryName(self::MEAL),
                     self::ECO => $this->categoryName(self::ECO),
                     self::GIFTS => $this->categoryName(self::GIFTS)
                 ),
-                'default'     => self::MEAL,
+                'default'     => self::NO_CATEGORY,
                 /* translators: Placeholder 1: Default order status, placeholder 2: Link to 'Hold Stock' setting */
                 'description' => sprintf(
                     __('In order to process it, all products in the order must have a category. This selector will assign the default category for the shop products', 'mollie-payments-for-woocommerce')

--- a/src/Mollie/WC/Helper/OrderLines.php
+++ b/src/Mollie/WC/Helper/OrderLines.php
@@ -76,7 +76,7 @@ class Mollie_WC_Helper_OrderLines {
 	 */
 	private function process_items() {
         $mealvoucherSettings = get_option('mollie_wc_gateway_mealvoucher_settings');
-	    $isMealVoucherEnabled = $mealvoucherSettings? ($mealvoucherSettings['enabled'] == 'yes'): false;
+	    $isMealVoucherEnabled = $mealvoucherSettings? ($mealvoucherSettings['enabled'] == 'yes'): true;
 		foreach ( $this->order->get_items() as $cart_item ) {
 
 			if ( $cart_item['quantity'] ) {
@@ -121,9 +121,11 @@ class Mollie_WC_Helper_OrderLines {
 				);
 
                 if ($isMealVoucherEnabled) {
-                    $mollie_order_item['category'] = $this->get_item_category(
-                        $product
-                    );
+					if ($this->get_item_category($product) <> "no_category"){
+						$mollie_order_item['category'] = $this->get_item_category(
+							$product
+						);
+					}
                 }
 				$this->order_lines[] = $mollie_order_item;
 

--- a/src/Mollie/WC/Plugin.php
+++ b/src/Mollie/WC/Plugin.php
@@ -323,12 +323,13 @@ class Mollie_WC_Plugin
 
                         'type' => 'select',
                         'options' => array(
+                                Mollie_WC_Gateway_Mealvoucher::NO_CATEGORY => 'No category',
                                 Mollie_WC_Gateway_Mealvoucher::MEAL => 'Meal',
                                 Mollie_WC_Gateway_Mealvoucher::ECO => 'Eco',
-                                Mollie_WC_Gateway_Mealvoucher::GIFTS => 'Gifts',
-                                Mollie_WC_Gateway_Mealvoucher::NO_CATEGORY => 'No category'
+                                Mollie_WC_Gateway_Mealvoucher::GIFTS => 'Gifts'
+                                
                         ),
-                        'default' => Mollie_WC_Gateway_Mealvoucher::MEAL,
+                        'default' => Mollie_WC_Gateway_Mealvoucher::NO_CATEGORY,
                     /* translators: Placeholder 1: Default order status, placeholder 2: Link to 'Hold Stock' setting */
                         'description' => sprintf(
                                 __(


### PR DESCRIPTION
- Payments with no vouchers were not created due to 'no_category' being passed. Replaced with null
- Set default option in dropdowns to 'no category' instead of meal.