### PR TITLE
Rename autoload() function to avoid collisions

### DIFF
--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -35,7 +35,7 @@ function mollie_wc_plugin_activation_hook()
     require_once __DIR__ . '/inc/functions.php';
     require_once __DIR__ . '/src/subscriptions_status_check_functions.php';
 
-    if (!autoload()) {
+    if (!mollie_wc_plugin_autoload()) {
         return;
     }
 
@@ -193,7 +193,7 @@ function mollie_wc_plugin_inactive()
     }
 }
 
-function autoload()
+function mollie_wc_plugin_autoload()
 {
     $autoloader = __DIR__ . '/vendor/autoload.php';
     if (file_exists($autoloader)) {
@@ -212,7 +212,7 @@ $bootstrap = Closure::bind(
                 require_once __DIR__ . '/inc/functions.php';
                 require_once __DIR__ . '/src/subscriptions_status_check_functions.php';
 
-                if (!autoload()) {
+                if (!mollie_wc_plugin_autoload()) {
                     return;
                 }
 


### PR DESCRIPTION
Addresses MOL-214

Just add a prefix to the `autoload()` function in the global namespace to avoid collisions and merge with the current `develop` branch.