### PR TITLE
Add support for WooCommerce Gift Cards

### DIFF
--- a/src/Mollie/WC/Helper/OrderLines.php
+++ b/src/Mollie/WC/Helper/OrderLines.php
@@ -53,6 +53,7 @@ class Mollie_WC_Helper_OrderLines {
 		$this->process_items();
 		$this->process_shipping();
 		$this->process_fees();
+		$this->process_gift_cards();
 
 		return array (
 			'lines' => $this->get_order_lines(),
@@ -218,6 +219,37 @@ class Mollie_WC_Helper_OrderLines {
 				$this->order_lines[] = $fee;
 			} // End foreach().
 		} // End if().
+	}
+
+	/**
+	 * Process Gift Cards
+	 *
+	 * @access private
+	*/
+	private function process_gift_cards() {
+		if (!empty($this->order->get_items('gift_card'))) {
+			foreach ($this->order->get_items('gift_card') as $cart_gift_card) {
+				$gift_card = array(
+					'type' => 'gift_card',
+					'name' => $cart_gift_card->get_name(),
+					'unitPrice' => array(
+						'currency' => $this->currency,
+						'value' =>  Mollie_WC_Plugin::getDataHelper()->formatCurrencyValue(-$cart_gift_card->get_amount(), $this->currency)
+					),
+					'vatRate' => 0,
+					'quantity' => 1,
+					'totalAmount' => array(
+						'currency' => $this->currency,
+						'value' =>  Mollie_WC_Plugin::getDataHelper()->formatCurrencyValue(-$cart_gift_card->get_amount(), $this->currency)
+					),
+					'vatAmount' => array(
+						'currency' => $this->currency,
+						'value' => Mollie_WC_Plugin::getDataHelper()->formatCurrencyValue(0, $this->currency)
+					)
+				);
+				$this->order_lines[] = $gift_card;
+			}
+		}
 	}
 
 	// Helpers.


### PR DESCRIPTION
This PR adds support for adding line items to an order representing gift cards (See https://woocommerce.com/products/gift-cards/)
