### PR TITLE
MOLL-125

### DIFF
--- a/src/Mollie/WC/Helper/MaybeDisableGateway.php
+++ b/src/Mollie/WC/Helper/MaybeDisableGateway.php
@@ -63,7 +63,12 @@ class Mollie_WC_Helper_MaybeDisableGateway
         $mealvoucherSettings = get_option(
             'mollie_wc_gateway_mealvoucher_settings'
         );
-        $defaultCategory = $mealvoucherSettings['mealvoucher_category_default'];
+        //Check if mealvoucherSettings is an array as to prevent notice from being thrown for PHP 7.4 and up.
+        if (is_array($mealvoucherSettings)) {
+            $defaultCategory = $mealvoucherSettings['mealvoucher_category_default'];
+        } else {
+            $defaultCategory = false;
+        }
         $numberOfProducts = 0;
         $productsWithCategory = 0;
         foreach ($products as $product) {


### PR DESCRIPTION
Add check if $mealvoucherSettings is an array as to prevent PHP 7.4 and up from throwing notice like:
Trying to access array offset on value of type bool in <somethingsomething>/wp-content/plugins/mollie-payments-for-woocommerce/src/Mollie/WC/Helper/MaybeDisableGateway.php on line 66