### PR TITLE
Add allowed_countries option for gateways

### DIFF
--- a/src/Mollie/WC/Gateway/Abstract.php
+++ b/src/Mollie/WC/Gateway/Abstract.php
@@ -124,6 +124,13 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
                 'default'     => $this->getDefaultDescription(),
                 'desc_tip'    => true,
             ),
+            'allowed_countries' =>    array(
+                 'title'   => __( 'Sell to specific countries', 'woocommerce' ),
+                 'desc'    => '',
+                 'css'     => 'min-width: 350px;',
+                 'default' => [],
+                 'type'    => 'multi_select_countries',
+            ),
         );
 
         if ($this->paymentConfirmationAfterCoupleOfDays())
@@ -179,19 +186,84 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $this->description = $description;
     }
 
-    public function admin_options ()
+    public function admin_options()
     {
-        if (!$this->enabled && count($this->errors))
-        {
+        if (!$this->enabled && count($this->errors)) {
             echo '<div class="inline error"><p><strong>' . __('Gateway Disabled', 'mollie-payments-for-woocommerce') . '</strong>: '
-                . implode('<br/>', $this->errors)
-                . '</p></div>';
+                    . implode('<br/>', $this->errors)
+                    . '</p></div>';
 
             return;
         }
 
-        parent::admin_options();
+        $html = '';
+        foreach ($this->get_form_fields() as $k => $v) {
+            $type = $this->get_field_type($v);
+
+            if ($type === 'multi_select_countries') {
+                $html .= $this->multiSelectCountry();
+            } else {
+                if (method_exists($this, 'generate_' . $type . '_html')) {
+                    $html .= $this->{'generate_' . $type . '_html'}($k, $v);
+                } else {
+                    $html .= $this->generate_text_html($k, $v);
+                }
+            }
+        }
+
+        echo '<h2>' . esc_html($this->get_method_title());
+        wc_back_link(__('Return to payments', 'woocommerce'), admin_url('admin.php?page=wc-settings&tab=checkout'));
+        echo '</h2>';
+        echo wp_kses_post(wpautop($this->get_method_description()));
+        echo '<table class="form-table">'
+                .
+                $html
+                .
+                '</table>';
     }
+
+    public function multiSelectCountry()
+    {
+
+        $selections = (array)$this->get_option('allowed_countries', []);
+        $gatewayId = $this->getMollieMethodId();
+        $id = 'mollie_wc_gateway_'.$gatewayId.'_allowed_countries';
+        $title = __('Sell to specific countries', 'woocommerce');
+        $description = '<span class="description">' . wp_kses_post($this->get_option('description', '')) . '</span>';
+        $countries = WC()->countries->countries;
+        asort($countries);
+        ob_start();
+        ?>
+        <tr valign="top">
+            <th scope="row" class="titledesc">
+                <label for="<?php echo esc_attr($id); ?>"><?php echo esc_html($title); ?> </label>
+            </th>
+            <td class="forminp">
+                <select multiple="multiple" name="<?php echo esc_attr($id); ?>[]" style="width:350px"
+                        data-placeholder="<?php esc_attr_e('Choose countries&hellip;', 'woocommerce'); ?>"
+                        aria-label="<?php esc_attr_e('Country', 'woocommerce'); ?>" class="wc-enhanced-select">
+                    <?php
+                    if (!empty($countries)) {
+                        foreach ($countries as $key => $val) {
+                            echo '<option value="' . esc_attr($key) . '"' . wc_selected($key, $selections) . '>' . esc_html($val) . '</option>';
+                        }
+                    }
+                    ?>
+                </select> <?php echo ($description) ? $description : ''; ?> <br/><a class="select_all button"
+                                                                                    href="#"><?php esc_html_e('Select all', 'woocommerce'); ?></a>
+                <a class="select_none button" href="#"><?php esc_html_e('Select none', 'woocommerce'); ?></a>
+            </td>
+        </tr>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    public function validate_multi_select_countries_field($key, $value)
+    {
+        return is_array($value) ? array_map('wc_clean', array_map('stripslashes', $value)) : '';
+    }
+
 
     /**
      * Check if this gateway can be used
@@ -323,7 +395,12 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
 
             // For regular payments, check available payment methods, but ignore SSD gateway (not shown in checkout)
             $status = ($this->id !== 'mollie_wc_gateway_directdebit') ? $this->isAvailableMethodInCheckout($filters) : false;
-
+            $allowedCountries = $this->get_option('allowed_countries', []);
+            //if no country is selected then this does not apply
+            $bCountryIsAllowed = empty($allowedCountries) ? true : in_array($billing_country, $allowedCountries);
+            if (!$bCountryIsAllowed) {
+                $status = false;
+            }
             // Do extra checks if WooCommerce Subscriptions is installed
             if (class_exists('WC_Subscriptions') && class_exists('WC_Subscriptions_Admin')) {
 

--- a/src/Mollie/WC/Gateway/Abstract.php
+++ b/src/Mollie/WC/Gateway/Abstract.php
@@ -125,7 +125,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
                 'desc_tip'    => true,
             ),
             'allowed_countries' =>    array(
-                 'title'   => __( 'Sell to specific countries', 'woocommerce' ),
+                 'title'   => __( 'Sell to specific countries', 'mollie-payments-for-woocommerce' ),
                  'desc'    => '',
                  'css'     => 'min-width: 350px;',
                  'default' => [],
@@ -212,7 +212,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         }
 
         echo '<h2>' . esc_html($this->get_method_title());
-        wc_back_link(__('Return to payments', 'woocommerce'), admin_url('admin.php?page=wc-settings&tab=checkout'));
+        wc_back_link(__('Return to payments', 'mollie-payments-for-woocommerce'), admin_url('admin.php?page=wc-settings&tab=checkout'));
         echo '</h2>';
         echo wp_kses_post(wpautop($this->get_method_description()));
         echo '<table class="form-table">'
@@ -228,7 +228,7 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         $selections = (array)$this->get_option('allowed_countries', []);
         $gatewayId = $this->getMollieMethodId();
         $id = 'mollie_wc_gateway_'.$gatewayId.'_allowed_countries';
-        $title = __('Sell to specific countries', 'woocommerce');
+        $title = __('Sell to specific countries', 'mollie-payments-for-woocommerce');
         $description = '<span class="description">' . wp_kses_post($this->get_option('description', '')) . '</span>';
         $countries = WC()->countries->countries;
         asort($countries);
@@ -240,8 +240,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
             </th>
             <td class="forminp">
                 <select multiple="multiple" name="<?php echo esc_attr($id); ?>[]" style="width:350px"
-                        data-placeholder="<?php esc_attr_e('Choose countries&hellip;', 'woocommerce'); ?>"
-                        aria-label="<?php esc_attr_e('Country', 'woocommerce'); ?>" class="wc-enhanced-select">
+                        data-placeholder="<?php esc_attr_e('Choose countries&hellip;', 'mollie-payments-for-woocommerce'); ?>"
+                        aria-label="<?php esc_attr_e('Country', 'mollie-payments-for-woocommerce'); ?>" class="wc-enhanced-select">
                     <?php
                     if (!empty($countries)) {
                         foreach ($countries as $key => $val) {
@@ -250,8 +250,8 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
                     }
                     ?>
                 </select> <?php echo ($description) ? $description : ''; ?> <br/><a class="select_all button"
-                                                                                    href="#"><?php esc_html_e('Select all', 'woocommerce'); ?></a>
-                <a class="select_none button" href="#"><?php esc_html_e('Select none', 'woocommerce'); ?></a>
+                                                                                    href="#"><?php esc_html_e('Select all', 'mollie-payments-for-woocommerce'); ?></a>
+                <a class="select_none button" href="#"><?php esc_html_e('Select none', 'mollie-payments-for-woocommerce'); ?></a>
             </td>
         </tr>
         <?php
@@ -259,6 +259,14 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         return ob_get_clean();
     }
 
+    /**
+     * Validates the multiselect country field.
+     * Overrides the one called by get_field_value() on WooCommerce abstract-wc-settings-api.php
+     *
+     * @param $key
+     * @param $value
+     * @return array|string
+     */
     public function validate_multi_select_countries_field($key, $value)
     {
         return is_array($value) ? array_map('wc_clean', array_map('stripslashes', $value)) : '';

--- a/tests/php/Stubs/woocommerce.php
+++ b/tests/php/Stubs/woocommerce.php
@@ -58,6 +58,9 @@ class WC_Customer
     public function get_shipping_country()
     {
     }
+    public function get_billing_country()
+    {
+    }
 
 }
 
@@ -93,9 +96,11 @@ class WC_Shipping_Rate
 class WC_Payment_Gateway
 {
     public $id;
-    public function __construct($id = 1)
+    public $enabled;
+    public function __construct($id = 1, $enabled = 'yes')
     {
         $this->id = $id;
+        $this->enabled = $enabled;
     }
 }
 

--- a/tests/php/Unit/WC/Gateway/Mollie_WC_Gateway_Abstract_Test.php
+++ b/tests/php/Unit/WC/Gateway/Mollie_WC_Gateway_Abstract_Test.php
@@ -18,6 +18,7 @@ use WP_Error;
 
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Actions\expectDone;
+use function Brain\Monkey\Functions\stubs;
 
 /**
  * Class Mollie_WC_Helper_Settings_Test
@@ -583,5 +584,246 @@ class Mollie_WC_Gateway_Abstract_Test extends TestCase
         $sutReflection->setAccessible(true);
 
         return array($sut, $sutReflection);
+    }
+
+    /* -----------------------------------------------------------------
+      is_available Tests
+      -------------------------------------------------------------- */
+
+    /**
+     * Scenario: when not enabled, gateway is not available to show
+     * @test
+     */
+    public function isNotAvailable_WhenNotEnabledGateway()
+    {
+        $expected = false;
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this->buildTesteeMock(
+            Testee::class,
+            [],
+            []
+        )->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+        $testee->enabled = 'no';
+
+        $result = $testee->is_available();
+
+        self::assertEquals($expected, $result);
+
+    }
+    /**
+     * Scenario: when in cart but quantity zero, gateway is available to show
+     * @test
+     */
+    public function isAvailable_WhenQuantityZero()
+    {
+        $expected = true;
+        stubs(
+            [
+                'WC' => $this->wooCommerce(),
+            ]
+        );
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this->buildTesteeMock(
+            Testee::class,
+            [],
+            ['get_order_total']
+        )->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+        $testee->enabled = 'yes';
+        $testee
+            ->expects($this->once())
+            ->method('get_order_total')
+            ->willReturn(0);
+
+        $result = $testee->is_available();
+
+        self::assertEquals($expected, $result);
+    }
+    /**
+     * Scenario: gateway is available if allowed from the api and allowed_countries option is empty
+     * @test
+     */
+    public function isAvailable_WhenEmptyAllowedCountries()
+    {
+
+        $expected = true;
+        stubs(
+            [
+                'WC' => $this->wooCommerce(),
+                'get_woocommerce_currency'=>'EUR',
+                'mollieWooCommerceWcVersion'=>4,
+                'get_option'=>'IT'
+            ]
+        );
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this->buildTesteeMock(
+            Testee::class,
+            [],
+            ['get_order_total', 'getAmountValue', 'isAvailableMethodInCheckout','get_option']
+        )->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+        $testee->enabled = 'yes';
+        $testee
+            ->expects($this->exactly(2))
+            ->method('get_order_total')
+            ->willReturn(1);
+        $testee
+            ->expects($this->once())
+            ->method('getAmountValue')
+            ->willReturn(1);
+        $testee
+            ->expects($this->once())
+            ->method('isAvailableMethodInCheckout')
+            ->willReturn(true);
+        $testee
+            ->expects($this->once())
+            ->method('get_option')
+            ->willReturn([]);
+
+        $result = $testee->is_available();
+
+        self::assertEquals($expected, $result);
+    }
+    /**
+     * Scenario: gateway is NOT available if allowed from the api
+     * but billing country is not in the Allowed countries option
+     * @test
+     */
+    public function isNOTAvailable_WhenNotInAllowedCountries()
+    {
+
+        $expected = false;
+        stubs(
+            [
+                'WC' => $this->wooCommerce(),
+                'get_woocommerce_currency'=>'EUR',
+                'mollieWooCommerceWcVersion'=>4,
+                'get_option'=>'IT'
+            ]
+        );
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this->buildTesteeMock(
+            Testee::class,
+            [],
+            ['get_order_total', 'getAmountValue', 'isAvailableMethodInCheckout','get_option']
+        )->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+        $testee->enabled = 'yes';
+        $testee
+            ->expects($this->exactly(2))
+            ->method('get_order_total')
+            ->willReturn(1);
+        $testee
+            ->expects($this->once())
+            ->method('getAmountValue')
+            ->willReturn(1);
+        $testee
+            ->expects($this->once())
+            ->method('isAvailableMethodInCheckout')
+            ->willReturn(true);
+        $testee
+            ->expects($this->once())
+            ->method('get_option')
+            ->willReturn(['ES']);
+
+        $result = $testee->is_available();
+
+        self::assertEquals($expected, $result);
+    }
+    /**
+     * Scenario: gateway is available if allowed from the api
+     * AND billing country is in the Allowed countries option
+     * @test
+     */
+    public function isAvailable_WhenInAllowedCountries()
+    {
+
+        $expected = true;
+        stubs(
+            [
+                'WC' => $this->wooCommerce(),
+                'get_woocommerce_currency'=>'EUR',
+                'mollieWooCommerceWcVersion'=>4,
+                'get_option'=>'IT'
+            ]
+        );
+
+        /*
+         * Setup Testee
+         */
+        $testee = $this->buildTesteeMock(
+            Testee::class,
+            [],
+            ['get_order_total', 'getAmountValue', 'isAvailableMethodInCheckout','get_option']
+        )->getMockForAbstractClass();
+        $testee = $this->proxyFor($testee);
+        $testee->enabled = 'yes';
+        $testee
+            ->expects($this->exactly(2))
+            ->method('get_order_total')
+            ->willReturn(1);
+        $testee
+            ->expects($this->once())
+            ->method('getAmountValue')
+            ->willReturn(1);
+        $testee
+            ->expects($this->once())
+            ->method('isAvailableMethodInCheckout')
+            ->willReturn(true);
+        $testee
+            ->expects($this->once())
+            ->method('get_option')
+            ->willReturn(['IT']);
+
+        $result = $testee->is_available();
+
+        self::assertEquals($expected, $result);
+    }
+    /**
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    private function wooCommerce() {
+        $item = $this->createConfiguredMock(
+            'WooCommerce',
+            [
+
+            ]
+        );
+        $item->cart = true;
+        $item->customer = $this->wcCustomer();
+
+        return $item;
+    }
+    /**
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    private function wcCustomer()
+    {
+        $item = $this->createConfiguredMock(
+            'WC_Customer',
+            [
+                'get_billing_country' => 'IT'
+
+            ]
+        );
+
+        return $item;
     }
 }


### PR DESCRIPTION
Addresses [MOL-222][].

[MOL-222]: https://inpsyde.atlassian.net/browse/MOL-222
New setting in every gateway to choose
countries where to show itself.
In checkout, if the country is not allowed, the gw refrains from showing.
If the option is empty the workflow is as usual.