### PR TITLE
Consistent transaction descriptions

### DIFF
--- a/src/Mollie/WC/Payment/Payment.php
+++ b/src/Mollie/WC/Payment/Payment.php
@@ -36,8 +36,7 @@ class Mollie_WC_Payment_Payment extends Mollie_WC_Payment_Object {
 	 */
 	public function getPaymentRequestData( $order, $customer_id ) {
         $settings_helper = Mollie_WC_Plugin::getSettingsHelper();
-        $payment_description = __('Order', 'woocommerce') . ' '
-            . $order->get_order_number();
+        $payment_description = 'Order ' . $order->get_order_number();
         $payment_locale = $settings_helper->getPaymentLocale();
         $store_customer = $settings_helper->shouldStoreCustomer();
 


### PR DESCRIPTION
Since it is now always attempted to create an order it would be nice to have consistent transaction.description. For transactions via the orders API this will be the "Order "+ order.orderNumber. However when this is done via the payments API it is a translation of "Order" done via the WP method __() + orderNumber. I removed this translation.