### PR TITLE
Add WooCommerce onboarding setup methods

### DIFF
--- a/src/Mollie/WC/Gateway/Abstract.php
+++ b/src/Mollie/WC/Gateway/Abstract.php
@@ -2725,4 +2725,27 @@ abstract class Mollie_WC_Gateway_Abstract extends WC_Payment_Gateway
         ];
         $order->set_address($wooBillingAddress, 'billing');
     }
+
+    /**
+	 * Get help text to display during onboarding setup.
+	 *
+	 * @return string
+	 */
+	public function get_setup_help_text() {
+		return sprintf(
+			/* translators: $1. Mollie account URL. $2. Settings URL. */
+			__( 'Create a <a href="%1$s" target="_blank">Mollie account</a> and finish the configuration in the <a href="%2$s" target="_blank">Mollie settings.</a>', 'mollie-payments-for-woocommerce' ),
+			'https://www.mollie.com/dashboard/signup',
+			$this->get_settings_url()
+		);
+	}
+
+    /**
+	 * Get the settings URL for onboarding configuration.
+	 *
+	 * @return string
+	 */
+	public function get_settings_url() {
+		return admin_url( 'admin.php?page=wc-settings&tab=mollie_settings' );
+	}
 }


### PR DESCRIPTION
Adds the setup methods for the payment gateway task in WooCommerce onboarding.

<img width="693" alt="Screen Shot 2021-06-30 at 7 17 37 PM" src="https://user-images.githubusercontent.com/10561050/124043370-e8649000-d9d8-11eb-9fc2-69506f5d6446.png">
<img width="696" alt="Screen Shot 2021-06-30 at 6 57 14 PM" src="https://user-images.githubusercontent.com/10561050/124043372-e8fd2680-d9d8-11eb-8165-4e906d175043.png">


1. Check out this branch of WooCommerce Admin - https://github.com/woocommerce/woocommerce-admin/pull/7281
2. Make sure you're in a country that accepts Mollie (e.g., France)
3. Visit the payment setup task at `wp-admin/admin.php?page=wc-admin&task=payments`
4. Click "Set up" next to Mollie
5. Check that the setup text and URLs are correct