### PR TITLE
Fix display instructions after checkout

### DIFF
--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -952,6 +952,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway
             $instructions = $this->orderInstructionsService->executeStrategy(
                 $this,
                 $payment,
+                $order,
                 $admin_instructions
             );
 

--- a/src/Payment/OrderInstructionsService.php
+++ b/src/Payment/OrderInstructionsService.php
@@ -15,7 +15,7 @@ class OrderInstructionsService
         if (!$gateway->paymentMethod->getProperty('instructions')) {
             $this->strategy = new DefaultInstructionStrategy();
         } else {
-            $className = 'Mollie\\WooCommerce\\PaymentMethods\\InstructionStrategies\\' . ucfirst($gateway->paymentMethod->getProperty('id')) . 'InstructionsStrategy';
+            $className = 'Mollie\\WooCommerce\\PaymentMethods\\InstructionStrategies\\' . ucfirst($gateway->paymentMethod->getProperty('id')) . 'InstructionStrategy';
             $this->strategy = class_exists($className) ? new $className() : new DefaultInstructionStrategy();
         }
     }
@@ -23,10 +23,10 @@ class OrderInstructionsService
     public function executeStrategy(
         MolliePaymentGateway $gateway,
         $payment,
-        $admin_instructions = false,
-        $order = null
+        $order = null,
+        $admin_instructions = false
     ) {
 
-        return $this->strategy->execute($gateway, $payment, $admin_instructions, $order);
+        return $this->strategy->execute($gateway, $payment, $order, $admin_instructions);
     }
 }

--- a/src/PaymentMethods/InstructionStrategies/BanktransferInstructionStrategy.php
+++ b/src/PaymentMethods/InstructionStrategies/BanktransferInstructionStrategy.php
@@ -28,7 +28,9 @@ class BanktransferInstructionStrategy implements InstructionStrategyI
                 substr($payment->details->consumerAccount, -4),
                 $payment->details->consumerBic
             );
-        } elseif ($order->has_status('on-hold') || $order->has_status('pending')) {
+            return $instructions;
+        }
+        if (is_object($order) && ($order->has_status('on-hold') || $order->has_status('pending')) ) {
             if (!$admin_instructions) {
                 $instructions .= __('Please complete your payment by transferring the total amount to the following bank account:', 'mollie-payments-for-woocommerce') . "\n\n\n";
             }


### PR DESCRIPTION
Handles[ MOL-706](https://inpsyde.atlassian.net/browse/MOL-706)

We need the order in the banktransfer strategy and there was also a mismatch in the order of expected parameters. 