### PR TITLE
MOL-681 add filter for third-party to register modules.

### DIFF
--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -174,7 +174,7 @@ function initialize()
         // Initialize plugin.
         $properties = PluginProperties::new(__FILE__);
         $bootstrap = Package::new($properties);
-        $bootstrap->boot(
+        $modules = [
             new ActivationModule(__FILE__),
             new LogModule('mollie-payments-for-woocommerce-'),
             new NoticeModule(),
@@ -185,7 +185,9 @@ function initialize()
             new GatewayModule(),
             new VoucherModule(),
             new PaymentModule()
-        );
+        ];
+        $modules = apply_filters('mollie_wc_plugin_modules', $modules);
+        $bootstrap->boot(...$modules);
     } catch (Throwable $throwable) {
         handleException($throwable);
     }


### PR DESCRIPTION
By registering their module with the provided filter 'mollie_wc_plugin_modules', third-party plugins can access the container outside.
One way to register the module is to require "inpsyde/modularity" in the composer.json file and then implement the ExecutableModule in the class that has to access the $container instance. 

``` php
$module = new class implements ExecutableModule{
    public function run(ContainerInterface $c): bool
    {
        //the container is available here $c->get('looking_for')
        return true;
    }

    public function id(): string
    {
        return __CLASS__;
    }
};

add_filter('mollie_wc_plugin_modules', function($modules) use ($module) {
    array_push($modules, $module);

    return $modules;
});
```
