### PR TITLE
MOL-724 second param can be null

### DIFF
--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -1094,11 +1094,11 @@ class MolliePaymentGateway extends WC_Payment_Gateway
 
     /**
      * @param          $text
-     * @param WC_Order $order
+     * @param WC_Order| null $order
      *
      * @return string|void
      */
-    public function onOrderReceivedText($text, WC_Order $order)
+    public function onOrderReceivedText($text, $order)
     {
         if (!is_a($order, 'WC_Order')) {
             return $text;


### PR DESCRIPTION
If we tamper with the url then there is no order and we receive a null. In this case we return the text as is but we will not crash. Handles [MOL-724](https://inpsyde.atlassian.net/browse/MOL-724)