### PR TITLE
MOL-715 fix fallback to default description

### DIFF
--- a/src/Gateway/Surcharge.php
+++ b/src/Gateway/Surcharge.php
@@ -31,22 +31,21 @@ class Surcharge
 
     public function buildDescriptionWithSurcharge($description, PaymentMethodI $paymentMethod)
     {
-        $defaultDescription = $description;
         $surchargeType = $paymentMethod->getProperty('payment_surcharge');
 
         if (
             !$surchargeType
             || $surchargeType === self::NO_FEE
         ) {
-            return $defaultDescription;
+            return $description;
         }
 
         $feeText = $this->feeTextByType($surchargeType, $paymentMethod);
         if ($feeText) {
             $feeLabel = '<span class="mollie-gateway-fee">' . $feeText . '</span>';
-            return $defaultDescription . $feeLabel;
+            return $description . $feeLabel;
         }
-        return $defaultDescription;
+        return $description;
     }
 
     public function buildDescriptionWithSurchargeForBlock(PaymentMethodI $paymentMethod)

--- a/src/Gateway/Surcharge.php
+++ b/src/Gateway/Surcharge.php
@@ -29,11 +29,9 @@ class Surcharge
 
 
 
-    public function buildDescriptionWithSurcharge(PaymentMethodI $paymentMethod)
+    public function buildDescriptionWithSurcharge($description, PaymentMethodI $paymentMethod)
     {
-        $defaultDescription = $paymentMethod->getProperty('description') ?: $paymentMethod->getProperty(
-            'defaultDescription'
-        );
+        $defaultDescription = $description;
         $surchargeType = $paymentMethod->getProperty('payment_surcharge');
 
         if (

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -82,7 +82,10 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
     }
 
     public function getProcessedDescription(){
-        return $this->surcharge->buildDescriptionWithSurcharge($this);
+        $description = $this->getProperty('description') === false ? $this->getProperty(
+            'defaultDescription'
+        ) : $this->getProperty('description');
+        return $this->surcharge->buildDescriptionWithSurcharge($description, $this);
     }
 
     public function getProcessedDescriptionForBlock(){


### PR DESCRIPTION
We only fallback to the default if the setting does not exists, when is false. If the user wants it empty we do not fallback. Handles [MOL-715](https://inpsyde.atlassian.net/browse/MOL-715)