### PR TITLE
Add ngrok wrapper script

### DIFF
--- a/.ddev/commands/web/wp
+++ b/.ddev/commands/web/wp
@@ -1,0 +1,7 @@
+#!/bin/bash
+## Description: Run WordPress CLI inside the web container. DDEV core only provides this for the "wordpress" project type for some reason
+## Usage: wp [flags] [args]
+## Example: "ddev wp core version" or "ddev wp plugin install user-switching --activate"
+## ProjectTypes: php
+
+wp "$@" --path=.ddev/wordpress

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -20,3 +20,15 @@ template package [`wp-oop/plugin-boilerplate`][].
 2. Run `ddev start` to download container images and start services
 3. Run `ddev orchestrate` to set up the WordPress environment. (You can pass the `-f` flag if you ever wish to start from scratch)
 4. TODO: document how to build assets
+
+## Using ngrok
+You will often need to test and debug webhooks which require your development environment to be reachable from the outside
+DDEV provides integration with `ngrok` via the `ddev share` command. Unfortunately, this is not very helpful with WordPress
+since it needs correct URLs in the database.
+Therefore, we have a wrapper command that sets up & restores the URLs in the database before and after a sharing session.
+
+To start a sharing session, simply run 
+```shell
+bin/ddev-share
+```
+

--- a/bin/ddev-share
+++ b/bin/ddev-share
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+PROJECT_HOST=$(ddev wp option get home | tr -d '\r' | awk -F'^http[s]?://' '{print $2}')
+ddev share >/dev/null &
+NGROK_PID=$!
+ngrok-url(){
+    curl -s localhost:4040/api/tunnels | jq -r .tunnels[0].public_url | awk -F'^http[s]?://' '{print $2}'
+}
+wp-replace(){
+  echo "Replacing ${1} with ${2}"
+  ddev wp search-replace "${1}" "${2}" --all-tables --precise --recurse-objects
+}
+kill-ngrok(){
+  echo "Killing ngrok process ${NGROK_PID}"
+  pkill "${NGROK_PID}"
+  wp-replace "${NGROK_HOST}" "${PROJECT_HOST}"
+}
+echo "ngrok started with PID ${NGROK_PID}"
+
+echo "Waiting a few seconds for the service to come up"
+sleep 3
+NGROK_HOST=$(ngrok-url)
+wp-replace "${PROJECT_HOST}" "${NGROK_HOST}"
+
+echo "Your site is now reachable at https://${NGROK_HOST}"
+echo "ctrl-c to stop sharing and revert database changes"
+trap kill-ngrok INT
+wait -f "${NGROK_PID}"


### PR DESCRIPTION
This PR adds a script that wraps `ddev share` and runs `wp search-replace` with the public URL - and restores the project's URL when finished:

`bin/ddev-share`