### PR TITLE
Fix ddev

### DIFF
--- a/.ddev/commands/web/orchestrate.d/00_download_wordpress.sh
+++ b/.ddev/commands/web/orchestrate.d/00_download_wordpress.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! wp core download; then
+if ! wp core download --version="${WP_VERSION:-latest}"; then
  echo 'WordPress is already installed.'
  exit
 fi

--- a/.ddev/commands/web/orchestrate.d/30_install_plugin_packages.sh
+++ b/.ddev/commands/web/orchestrate.d/30_install_plugin_packages.sh
@@ -4,3 +4,4 @@ popd
 
 composer install
 npm install
+npm run build

--- a/.ddev/commands/web/orchestrate.d/40_setup_and_activate.sh
+++ b/.ddev/commands/web/orchestrate.d/40_setup_and_activate.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+pushd "${DDEV_DOCROOT}"
+
 wp plugin activate "${PLUGIN_NAME:-$DDEV_PROJECT}"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,6 +14,9 @@ nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"
+hooks:
+  pre-start:
+    - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
 web_environment:
   - WP_VERSION=5.9
   - WP_LOCALE=de_DE

--- a/.ddev/docker-compose.wp-plugin.yaml
+++ b/.ddev/docker-compose.wp-plugin.yaml
@@ -2,4 +2,4 @@ version: '3.6'
 services:
     web:
         volumes:
-            - ../:/var/www/html/.ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}:ro
+            - ../:/var/www/html/.ddev/wordpress/wp-content/plugins/mollie-payments-for-woocommerce:ro

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "watch": "webpack --watch",
-    "build": "gulp buildAssets",
+    "build": "node_modules/.bin/encore dev --env.basePath=.",
     "setup": "gulp setup",
     "cypress:open": "cypress open"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-rename": "^2.0",
     "gulp-zip": "^4.2.0",
     "minimist": "^1.2.3",
-    "node-sass": "^4.13.0",
+    "sass": "^1.52.1",
     "pump": "^3.0.0",
     "sass-loader": "^7.0.1"
   },


### PR DESCRIPTION
Fixed DDEV setup.

Also replaced [deprecated](https://www.npmjs.com/package/node-sass) `node-sass` package with `sass` because it was causing weird errors. It should not need any other changes because [`sass-loader`](https://www.npmjs.com/package/sass-loader) supports both.