### PR TITLE
MOL-846 Components enabled by default

### DIFF
--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -145,7 +145,7 @@ function initialize()
         $properties = PluginProperties::new(__FILE__);
         $bootstrap = Package::new($properties);
         $modules = [
-            new ActivationModule(__FILE__),
+            new ActivationModule(__FILE__, $properties->version()),
             new LogModule('mollie-payments-for-woocommerce-'),
             new NoticeModule(),
             new SharedModule(),
@@ -155,7 +155,7 @@ function initialize()
             new GatewayModule(),
             new VoucherModule(),
             new PaymentModule(),
-            new UninstallModule()
+            new UninstallModule(),
         ];
         $modules = apply_filters('mollie_wc_plugin_modules', $modules);
         $bootstrap->boot(...$modules);

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -61,6 +61,11 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
             && $this->getProperty('payment_surcharge') !== Surcharge::NO_FEE;
     }
 
+    public function hasPaymentFields(): bool
+    {
+        return $this->getProperty('paymentFields');
+    }
+
     public function getIconUrl(): string
     {
         return $this->iconFactory->getIconUrl(

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -56,7 +56,8 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         return $this->surcharge;
     }
 
-    public function hasSurcharge(){
+    public function hasSurcharge()
+    {
         return $this->getProperty('payment_surcharge')
             && $this->getProperty('payment_surcharge') !== Surcharge::NO_FEE;
     }
@@ -76,10 +77,11 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
     public function shouldDisplayIcon(): bool
     {
         $defaultIconSetting = true;
-        return $this->hasProperty('display_logo')? $this->getProperty('display_logo') === 'yes': $defaultIconSetting;
+        return $this->hasProperty('display_logo') ? $this->getProperty('display_logo') === 'yes' : $defaultIconSetting;
     }
 
-    public function getSharedFormFields(){
+    public function getSharedFormFields()
+    {
         return $this->settingsHelper->generalFormFields(
             $this->getProperty('defaultTitle'),
             $this->getProperty('defaultDescription'),
@@ -87,23 +89,27 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         );
     }
 
-    public function getAllFormFields(){
+    public function getAllFormFields()
+    {
         return $this->getFormFields($this->getSharedFormFields());
     }
 
-    public function paymentFieldsStrategy($gateway){
+    public function paymentFieldsStrategy($gateway)
+    {
         $this->paymentFieldsService->setStrategy($this);
         $this->paymentFieldsService->executeStrategy($gateway);
     }
 
-    public function getProcessedDescription(){
+    public function getProcessedDescription()
+    {
         $description = $this->getProperty('description') === false ? $this->getProperty(
             'defaultDescription'
         ) : $this->getProperty('description');
         return $this->surcharge->buildDescriptionWithSurcharge($description, $this);
     }
 
-    public function getProcessedDescriptionForBlock(){
+    public function getProcessedDescriptionForBlock()
+    {
         return $this->surcharge->buildDescriptionWithSurchargeForBlock($this);
     }
 

--- a/src/PaymentMethods/Creditcard.php
+++ b/src/PaymentMethods/Creditcard.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\PaymentMethods;
 
+use Mollie\WooCommerce\Activation\ActivationModule;
+use Mollie\WooCommerce\Shared\SharedDataDictionary;
+
 class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
 {
     protected function getConfig(): array
@@ -33,9 +36,10 @@ class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
         return $this->includeCreditCardIconSelector($componentFields);
     }
 
-    protected function hasPaymentFields()
+    public function hasPaymentFields(): bool
     {
-        return $this->getProperty('mollie_components_enabled') === 'yes';
+        $componentsEnabled = $this->getProperty('mollie_components_enabled');
+        return $componentsEnabled ? $componentsEnabled === 'yes' : $this->defaultComponentsEnabled() === 'yes';
     }
 
     protected function includeMollieComponentsFields($generalFormFields)
@@ -52,11 +56,20 @@ class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
                     ),
                     __('Mollie Components', 'mollie-payments-for-woocommerce')
                 ),
-                'default' => 'no',
+                'default' => $this->defaultComponentsEnabled(),
             ],
         ];
 
         return array_merge($generalFormFields, $fields);
+    }
+
+    protected function defaultComponentsEnabled()
+    {
+        $isNewInstall = get_option(SharedDataDictionary::NEW_INSTALL_PARAM_NAME, false);
+        if ($isNewInstall === 'yes') {
+            return 'yes';
+        }
+        return 'no';
     }
 
     /**

--- a/src/PaymentMethods/PaymentFieldsStrategies/CreditcardFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/CreditcardFieldsStrategy.php
@@ -45,7 +45,7 @@ class CreditcardFieldsStrategy implements PaymentFieldsStrategyI
 
     protected function isMollieComponentsEnabled(PaymentMethodI $paymentMethod): bool
     {
-        return $paymentMethod->getProperty('mollie_components_enabled') === 'yes';
+        return $paymentMethod->hasPaymentFields();
     }
 
     protected function lockIcon($dataHelper)

--- a/src/PaymentMethods/PaymentMethodI.php
+++ b/src/PaymentMethods/PaymentMethodI.php
@@ -8,4 +8,5 @@ interface PaymentMethodI
 {
     public function getProperty(string $propertyName);
     public function hasProperty(string $propertyName);
+    public function hasPaymentFields();
 }

--- a/src/Shared/SharedDataDictionary.php
+++ b/src/Shared/SharedDataDictionary.php
@@ -61,6 +61,13 @@ class SharedDataDictionary
         'mollie_apple_pay_button_enabled_product',
         'mollie_apple_pay_button_enabled_cart',
         'mollie_wc_applepay_validated',
-        'mollie-payments-for-woocommerce_removeOptionsAndTransients'
+        'mollie-payments-for-woocommerce_removeOptionsAndTransients',
+        'mollie-plugin-version',
+        'mollie-new-install',
     ];
+    public const DB_VERSION_PARAM_NAME = 'mollie-db-version';
+    public const PLUGIN_VERSION_PARAM_NAME = 'mollie-plugin-version';
+    public const NEW_INSTALL_PARAM_NAME = 'mollie-new-install';
+    public const PENDING_PAYMENT_DB_TABLE_NAME = 'mollie_pending_payment';
+    public const DB_VERSION = '1.0';
 }


### PR DESCRIPTION
On new install components are enabled, on update disabled. So we check if is a new install and we set hasFields to default if there is no setting saved
Handles [MOL-846](https://inpsyde.atlassian.net/browse/MOL-846)