### PR TITLE
Define Collate utf8mb4_unicode_ci in DB table

### DIFF
--- a/src/Activation/ActivationModule.php
+++ b/src/Activation/ActivationModule.php
@@ -68,6 +68,7 @@ class ActivationModule implements ExecutableModule
                     post_id bigint NOT NULL,
                     expired_time int NOT NULL,
                     PRIMARY KEY id (id)
+                    COLLATE=utf8mb4_unicode_ci
                 );";
                 dbDelta($sql);
 


### PR DESCRIPTION
Please define `COLLATE=utf8mb4_unicode_ci` when creating the table to avoid MySQL 8.0 > MySQL 5.7 export and import errors. This took me a bit to figure out. Not sure if it's behaviour from `dbDelta()` but this should make it compatible for both MySQL versions.