### PR TITLE
MOL-891 Remove some coupling with WC_Subscription

### DIFF
--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -556,7 +556,7 @@ class MollieObject
         $payment
     ) {
 
-        if (class_exists('WC_Subscriptions')) {
+        if ($this->dataHelper->isSubscriptionPluginActive()) {
             $payment = isset($payment->_embedded->payments[0]) ? $payment->_embedded->payments[0] : false;
             if (
                 $payment && $payment->sequenceType === 'first'

--- a/src/Settings/Page/MollieSettingsPage.php
+++ b/src/Settings/Page/MollieSettingsPage.php
@@ -396,7 +396,7 @@ class MollieSettingsPage extends WC_Settings_Page
         $idealGateway = !empty($this->registeredGateways["mollie_wc_gateway_ideal"]) && $isIdealEnabled;
         $sepaGateway = !empty($this->registeredGateways["mollie_wc_gateway_directdebit"]) && $isSepaEnabled;
 
-        if ((class_exists('WC_Subscription')) && $idealGateway && !$sepaGateway) {
+        if ($idealGateway && !$sepaGateway) {
             $warning_message = __(
                 'You have WooCommerce Subscriptions activated, but not SEPA Direct Debit. Enable SEPA Direct Debit if you want to allow customers to pay subscriptions with iDEAL and/or other "first" payment methods.',
                 'mollie-payments-for-woocommerce'


### PR DESCRIPTION
Some methods check if there is a subscription plugin.
Now that check can be true for plugins[ declaring themselves as subscription via filter.] Not only if WC_Subscriptions class is present.(https://github.com/mollie/WooCommerce/blob/0ec01f2001f8fd80aae1e960c53155ffda96e915/src/Shared/Data.php#L68) 
DirectDebit gateway [is enabled upon that same filter](https://github.com/mollie/WooCommerce/blob/0ec01f2001f8fd80aae1e960c53155ffda96e915/src/Shared/Data.php#L227).

The methods where we handle WC_Subs code still need to check for its classes to be present.