### PR TITLE
MOL-936 cast surcharge limit to float

### DIFF
--- a/src/Gateway/Surcharge.php
+++ b/src/Gateway/Surcharge.php
@@ -232,7 +232,7 @@ class Surcharge
         if (empty($gatewaySettings['surcharge_limit'])) {
             return $fee;
         }
-        $maxLimit = $gatewaySettings['surcharge_limit'];
+        $maxLimit = (float)$gatewaySettings['surcharge_limit'];
         if ($fee > $maxLimit) {
             return $maxLimit;
         }


### PR DESCRIPTION
The option is saved as string, we need a float.
Handles [MOL-936](https://inpsyde.atlassian.net/browse/MOL-936)