### PR TITLE
Feature/p 100 update creditcard title

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -631,7 +631,7 @@ class GatewayModule implements ServiceModule, ExecutableModule
                 $settingsHelper,
                 $paymentFieldsService,
                 $surchargeService,
-                $paymentMethods
+                $paymentMethodAvailable
             );
         }
 
@@ -644,7 +644,7 @@ class GatewayModule implements ServiceModule, ExecutableModule
                 $settingsHelper,
                 $paymentFieldsService,
                 $surchargeService,
-                $paymentMethods
+                []
             );
         }
         return $paymentMethods;
@@ -697,14 +697,15 @@ class GatewayModule implements ServiceModule, ExecutableModule
         Settings $settingsHelper,
         PaymentFieldsService $paymentFieldsService,
         Surcharge $surchargeService,
-        array $paymentMethods
+        array $apiMethod
     ): PaymentMethodI {
         $paymentMethodClassName = 'Mollie\\WooCommerce\\PaymentMethods\\' . ucfirst($id);
         $paymentMethod = new $paymentMethodClassName(
             $iconFactory,
             $settingsHelper,
             $paymentFieldsService,
-            $surchargeService
+            $surchargeService,
+            $apiMethod
         );
 
         return $paymentMethod;

--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -120,9 +120,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
         // Use gateway class name as gateway id
         $this->gatewayId();
         // Set gateway title (visible in admin)
-        $this->method_title = 'Mollie - ' . $this->paymentMethod->getProperty(
-            'defaultTitle'
-        );
+        $this->method_title = 'Mollie - ' . $this->paymentMethod->title();
         $this->method_description = $this->paymentMethod->getProperty(
             'settingsDescription'
         );
@@ -131,8 +129,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
         // Load the settings.
         $this->init_form_fields();
         $this->init_settings();
-        $this->title = $this->paymentMethod->hasProperty('title')
-            ? $this->paymentMethod->getProperty('title') : $this->paymentMethod->getProperty('defaultTitle');
+        $this->title = $this->paymentMethod->title();
 
         $this->initDescription();
         $this->initIcon();

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -65,9 +65,11 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
 
     public function title(): string
     {
-        $title = $this->getProperty('title');
+        $titleIsDefault = $this->titleIsDefault();
         $useApiTitle = $this->getProperty('use_api_title');
-        if ($useApiTitle !== 'no' || !$title) {
+        $title = $this->getProperty('title');
+        //new installations or installations that saved the default one should use the api title
+        if ($useApiTitle !== 'no' || !$title || $titleIsDefault) {
             return $this->getApiTitle();
         }
          return $title;
@@ -286,5 +288,15 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
     {
         $apiTitle = $this->apiPaymentMethod['description'];
         return $apiTitle ?: $this->config['defaultTitle'];
+    }
+
+    protected function titleIsDefault(): bool
+    {
+        $savedTitle = $this->getProperty('title');
+        if (!$savedTitle) {
+            return false;
+        }
+
+        return $savedTitle === $this->config['defaultTitle'];
     }
 }

--- a/src/PaymentMethods/PaymentMethodI.php
+++ b/src/PaymentMethods/PaymentMethodI.php
@@ -10,6 +10,7 @@ interface PaymentMethodI
 {
     public function getProperty(string $propertyName);
     public function hasProperty(string $propertyName): bool;
+    public function title(): string;
     public function hasPaymentFields(): bool;
     public function getProcessedDescriptionForBlock(): string;
     public function paymentFieldsService(): PaymentFieldsService;

--- a/src/Settings/General/MollieGeneralSettings.php
+++ b/src/Settings/General/MollieGeneralSettings.php
@@ -58,7 +58,7 @@ class MollieGeneralSettings
                 ),
                 'type' => 'checkbox',
                 'label' => __('Retrieve the gateway title from Mollie', 'mollie-payments-for-woocommerce'),
-                'default' => 'yes',
+                'default' => 'no',
             ],
             'description' => [
                 'title' => __('Description', 'mollie-payments-for-woocommerce'),

--- a/src/Settings/General/MollieGeneralSettings.php
+++ b/src/Settings/General/MollieGeneralSettings.php
@@ -51,6 +51,15 @@ class MollieGeneralSettings
                 'default' => $defaultTitle,
                 'desc_tip' => true,
             ],
+            'use_api_title' => [
+                'title' => __(
+                    'Use API dynamic title',
+                    'mollie-payments-for-woocommerce'
+                ),
+                'type' => 'checkbox',
+                'label' => __('Retrieve the gateway title from Mollie', 'mollie-payments-for-woocommerce'),
+                'default' => 'yes',
+            ],
             'description' => [
                 'title' => __('Description', 'mollie-payments-for-woocommerce'),
                 'type' => 'textarea',

--- a/src/Settings/Page/MollieSettingsPage.php
+++ b/src/Settings/Page/MollieSettingsPage.php
@@ -350,7 +350,7 @@ class MollieSettingsPage extends WC_Settings_Page
             $paymentMethodEnabledAtMollie = array_key_exists($gatewayKey, $mollieGateways);
             $content .= '<li>';
             $content .= $paymentMethod->getIconUrl();
-            $content .= ' ' . esc_html($paymentMethod->getProperty('defaultTitle'));
+            $content .= ' ' . esc_html($paymentMethod->title());
             if ($paymentMethodEnabledAtMollie) {
                 $content .= $iconAvailable;
                 $content .= ' <a href="' . $this->getGatewaySettingsUrl($gatewayKey) . '">' . strtolower(

--- a/tests/php/Functional/HelperMocks.php
+++ b/tests/php/Functional/HelperMocks.php
@@ -204,7 +204,7 @@ class HelperMocks extends TestCase
     {
         $paymentMethod = $this->createPartialMock(
             Ideal::class,
-            ['getConfig', 'getInitialOrderStatus', 'getMergedProperties', 'getSettings']
+            ['getConfig', 'getInitialOrderStatus', 'getMergedProperties', 'getSettings', 'title']
         );
         $paymentMethod
             ->method('getConfig')
@@ -217,6 +217,9 @@ class HelperMocks extends TestCase
         $paymentMethod
             ->method('getMergedProperties')
             ->willReturn($this->paymentMethodMergedProperties($paymentMethodName, $isSepa, $isSubscription, $settings));
+        $paymentMethod
+            ->method('title')
+            ->willReturn($paymentMethodName);
 
         return $paymentMethod;
     }

--- a/tests/php/Functional/PaymentMethod/PaymentMethodTest.php
+++ b/tests/php/Functional/PaymentMethod/PaymentMethodTest.php
@@ -160,7 +160,7 @@ class PaymentMethodTest extends TestCase
 
         $paymentMethod = $this->buildTesteeMock(
             Creditcard::class,
-            [$iconFactory, $settingsHelper, $paymentFieldsService, $surchargeService],
+            [$iconFactory, $settingsHelper, $paymentFieldsService, $surchargeService, []],
             ['getConfig', 'getSettings', 'getInitialOrderStatus', 'getIdFromConfig']
         )->getMock();
 


### PR DESCRIPTION
Handles [PIWOO-100](https://mollie.atlassian.net/browse/PIWOO-100)

New users will not save the default title. There is a new option to decide if we want to receive the title from the API that is disabled by default. So old users will see whatever title they have saved without action needed. If the string they have saved is exactly the same as the default one, or there is nothing saved, then we show the API title. 
The API title is saved in cache along the payment method. 
If the API title fails we fallback to the title hardcoded in the payment method.

[PIWOO-100]: https://mollie.atlassian.net/browse/PIWOO-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ