### PR TITLE
Bugfix: Do not escape the HTML when there is only 1 giftcard

### DIFF
--- a/src/PaymentMethods/PaymentFieldsStrategies/GiftcardFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/GiftcardFieldsStrategy.php
@@ -28,7 +28,7 @@ class GiftcardFieldsStrategy implements PaymentFieldsStrategyI
             $issuerImageSvg = $this->checkSvgIssuers($issuers);
             $issuerImageSvg && ($html .= '<img src="' . $issuerImageSvg . '" style="vertical-align:middle" />');
             $html .= $issuer->name;
-            echo esc_html(wpautop(wptexturize($html)));
+            echo wpautop(wptexturize($html));
 
             return;
         }


### PR DESCRIPTION
When only one gift card is available, the HTML is rendered differently than when there are multiple. This HTML is escaped before being outputted, causing this:

<img width="267" alt="image" src="https://github.com/mollie/WooCommerce/assets/5858697/a014c7c7-7bf7-405e-9d07-37cb2db830ac">

This PR removes the escape function so that the HTML is properly shown:
<img width="242" alt="image" src="https://github.com/mollie/WooCommerce/assets/5858697/a0df1293-c2c1-4cc8-9509-690f17b428e0">
