### PR TITLE
Ignore default title to get api one

### DIFF
--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -65,16 +65,10 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
 
     public function title(): string
     {
-        $titleIsDefault = $this->titleIsDefault();
         $useApiTitle = $this->getProperty(SharedDataDictionary::USE_API_TITLE) === 'yes';
-        if ($titleIsDefault && $useApiTitle === false) {
-            $this->updateMethodOption(SharedDataDictionary::USE_API_TITLE, 'yes');
-            $useApiTitle = true;
-        }
-
         $title = $this->getProperty('title');
-        //new installations or installations that saved the default one should use the api title
-        if ($useApiTitle || $title === false || $titleIsDefault) {
+        //new installations should use the api title
+        if ($useApiTitle || $title === false) {
             return $this->getApiTitle();
         }
          return $title;


### PR DESCRIPTION
Handles [PIWOO-234](https://mollie.atlassian.net/browse/PIWOO-234)
This Pr  changes the requirement that when a user has the default title in a gateway we would use the API title, not we respect that default title

[PIWOO-234]: https://mollie.atlassian.net/browse/PIWOO-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ