### PR TITLE
Fix/piwoo 125 - Add woocommerce checkout blocks support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "fzaninotto/faker": "^1.9@dev",
     "inpsyde/php-coding-standards": "^1.0.0",
     "php-stubs/wordpress-stubs": "^5.0@stable",
-    "php-stubs/woocommerce-stubs": "^5.0@stable",
+    "php-stubs/woocommerce-stubs": "7.9.0",
     "vimeo/psalm": "^4.8 || ^5.13.0"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cea1ff9bf85bcfc84018e2cbe6806299",
+    "content-hash": "08ed061076326ed4c72999e92368f69c",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1943,23 +1943,23 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v5.9.1",
+            "version": "v7.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "486ccff117badfab94c404065d37a77d632d7db5"
+                "reference": "3a2f522e29451490c357af550227795d2b0fc55a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/486ccff117badfab94c404065d37a77d632d7db5",
-                "reference": "486ccff117badfab94c404065d37a77d632d7db5",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/3a2f522e29451490c357af550227795d2b0fc55a",
+                "reference": "3a2f522e29451490c357af550227795d2b0fc55a",
                 "shasum": ""
             },
             "require": {
-                "php-stubs/wordpress-stubs": "^5.3.0"
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
             },
             "require-dev": {
-                "php": "~7.1",
+                "php": "~7.1 || ~8.0",
                 "php-stubs/generator": "^0.8.0"
             },
             "suggest": {
@@ -1981,9 +1981,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v5.9.1"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.9.0"
             },
-            "time": "2022-04-30T06:35:48+00:00"
+            "time": "2023-07-17T22:41:38+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -4684,8 +4684,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "fzaninotto/faker": 20,
-        "php-stubs/wordpress-stubs": 0,
-        "php-stubs/woocommerce-stubs": 0
+        "php-stubs/wordpress-stubs": 0
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/psalm.xml
+++ b/psalm.xml
@@ -24,6 +24,7 @@
         <file name=".psalm/stubs.php"/>
         <file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"/>
         <file name="vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php"/>
+        <file name="vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php"/>
     </stubs>
     <issueHandlers>
         <MixedAssignment errorLevel="suppress" />

--- a/resources/js/mollieBlockIndex.js
+++ b/resources/js/mollieBlockIndex.js
@@ -10,8 +10,9 @@ import molliePaymentMethod from './blocks/molliePaymentMethod'
             const { ajaxUrl, filters, gatewayData, availableGateways } = mollieBlockData.gatewayData;
             const {useEffect} = wp.element;
             const isAppleSession = typeof window.ApplePaySession === "function"
-            function getCompanyField()
-            {
+            const isBlockEditor = !!wp?.blockEditor;
+
+            function getCompanyField() {
                 let shippingCompany = document.getElementById('shipping-company');
                 let billingCompany = document.getElementById('billing-company');
                 return shippingCompany ? shippingCompany : billingCompany;
@@ -39,8 +40,8 @@ import molliePaymentMethod from './blocks/molliePaymentMethod'
             }
             gatewayData.forEach(item => {
                 let register = () => registerPaymentMethod(molliePaymentMethod(useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, isCompanyFieldVisible, isPhoneFieldVisible));
-                if (item.name === 'mollie_wc_gateway_applepay' ) {
-                    if (isAppleSession && window.ApplePaySession.canMakePayments()) {
+                if (item.name === 'mollie_wc_gateway_applepay'  && !isBlockEditor) {
+                    if ((isAppleSession && window.ApplePaySession.canMakePayments())) {
                         register();
                     }
                     return;

--- a/src/Assets/AssetsModule.php
+++ b/src/Assets/AssetsModule.php
@@ -6,15 +6,13 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\Assets;
 
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Inpsyde\Modularity\Module\ExecutableModule;
 use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\WooCommerce\Buttons\ApplePayButton\DataToAppleButtonScripts;
 use Mollie\WooCommerce\Buttons\PayPalButton\DataToPayPal;
 use Mollie\WooCommerce\Components\AcceptedLocaleValuesDictionary;
-use Mollie\WooCommerce\Gateway\MolliePaymentGateway;
-use Mollie\WooCommerce\Gateway\MolliePaymentGatewayI;
-use Mollie\WooCommerce\PaymentMethods\PaymentMethodI;
 use Mollie\WooCommerce\Settings\Settings;
 use Mollie\WooCommerce\Shared\Data;
 use Psr\Container\ContainerInterface;
@@ -34,15 +32,7 @@ class AssetsModule implements ExecutableModule
         if (!has_block('woocommerce/checkout')) {
             return;
         }
-        wp_enqueue_script('mollie_block_index');
         wp_enqueue_style('mollie-gateway-icons');
-        wp_localize_script(
-            'mollie_block_index',
-            'mollieBlockData',
-            [
-                'gatewayData' => $this->gatewayDataForWCBlocks($dataService, $gatewayInstances),
-            ]
-        );
     }
 
     public function registerButtonsBlockScripts(string $pluginUrl, string $pluginPath): void
@@ -431,102 +421,6 @@ class AssetsModule implements ExecutableModule
         );
     }
 
-    protected function gatewayDataForWCBlocks(Data $dataService, array $gatewayInstances): array
-    {
-        $filters = $dataService->wooCommerceFiltersForCheckout();
-        $availableGateways = WC()->payment_gateways()->get_available_payment_gateways();
-        $availablePaymentMethods = [];
-        /**
-         * @var MolliePaymentGatewayI $gateway
-         * psalm-suppress  UnusedForeachValue
-         */
-        foreach ($availableGateways as $key => $gateway) {
-            if (strpos($key, 'mollie_wc_gateway_') === false) {
-                unset($availableGateways[$key]);
-            }
-        }
-        if (
-            isset($filters['amount']['currency'])
-            && isset($filters['locale'])
-            && isset($filters['billingCountry'])
-        ) {
-            $filterKey = "{$filters['amount']['currency']}-{$filters['locale']}-{$filters['billingCountry']}";
-            foreach ($availableGateways as $key => $gateway) {
-                $availablePaymentMethods[$filterKey][$key] = $gateway->paymentMethod()->getProperty('id');
-            }
-        }
-
-        $dataToScript = [
-            'ajaxUrl' => admin_url('admin-ajax.php'),
-            'filters' => [
-                'currency' => isset($filters['amount']['currency']) ? $filters['amount']['currency'] : false,
-                'cartTotal' => isset($filters['amount']['value']) ? $filters['amount']['value'] : false,
-                'paymentLocale' => isset($filters['locale']) ? $filters['locale'] : false,
-                'billingCountry' => isset($filters['billingCountry']) ? $filters['billingCountry'] : false,
-                        ],
-        ];
-        $gatewayData = [];
-        $isSepaEnabled = isset($gatewayInstances['mollie_wc_gateway_directdebit']) && $gatewayInstances['mollie_wc_gateway_directdebit']->enabled === 'yes';
-        /** @var MolliePaymentGateway $gateway */
-        foreach ($gatewayInstances as $gatewayKey => $gateway) {
-            /** @var string $gatewayId */
-            $gatewayId = is_string($gateway->paymentMethod()->getProperty('id')) ? $gateway->paymentMethod()->getProperty('id') : "";
-
-            if ($gateway->enabled !== 'yes' || $gatewayId === 'directdebit') {
-                continue;
-            }
-            $content = $gateway->paymentMethod()->getProcessedDescriptionForBlock();
-            $issuers = false;
-            if ($gateway->paymentMethod()->getProperty('paymentFields') === true) {
-                $paymentFieldsService = $gateway->paymentMethod()->paymentFieldsService();
-                $paymentFieldsService->setStrategy($gateway->paymentMethod());
-                $issuers = $gateway->paymentMethod()->paymentFieldsService()->getStrategyMarkup($gateway);
-            }
-            if ($gatewayId === 'creditcard') {
-                $content .= $issuers;
-                $issuers = false;
-            }
-            $title = $gateway->paymentMethod()->title();
-            $labelMarkup = "<span style='margin-right: 1em'>{$title}</span>{$gateway->icon}";
-            $hasSurcharge = $gateway->paymentMethod()->hasSurcharge();
-            $gatewayData[] = [
-                'name' => $gatewayKey,
-                'label' => $labelMarkup,
-                'content' => $content,
-                'issuers' => $issuers,
-                'hasSurcharge' => $hasSurcharge,
-                'title' => $title,
-                'contentFallback' => __('Please choose a billing country to see the available payment methods', 'mollie-payments-for-woocommerce'),
-                'edit' => $content,
-                'paymentMethodId' => $gatewayKey,
-                'allowedCountries' => is_array(
-                    $gateway->paymentMethod()->getProperty('allowed_countries')
-                ) ? $gateway->paymentMethod()->getProperty('allowed_countries') : [],
-                'ariaLabel' => $gateway->paymentMethod()->getProperty('defaultDescription'),
-                'supports' => $this->gatewaySupportsFeatures($gateway->paymentMethod(), $isSepaEnabled),
-                'errorMessage' => $gateway->paymentMethod()->getProperty('errorMessage'),
-                'companyPlaceholder' => $gateway->paymentMethod()->getProperty('companyPlaceholder'),
-                'phonePlaceholder' => $gateway->paymentMethod()->getProperty('phonePlaceholder'),
-                'birthdatePlaceholder' => $gateway->paymentMethod()->getProperty('birthdatePlaceholder'),
-            ];
-        }
-        $dataToScript['gatewayData'] = $gatewayData;
-        $dataToScript['availableGateways'] = $availablePaymentMethods;
-
-        return $dataToScript;
-    }
-
-    public function gatewaySupportsFeatures(PaymentMethodI $paymentMethod, bool $isSepaEnabled): array
-    {
-        $supports = (array) $paymentMethod->getProperty('supports');
-        $isSepaPaymentMethod = (bool) $paymentMethod->getProperty('SEPA');
-        if ($isSepaEnabled && $isSepaPaymentMethod) {
-            array_push($supports, 'subscriptions');
-        }
-
-        return $supports;
-    }
-
     protected function getPluginUrl(string $pluginUrl, string $path = ''): string
     {
         return $pluginUrl . ltrim($path, '/');
@@ -633,9 +527,34 @@ class AssetsModule implements ExecutableModule
         $pluginPath = $container->get('shared.plugin_path');
         /** @var Settings */
         $settingsHelper = $container->get('settings.settings_helper');
+        $gatewayInstances = $container->get('gateway.instances');
+
+        /** Add support to Mollie blocks for Woocommerce checkout blocks functionality */
+        //https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/third-party-developers/extensibility/checkout-payment-methods/payment-method-integration.md#putting-it-all-together
+        add_action(
+            'woocommerce_blocks_loaded',
+            function () use ($dataService, $gatewayInstances, $pluginUrl, $pluginPath, $hasBlocksEnabled) {
+                if ($hasBlocksEnabled && class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
+                    add_action(
+                        'woocommerce_blocks_payment_method_type_registration',
+                        function (PaymentMethodRegistry $paymentMethodRegistry) use ($dataService, $gatewayInstances, $pluginUrl, $pluginPath) {
+                            $paymentMethodRegistry->register(
+                                new MollieCheckoutBlocksSupport(
+                                    $dataService,
+                                    $gatewayInstances,
+                                    $this->getPluginUrl($pluginUrl, '/public/js/mollieBlockIndex.min.js'),
+                                    (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollieBlockIndex.min.js'))
+                                )
+                            );
+                        }
+                    );
+                }
+            }
+        );
+
         add_action(
             'init',
-            function () use ($container, $hasBlocksEnabled, $settingsHelper, $pluginUrl, $pluginPath, $dataService) {
+            function () use ($hasBlocksEnabled, $settingsHelper, $pluginUrl, $pluginPath) {
                 self::registerFrontendScripts($pluginUrl, $pluginPath);
 
                 // Enqueue Scripts
@@ -649,12 +568,6 @@ class AssetsModule implements ExecutableModule
                 });
 
                 if ($hasBlocksEnabled) {
-                    /** @var array */
-                    $gatewayInstances = $container->get('gateway.instances');
-                    self::registerBlockScripts($pluginUrl, $pluginPath);
-                    add_action('wp_enqueue_scripts', function () use ($dataService, $gatewayInstances) {
-                        $this->enqueueBlockCheckoutScripts($dataService, $gatewayInstances);
-                    });
                     $this->registerButtonsBlockScripts($pluginUrl, $pluginPath);
                 }
             }

--- a/src/Assets/AssetsModule.php
+++ b/src/Assets/AssetsModule.php
@@ -32,7 +32,10 @@ class AssetsModule implements ExecutableModule
         if (!has_block('woocommerce/checkout')) {
             return;
         }
+        wp_enqueue_script(MollieCheckoutBlocksSupport::getScriptHandle());
         wp_enqueue_style('mollie-gateway-icons');
+
+        MollieCheckoutBlocksSupport::localizeWCBlocksData($dataService, $gatewayInstances);
     }
 
     public function registerButtonsBlockScripts(string $pluginUrl, string $pluginPath): void
@@ -49,7 +52,7 @@ class AssetsModule implements ExecutableModule
                         '/public/js/paypalButtonBlockComponent.min.js'
                     ),
                     [],
-                    (string) filemtime(
+                    (string)filemtime(
                         $this->getPluginPath(
                             $pluginPath,
                             '/public/js/paypalButtonBlockComponent.min.js'
@@ -73,7 +76,7 @@ class AssetsModule implements ExecutableModule
                         '/public/js/applepayButtonBlockComponent.min.js'
                     ),
                     [],
-                    (string) filemtime(
+                    (string)filemtime(
                         $this->getPluginPath(
                             $pluginPath,
                             '/public/js/applepayButtonBlockComponent.min.js'
@@ -183,7 +186,7 @@ class AssetsModule implements ExecutableModule
             'babel-polyfill',
             $this->getPluginUrl($pluginUrl, '/public/js/babel-polyfill.min.js'),
             [],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/babel-polyfill.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/babel-polyfill.min.js')),
             true
         );
 
@@ -191,56 +194,56 @@ class AssetsModule implements ExecutableModule
             'mollie_wc_gateway_applepay',
             $this->getPluginUrl($pluginUrl, '/public/js/applepay.min.js'),
             [],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/applepay.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/applepay.min.js')),
             true
         );
         wp_register_style(
             'mollie-gateway-icons',
             $this->getPluginUrl($pluginUrl, '/public/css/mollie-gateway-icons.min.css'),
             [],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/css/mollie-gateway-icons.min.css')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/css/mollie-gateway-icons.min.css')),
             'screen'
         );
         wp_register_style(
             'mollie-components',
             $this->getPluginUrl($pluginUrl, '/public/css/mollie-components.min.css'),
             [],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/css/mollie-components.min.css')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/css/mollie-components.min.css')),
             'screen'
         );
         wp_register_style(
             'mollie-applepaydirect',
             $this->getPluginUrl($pluginUrl, '/public/css/mollie-applepaydirect.min.css'),
             [],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/css/mollie-applepaydirect.min.css')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/css/mollie-applepaydirect.min.css')),
             'screen'
         );
         wp_register_script(
             'mollie_applepaydirect',
             $this->getPluginUrl($pluginUrl, '/public/js/applepayDirect.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/applepayDirect.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/applepayDirect.min.js')),
             true
         );
         wp_register_script(
             'mollie_paypalButton',
             $this->getPluginUrl($pluginUrl, '/public/js/paypalButton.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/paypalButton.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/paypalButton.min.js')),
             true
         );
         wp_register_script(
             'mollie_paypalButtonCart',
             $this->getPluginUrl($pluginUrl, '/public/js/paypalButtonCart.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/paypalButtonCart.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/paypalButtonCart.min.js')),
             true
         );
         wp_register_script(
             'mollie_applepaydirectCart',
             $this->getPluginUrl($pluginUrl, '/public/js/applepayDirectCart.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/applepayDirectCart.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/applepayDirectCart.min.js')),
             true
         );
         wp_register_script('mollie', 'https://js.mollie.com/v1/mollie.js', [], date("d"), true);
@@ -248,14 +251,14 @@ class AssetsModule implements ExecutableModule
             'mollie-components',
             $this->getPluginUrl($pluginUrl, '/public/js/mollie-components.min.js'),
             ['underscore', 'jquery', 'mollie', 'babel-polyfill'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollie-components.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/mollie-components.min.js')),
             true
         );
         wp_register_script(
             'mollie-components-blocks',
             $this->getPluginUrl($pluginUrl, '/public/js/mollie-components-blocks.min.js'),
             ['underscore', 'jquery', 'mollie', 'babel-polyfill'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollie-components-blocks.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/mollie-components-blocks.min.js')),
             true
         );
 
@@ -263,40 +266,39 @@ class AssetsModule implements ExecutableModule
             'unabledButton',
             $this->getPluginUrl($pluginUrl, '/public/css/unabledButton.min.css'),
             [],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/css/unabledButton.min.css')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/css/unabledButton.min.css')),
             'screen'
         );
         wp_register_script(
             'gatewaySurcharge',
             $this->getPluginUrl($pluginUrl, '/public/js/gatewaySurcharge.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/gatewaySurcharge.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/gatewaySurcharge.min.js')),
             true
         );
         wp_register_script(
             'mollie-billie-classic-handles',
             $this->getPluginUrl($pluginUrl, '/public/js/mollieBillie.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollieBillie.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/mollieBillie.min.js')),
             true
         );
         wp_register_script(
             'mollie-in3-classic-handles',
             $this->getPluginUrl($pluginUrl, '/public/js/mollieIn3.min.js'),
             ['underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollieIn3.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/mollieIn3.min.js')),
             true
         );
     }
 
     public function registerBlockScripts(string $pluginUrl, string $pluginPath): void
     {
-
         wp_register_script(
             'mollie_block_index',
             $this->getPluginUrl($pluginUrl, '/public/js/mollieBlockIndex.min.js'),
             ['wc-blocks-registry', 'underscore', 'jquery'],
-            (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollieBlockIndex.min.js')),
+            (string)filemtime($this->getPluginPath($pluginPath, '/public/js/mollieBlockIndex.min.js')),
             true
         );
     }
@@ -357,7 +359,7 @@ class AssetsModule implements ExecutableModule
         }
 
         $locale = get_locale();
-        $locale =  str_replace('_formal', '', $locale);
+        $locale = str_replace('_formal', '', $locale);
         $allowedLocaleValues = AcceptedLocaleValuesDictionary::ALLOWED_LOCALES_KEYS_MAP;
         if (!in_array($locale, $allowedLocaleValues, true)) {
             $locale = AcceptedLocaleValuesDictionary::DEFAULT_LOCALE_VALUE;
@@ -436,7 +438,10 @@ class AssetsModule implements ExecutableModule
      */
     protected function enqueueIconSettings(?string $current_section): void
     {
-        $uri = isset($_SERVER['REQUEST_URI']) ? wc_clean(wp_unslash($_SERVER['REQUEST_URI'])) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $uri = isset($_SERVER['REQUEST_URI']) ? wc_clean(
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+            wp_unslash($_SERVER['REQUEST_URI'])
+        ) : '';
         if (is_string($uri) && strpos($uri, 'tab=mollie_settings')) {
             wp_enqueue_style('mollie-gateway-icons');
         }
@@ -534,16 +539,27 @@ class AssetsModule implements ExecutableModule
         add_action(
             'woocommerce_blocks_loaded',
             function () use ($dataService, $gatewayInstances, $pluginUrl, $pluginPath, $hasBlocksEnabled) {
-                if ($hasBlocksEnabled && class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
+                if (
+                    $hasBlocksEnabled && is_admin() && class_exists(
+                        'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType'
+                    )
+                ) {
                     add_action(
                         'woocommerce_blocks_payment_method_type_registration',
-                        function (PaymentMethodRegistry $paymentMethodRegistry) use ($dataService, $gatewayInstances, $pluginUrl, $pluginPath) {
+                        function (PaymentMethodRegistry $paymentMethodRegistry) use (
+                            $dataService,
+                            $gatewayInstances,
+                            $pluginUrl,
+                            $pluginPath
+                        ) {
                             $paymentMethodRegistry->register(
                                 new MollieCheckoutBlocksSupport(
                                     $dataService,
                                     $gatewayInstances,
                                     $this->getPluginUrl($pluginUrl, '/public/js/mollieBlockIndex.min.js'),
-                                    (string) filemtime($this->getPluginPath($pluginPath, '/public/js/mollieBlockIndex.min.js'))
+                                    (string)filemtime(
+                                        $this->getPluginPath($pluginPath, '/public/js/mollieBlockIndex.min.js')
+                                    )
                                 )
                             );
                         }
@@ -554,7 +570,7 @@ class AssetsModule implements ExecutableModule
 
         add_action(
             'init',
-            function () use ($hasBlocksEnabled, $settingsHelper, $pluginUrl, $pluginPath) {
+            function () use ($container, $hasBlocksEnabled, $settingsHelper, $pluginUrl, $pluginPath, $dataService) {
                 self::registerFrontendScripts($pluginUrl, $pluginPath);
 
                 // Enqueue Scripts
@@ -568,6 +584,12 @@ class AssetsModule implements ExecutableModule
                 });
 
                 if ($hasBlocksEnabled) {
+                    /** @var array */
+                    $gatewayInstances = $container->get('gateway.instances');
+                    self::registerBlockScripts($pluginUrl, $pluginPath);
+                    add_action('wp_enqueue_scripts', function () use ($dataService, $gatewayInstances) {
+                        $this->enqueueBlockCheckoutScripts($dataService, $gatewayInstances);
+                    });
                     $this->registerButtonsBlockScripts($pluginUrl, $pluginPath);
                 }
             }
@@ -614,12 +636,6 @@ class AssetsModule implements ExecutableModule
                         $pluginVersion,
                         true
                     );
-
-                    if ($hasBlocksEnabled) {
-                        /** @var array */
-                        $gatewayInstances = $container->get('gateway.instances');
-                        $this->enqueueBlockCheckoutScripts($dataService, $gatewayInstances);
-                    }
 
                     $this->enqueueIconSettings($current_section);
                 }

--- a/src/Assets/MollieCheckoutBlocksSupport.php
+++ b/src/Assets/MollieCheckoutBlocksSupport.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Mollie\WooCommerce\Assets;
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use Mollie\WooCommerce\Gateway\MolliePaymentGateway;
+use Mollie\WooCommerce\Gateway\MolliePaymentGatewayI;
+use Mollie\WooCommerce\PaymentMethods\PaymentMethodI;
+use Mollie\WooCommerce\Shared\Data;
+
+final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
+{
+    protected $name = "mollie";
+    /** @var string $scriptHandle */
+    protected $scriptHandle = "mollie_block_index";
+
+    /** @var Data */
+    protected $dataService;
+    /** @var array */
+    protected $gatewayInstances;
+    /** @var string $registerScriptUrl */
+    protected $registerScriptUrl;
+    /** @var string $registerScriptVersion */
+    protected $registerScriptVersion;
+    public function __construct(Data $dataService, array $gatewayInstances, string $registerScriptUrl, string $registerScriptVersion)
+    {
+        $this->dataService = $dataService;
+        $this->gatewayInstances = $gatewayInstances;
+        $this->registerScriptUrl = $registerScriptUrl;
+        $this->registerScriptVersion = $registerScriptVersion;
+    }
+
+    public function initialize()
+    {
+        //
+    }
+
+    public function get_payment_method_script_handles()
+    {
+        wp_register_script(
+            $this->scriptHandle,
+            $this->registerScriptUrl,
+            ['wc-blocks-registry', 'underscore', 'jquery'],
+            $this->registerScriptVersion,
+            true
+        );
+
+        wp_localize_script(
+            $this->scriptHandle,
+            'mollieBlockData',
+            [
+                'gatewayData' => $this->gatewayDataForWCBlocks($this->dataService, $this->gatewayInstances),
+            ]
+        );
+        return [$this->scriptHandle];
+    }
+
+    public function get_payment_method_data()
+    {
+        return [
+            'title' => "Credit card",
+            'description' => "Credit card description",
+            'supports' => $this->get_supported_features(),
+        ];
+    }
+
+    private function gatewayDataForWCBlocks(Data $dataService, array $gatewayInstances): array
+    {
+        $filters = $dataService->wooCommerceFiltersForCheckout();
+        $availableGateways = WC()->payment_gateways()->get_available_payment_gateways();
+        $availablePaymentMethods = [];
+        /**
+         * @var MolliePaymentGatewayI $gateway
+         * psalm-suppress  UnusedForeachValue
+         */
+        foreach ($availableGateways as $key => $gateway) {
+            if (strpos($key, 'mollie_wc_gateway_') === false) {
+                unset($availableGateways[$key]);
+            }
+        }
+        if (
+            isset($filters['amount']['currency'])
+            && isset($filters['locale'])
+            && isset($filters['billingCountry'])
+        ) {
+            $filterKey = "{$filters['amount']['currency']}-{$filters['locale']}-{$filters['billingCountry']}";
+            foreach ($availableGateways as $key => $gateway) {
+                $availablePaymentMethods[$filterKey][$key] = $gateway->paymentMethod()->getProperty('id');
+            }
+        }
+
+        $dataToScript = [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'filters' => [
+                'currency' => isset($filters['amount']['currency']) ? $filters['amount']['currency'] : false,
+                'cartTotal' => isset($filters['amount']['value']) ? $filters['amount']['value'] : false,
+                'paymentLocale' => isset($filters['locale']) ? $filters['locale'] : false,
+                'billingCountry' => isset($filters['billingCountry']) ? $filters['billingCountry'] : false,
+            ],
+        ];
+        $gatewayData = [];
+        $isSepaEnabled = isset($gatewayInstances['mollie_wc_gateway_directdebit']) && $gatewayInstances['mollie_wc_gateway_directdebit']->enabled === 'yes';
+        /** @var MolliePaymentGateway $gateway */
+        foreach ($gatewayInstances as $gatewayKey => $gateway) {
+            /** @var string $gatewayId */
+            $gatewayId = is_string($gateway->paymentMethod()->getProperty('id')) ? $gateway->paymentMethod(
+            )->getProperty('id') : "";
+
+            if ($gateway->enabled !== 'yes' || $gatewayId === 'directdebit') {
+                continue;
+            }
+            $content = $gateway->paymentMethod()->getProcessedDescriptionForBlock();
+            $issuers = false;
+            if ($gateway->paymentMethod()->getProperty('paymentFields') === true) {
+                $paymentFieldsService = $gateway->paymentMethod()->paymentFieldsService();
+                $paymentFieldsService->setStrategy($gateway->paymentMethod());
+                $issuers = $gateway->paymentMethod()->paymentFieldsService()->getStrategyMarkup($gateway);
+            }
+            if ($gatewayId === 'creditcard') {
+                $content .= $issuers;
+                $issuers = false;
+            }
+            $title = $gateway->paymentMethod()->title();
+            $labelMarkup = "<span style='margin-right: 1em'>{$title}</span>{$gateway->icon}";
+            $hasSurcharge = $gateway->paymentMethod()->hasSurcharge();
+            $gatewayData[] = [
+                'name' => $gatewayKey,
+                'label' => $labelMarkup,
+                'content' => $content,
+                'issuers' => $issuers,
+                'hasSurcharge' => $hasSurcharge,
+                'title' => $title,
+                'contentFallback' => __(
+                    'Please choose a billing country to see the available payment methods',
+                    'mollie-payments-for-woocommerce'
+                ),
+                'edit' => $content,
+                'paymentMethodId' => $gatewayKey,
+                'allowedCountries' => is_array(
+                    $gateway->paymentMethod()->getProperty('allowed_countries')
+                ) ? $gateway->paymentMethod()->getProperty('allowed_countries') : [],
+                'ariaLabel' => $gateway->paymentMethod()->getProperty('defaultDescription'),
+                'supports' => $this->gatewaySupportsFeatures($gateway->paymentMethod(), $isSepaEnabled),
+                'errorMessage' => $gateway->paymentMethod()->getProperty('errorMessage'),
+                'companyPlaceholder' => $gateway->paymentMethod()->getProperty('companyPlaceholder'),
+                'phonePlaceholder' => $gateway->paymentMethod()->getProperty('phonePlaceholder'),
+                'birthdatePlaceholder' => $gateway->paymentMethod()->getProperty('birthdatePlaceholder'),
+            ];
+        }
+        $dataToScript['gatewayData'] = $gatewayData;
+        $dataToScript['availableGateways'] = $availablePaymentMethods;
+
+        return $dataToScript;
+    }
+
+    public function gatewaySupportsFeatures(PaymentMethodI $paymentMethod, bool $isSepaEnabled): array
+    {
+        $supports = (array)$paymentMethod->getProperty('supports');
+        $isSepaPaymentMethod = (bool)$paymentMethod->getProperty('SEPA');
+        if ($isSepaEnabled && $isSepaPaymentMethod) {
+            array_push($supports, 'subscriptions');
+        }
+
+        return $supports;
+    }
+}

--- a/src/Assets/MollieCheckoutBlocksSupport.php
+++ b/src/Assets/MollieCheckoutBlocksSupport.php
@@ -13,7 +13,6 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
     protected $name = "mollie";
     /** @var string $scriptHandle */
     protected $scriptHandle = "mollie_block_index";
-
     /** @var Data */
     protected $dataService;
     /** @var array */
@@ -22,8 +21,13 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
     protected $registerScriptUrl;
     /** @var string $registerScriptVersion */
     protected $registerScriptVersion;
-    public function __construct(Data $dataService, array $gatewayInstances, string $registerScriptUrl, string $registerScriptVersion)
-    {
+
+    public function __construct(
+        Data $dataService,
+        array $gatewayInstances,
+        string $registerScriptUrl,
+        string $registerScriptVersion
+    ) {
         $this->dataService = $dataService;
         $this->gatewayInstances = $gatewayInstances;
         $this->registerScriptUrl = $registerScriptUrl;
@@ -35,7 +39,7 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
         //
     }
 
-    public function get_payment_method_script_handles()
+    public function get_payment_method_script_handles(): array
     {
         wp_register_script(
             $this->scriptHandle,
@@ -53,15 +57,6 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
             ]
         );
         return [$this->scriptHandle];
-    }
-
-    public function get_payment_method_data()
-    {
-        return [
-            'title' => "Credit card",
-            'description' => "Credit card description",
-            'supports' => $this->get_supported_features(),
-        ];
     }
 
     private function gatewayDataForWCBlocks(Data $dataService, array $gatewayInstances): array
@@ -102,7 +97,6 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
         $isSepaEnabled = isset($gatewayInstances['mollie_wc_gateway_directdebit']) && $gatewayInstances['mollie_wc_gateway_directdebit']->enabled === 'yes';
         /** @var MolliePaymentGateway $gateway */
         foreach ($gatewayInstances as $gatewayKey => $gateway) {
-            /** @var string $gatewayId */
             $gatewayId = is_string($gateway->paymentMethod()->getProperty('id')) ? $gateway->paymentMethod(
             )->getProperty('id') : "";
 
@@ -158,7 +152,7 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
         $supports = (array)$paymentMethod->getProperty('supports');
         $isSepaPaymentMethod = (bool)$paymentMethod->getProperty('SEPA');
         if ($isSepaEnabled && $isSepaPaymentMethod) {
-            array_push($supports, 'subscriptions');
+            $supports[] = 'subscriptions';
         }
 
         return $supports;

--- a/src/Assets/MollieCheckoutBlocksSupport.php
+++ b/src/Assets/MollieCheckoutBlocksSupport.php
@@ -100,7 +100,7 @@ final class MollieCheckoutBlocksSupport extends AbstractPaymentMethodType
             $gatewayId = is_string($gateway->paymentMethod()->getProperty('id')) ? $gateway->paymentMethod(
             )->getProperty('id') : "";
 
-            if ($gateway->enabled !== 'yes' || $gatewayId === 'directdebit') {
+            if ($gateway->enabled !== 'yes' || ($gatewayId === 'directdebit' && !is_admin())) {
                 continue;
             }
             $content = $gateway->paymentMethod()->getProcessedDescriptionForBlock();


### PR DESCRIPTION
Woocommerce checkout blocks require implementation of the following class: `Automattic\WooCommerce\Blocks\Payments\Integration\AbstractPaymentMethodType`

I implemented a class `MollieCheckoutBlocksSupport.php` which extends `AbstractPaymentMethodType` and registered its object using `PaymentMethodRegistry` in `woocommerce_blocks_payment_method_type_registration` hook. 

Some of the code was removed from the AssetModule and some of the code was moved from the AssetsModule to the MollieCheckoutBlocksSupport. 

Additionally I updated Woocommerce stubs and included `<file name="vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php"/>` in psalm.xml.
