### PR TITLE
[PIWOO-349] Show notice to user if payment is not successful on the Pay for order page.

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -18,6 +18,7 @@ use Mollie\WooCommerce\Buttons\PayPalButton\PayPalAjaxRequests;
 use Mollie\WooCommerce\Buttons\PayPalButton\PayPalButtonHandler;
 use Mollie\WooCommerce\Gateway\Voucher\MaybeDisableGateway;
 use Mollie\WooCommerce\Notice\AdminNotice;
+use Mollie\WooCommerce\Notice\FrontendNotice;
 use Mollie\WooCommerce\Notice\NoticeInterface;
 use Mollie\WooCommerce\Payment\MollieObject;
 use Mollie\WooCommerce\Payment\MollieOrderService;
@@ -495,8 +496,8 @@ class GatewayModule implements ServiceModule, ExecutableModule
     {
         $logger = $container->get(Logger::class);
         assert($logger instanceof Logger);
-        $notice = $container->get(AdminNotice::class);
-        assert($notice instanceof AdminNotice);
+        $notice = $container->get(FrontendNotice::class);
+        assert($notice instanceof FrontendNotice);
         $paymentService = $container->get(PaymentService::class);
         assert($paymentService instanceof PaymentService);
         $mollieOrderService = $container->get(MollieOrderService::class);

--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -570,6 +570,12 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                 if ($order_status_cancelled_payments === 'cancelled') {
                     return $this->get_return_url($order);
                 } else {
+
+                    wc_add_notice(__(
+                                      'You have cancelled your payment. Please complete your order with a different payment method.',
+                                      'mollie-payments-for-woocommerce'
+                                  ), "error");
+
                     $this->notice->addNotice(
                         'notice',
                         __(
@@ -591,6 +597,12 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                     && !$payment->isPaid()
                     && !$payment->isAuthorized()
                 ) {
+
+                    wc_add_notice(__(
+                                      'Your payment was not successful. Please complete your order with a different payment method.',
+                                      'mollie-payments-for-woocommerce'
+                                  ), "error");
+
                     $this->notice->addNotice(
                         'notice',
                         __(
@@ -605,6 +617,12 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                     $this->paymentMethod->debugGiftcardDetails($payment, $order);
                 }
             } catch (UnexpectedValueException $exc) {
+
+                wc_add_notice(__(
+                                  'Your payment was not successful. Please complete your order with a different payment method.',
+                                  'mollie-payments-for-woocommerce'
+                              ), "error");
+
                 $this->notice->addNotice(
                     'notice',
                     __(

--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -570,12 +570,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                 if ($order_status_cancelled_payments === 'cancelled') {
                     return $this->get_return_url($order);
                 } else {
-
-                    wc_add_notice(__(
-                                      'You have cancelled your payment. Please complete your order with a different payment method.',
-                                      'mollie-payments-for-woocommerce'
-                                  ), "error");
-
+                    wc_add_notice(__('You have cancelled your payment. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'), "error");
                     $this->notice->addNotice(
                         'notice',
                         __(
@@ -583,7 +578,6 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                             'mollie-payments-for-woocommerce'
                         )
                     );
-
                     // Return to order payment page
                     return $failedRedirect;
                 }
@@ -597,12 +591,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                     && !$payment->isPaid()
                     && !$payment->isAuthorized()
                 ) {
-
-                    wc_add_notice(__(
-                                      'Your payment was not successful. Please complete your order with a different payment method.',
-                                      'mollie-payments-for-woocommerce'
-                                  ), "error");
-
+                    wc_add_notice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'), "error");
                     $this->notice->addNotice(
                         'notice',
                         __(
@@ -617,12 +606,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                     $this->paymentMethod->debugGiftcardDetails($payment, $order);
                 }
             } catch (UnexpectedValueException $exc) {
-
-                wc_add_notice(__(
-                                  'Your payment was not successful. Please complete your order with a different payment method.',
-                                  'mollie-payments-for-woocommerce'
-                              ), "error");
-
+                wc_add_notice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'), "error");
                 $this->notice->addNotice(
                     'notice',
                     __(

--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -570,9 +570,8 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                 if ($order_status_cancelled_payments === 'cancelled') {
                     return $this->get_return_url($order);
                 } else {
-                    wc_add_notice(__('You have cancelled your payment. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'), "error");
                     $this->notice->addNotice(
-                        'notice',
+                        'error',
                         __(
                             'You have cancelled your payment. Please complete your order with a different payment method.',
                             'mollie-payments-for-woocommerce'
@@ -591,9 +590,8 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                     && !$payment->isPaid()
                     && !$payment->isAuthorized()
                 ) {
-                    wc_add_notice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'), "error");
                     $this->notice->addNotice(
-                        'notice',
+                        'error',
                         __(
                             'Your payment was not successful. Please complete your order with a different payment method.',
                             'mollie-payments-for-woocommerce'
@@ -606,9 +604,8 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
                     $this->paymentMethod->debugGiftcardDetails($payment, $order);
                 }
             } catch (UnexpectedValueException $exc) {
-                wc_add_notice(__('Your payment was not successful. Please complete your order with a different payment method.', 'mollie-payments-for-woocommerce'), "error");
                 $this->notice->addNotice(
-                    'notice',
+                    'error',
                     __(
                         'Your payment was not successful. Please complete your order with a different payment method.',
                         'mollie-payments-for-woocommerce'

--- a/src/Notice/FrontendNotice.php
+++ b/src/Notice/FrontendNotice.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\Notice;
+
+class FrontendNotice implements NoticeInterface
+{
+    public function addNotice($level, $message): void
+    {
+        wc_add_notice($message, $level);
+    }
+}

--- a/src/Notice/NoticeModule.php
+++ b/src/Notice/NoticeModule.php
@@ -8,9 +8,6 @@ namespace Mollie\WooCommerce\Notice;
 
 use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use Inpsyde\Modularity\Module\ServiceModule;
-use Mollie\WooCommerce\Notice\AdminNotice;
-use Psr\Container\ContainerInterface;
-use Mollie\WooCommerce\Notice\NoticeInterface as Notice;
 
 class NoticeModule implements ServiceModule
 {
@@ -21,6 +18,9 @@ class NoticeModule implements ServiceModule
         return [
             AdminNotice::class => static function (): AdminNotice {
                 return new AdminNotice();
+            },
+            FrontendNotice::class => static function (): FrontendNotice {
+                return new FrontendNotice();
             },
         ];
     }

--- a/src/Payment/PaymentService.php
+++ b/src/Payment/PaymentService.php
@@ -717,7 +717,7 @@ class PaymentService
             $message .= 'hii ' . $e->getMessage();
         }
 
-        add_action('before_woocommerce_pay_form', function() use($message){
+        add_action('before_woocommerce_pay_form', static function () use ($message) {
             wc_print_notice($message, 'error');
         });
     }

--- a/src/Payment/PaymentService.php
+++ b/src/Payment/PaymentService.php
@@ -717,7 +717,9 @@ class PaymentService
             $message .= 'hii ' . $e->getMessage();
         }
 
-        $this->notice->addNotice('error', $message);
+        add_action('before_woocommerce_pay_form', function() use($message){
+            wc_print_notice($message, 'error');
+        });
     }
 
     /**


### PR DESCRIPTION
I created a new Notice type - FrontendNotice. This notice is sent to MolliePaymantGateway as a substitute for AdminNotice. 
It should show an error on the Pay for order page. 

Please check if this implementation could cause issue on the `\Mollie\WooCommerce\Gateway\MolliePaymentGateway::noOrderPaymentFailure` method. 