### PR TITLE
Retrieve gateway icons from Mollie

### DIFF
--- a/resources/scss/mollie-gateway-icons.scss
+++ b/resources/scss/mollie-gateway-icons.scss
@@ -1,9 +1,10 @@
 .mollie-gateway-icon {
   vertical-align: bottom;
-  height: 24px;
 }
 label .mollie-gateway-icon{
   float:right;
+  max-width: 32px;
+  max-height: 24px;
 }
 .mollie-gateway-icon svg{
   float:right;

--- a/src/Assets/AssetsModule.php
+++ b/src/Assets/AssetsModule.php
@@ -646,7 +646,6 @@ class AssetsModule implements ExecutableModule
                 // Enqueue Scripts
                 add_action('wp_enqueue_scripts', function () use ($container) {
                     $this->enqueueFrontendScripts($container);
-
                 });
                 add_action('wp_enqueue_scripts', function () use ($settingsHelper) {
                     $this->enqueueComponentsAssets($settingsHelper);

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -65,7 +65,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
 
     public function title(): string
     {
-        $useApiTitle = apply_filters('mollie_wc_gateway_use_api_title', $this->isUseApiTitleChecked(),$this->id);
+        $useApiTitle = apply_filters('mollie_wc_gateway_use_api_title', $this->isUseApiTitleChecked(), $this->id);
         $title = $this->getProperty('title');
         //new installations should use the api title
         if ($useApiTitle || $title === false) {

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -90,7 +90,8 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         return $settings["iconFileUrl"] ?? null;
     }
 
-    public function isCreditCardSelectorEnabled(){
+    public function isCreditCardSelectorEnabled()
+    {
         $settings = $this->getSettings();
         return isset($settings[PaymentMethodsIconUrl::MOLLIE_CREDITCARD_ICONS_ENABLER]) ? $settings[PaymentMethodsIconUrl::MOLLIE_CREDITCARD_ICONS_ENABLER] === "yes" :  null;
     }
@@ -129,8 +130,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
      */
     public function getIconUrl(): string
     {
-
-        if($uploadedImageUrl = $this->getUploadedImage()){
+        if ($uploadedImageUrl = $this->getUploadedImage()) {
             return $this->iconFactory->getExternalIconHtml($uploadedImageUrl);
         }
 

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -65,7 +65,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
 
     public function title(): string
     {
-        $useApiTitle = $this->getProperty(SharedDataDictionary::USE_API_TITLE) === 'yes';
+        $useApiTitle = apply_filters('mollie_wc_gateway_use_api_title', $this->isUseApiTitleChecked(),$this->id);
         $title = $this->getProperty('title');
         //new installations should use the api title
         if ($useApiTitle || $title === false) {
@@ -134,7 +134,9 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
             return $this->iconFactory->getExternalIconHtml($uploadedImageUrl);
         }
 
-        if (isset($this->apiPaymentMethod["image"]) && property_exists($this->apiPaymentMethod["image"], "svg") && !$this->isCreditCardSelectorEnabled()) {
+        $useAPIImage = apply_filters('mollie_wc_gateway_use_api_image', $this->isUseApiTitleChecked(), $this->id);
+
+        if (isset($this->apiPaymentMethod["image"]) && property_exists($this->apiPaymentMethod["image"], "svg") && !$this->isCreditCardSelectorEnabled() && $useAPIImage) {
             return $this->iconFactory->getExternalIconHtml($this->apiPaymentMethod["image"]->svg);
         }
         return $this->iconFactory->getIconUrl(
@@ -322,6 +324,11 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
     {
         $apiTitle = $this->apiPaymentMethod['description'] ?? null;
         return $apiTitle ?: $this->config['defaultTitle'];
+    }
+
+    private function isUseApiTitleChecked(): bool
+    {
+        return $this->getProperty(SharedDataDictionary::USE_API_TITLE_AND_IMAGE) === 'yes';
     }
 
     protected function titleIsDefault(): bool

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -134,7 +134,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
             return $this->iconFactory->getExternalIconHtml($uploadedImageUrl);
         }
 
-        $useAPIImage = apply_filters('mollie_wc_gateway_use_api_image', $this->isUseApiTitleChecked(), $this->id);
+        $useAPIImage = apply_filters('mollie_wc_gateway_use_api_icon', $this->isUseApiTitleChecked(), $this->id);
 
         if (isset($this->apiPaymentMethod["image"]) && property_exists($this->apiPaymentMethod["image"], "svg") && !$this->isCreditCardSelectorEnabled() && $useAPIImage) {
             return $this->iconFactory->getExternalIconHtml($this->apiPaymentMethod["image"]->svg);

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -117,6 +117,9 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
      */
     public function getIconUrl(): string
     {
+        if (isset($this->apiPaymentMethod["image"]) && property_exists($this->apiPaymentMethod["image"], "svg")) {
+            return $this->iconFactory->getExternalIconHtml($this->apiPaymentMethod["image"]->svg);
+        }
         return $this->iconFactory->getIconUrl(
             $this->getIdFromConfig()
         );

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -83,6 +83,18 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         return $this->getConfig()['id'];
     }
 
+    public function getUploadedImage()
+    {
+        $settings = $this->getSettings();
+
+        return $settings["iconFileUrl"] ?? null;
+    }
+
+    public function isCreditCardSelectorEnabled(){
+        $settings = $this->getSettings();
+        return isset($settings[PaymentMethodsIconUrl::MOLLIE_CREDITCARD_ICONS_ENABLER]) ? $settings[PaymentMethodsIconUrl::MOLLIE_CREDITCARD_ICONS_ENABLER] === "yes" :  null;
+    }
+
     /**
      * Access the payment method surcharge applied
      * @return Surcharge
@@ -117,7 +129,12 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
      */
     public function getIconUrl(): string
     {
-        if (isset($this->apiPaymentMethod["image"]) && property_exists($this->apiPaymentMethod["image"], "svg")) {
+
+        if($uploadedImageUrl = $this->getUploadedImage()){
+            return $this->iconFactory->getExternalIconHtml($uploadedImageUrl);
+        }
+
+        if (isset($this->apiPaymentMethod["image"]) && property_exists($this->apiPaymentMethod["image"], "svg") && !$this->isCreditCardSelectorEnabled()) {
             return $this->iconFactory->getExternalIconHtml($this->apiPaymentMethod["image"]->svg);
         }
         return $this->iconFactory->getIconUrl(
@@ -268,6 +285,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
     {
         return array_merge($this->config, $this->getSettings());
     }
+
     /**
      * Default values for the initial settings saved
      *

--- a/src/PaymentMethods/IconFactory.php
+++ b/src/PaymentMethods/IconFactory.php
@@ -28,6 +28,11 @@ class IconFactory
         return $this->iconFactory()->svgUrlForPaymentMethod($paymentMethodName);
     }
 
+    public function getExternalIconHtml($svgIconUrl): string
+    {
+        return $this->iconFactory()->generateIconHtml($svgIconUrl);
+    }
+
     /**
      * Singleton of the class that handles icons (API/fallback)
      * @return PaymentMethodsIconUrl|null

--- a/src/PaymentMethods/PaymentMethodsIconUrl.php
+++ b/src/PaymentMethods/PaymentMethodsIconUrl.php
@@ -84,6 +84,12 @@ class PaymentMethodsIconUrl
             $svgUrl = $this->pluginUrl . '/' . sprintf('public/images/%s', $paymentMethodName) . self::SVG_FILE_EXTENSION;
         }
 
+        return $this->generateIconHtml($svgUrl);
+    }
+
+    public function generateIconHtml($svgUrl)
+    {
+
         return '<img src="' . esc_url($svgUrl)
             . '" class="mollie-gateway-icon" />';
     }

--- a/src/Settings/General/MollieGeneralSettings.php
+++ b/src/Settings/General/MollieGeneralSettings.php
@@ -53,11 +53,11 @@ class MollieGeneralSettings
             ],
             'use_api_title' => [
                 'title' => __(
-                    'Use API dynamic title',
+                    'Use API dynamic title and gateway logo',
                     'mollie-payments-for-woocommerce'
                 ),
                 'type' => 'checkbox',
-                'label' => __('Retrieve the gateway title from Mollie', 'mollie-payments-for-woocommerce'),
+                'label' => __('Retrieve the gateway title and logo from the Mollie API', 'mollie-payments-for-woocommerce'),
                 'default' => 'no',
             ],
             'description' => [

--- a/src/Shared/SharedDataDictionary.php
+++ b/src/Shared/SharedDataDictionary.php
@@ -140,5 +140,5 @@ class SharedDataDictionary
     /**
      * @var string
      */
-    public const USE_API_TITLE = 'use_api_title';
+    public const USE_API_TITLE_AND_IMAGE = 'use_api_title';
 }


### PR DESCRIPTION
I changed the `\Mollie\WooCommerce\PaymentMethods\AbstractPaymentMethod::getIconUrl` method. It prioritises the image from API payment method. Icons will be loaded directly from the Mollie URL. 