### PR TITLE
Fix Site is broken on bulk edit when Mollie Voucher is activated

### DIFF
--- a/src/Gateway/Voucher/VoucherModule.php
+++ b/src/Gateway/Voucher/VoucherModule.php
@@ -128,7 +128,11 @@ class VoucherModule implements ExecutableModule, ServiceModule
     {
         $post_id = $product->get_id();
         $optionName = Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION;
-        check_ajax_referer('inlineeditnonce', '_inline_edit');
+
+        if (wp_doing_ajax()) {
+            check_ajax_referer('inlineeditnonce', '_inline_edit');
+        }
+
         if (isset($_REQUEST[$optionName])) {
             $option = filter_var(wp_unslash($_REQUEST[$optionName]), FILTER_SANITIZE_SPECIAL_CHARS);
             update_post_meta($post_id, $optionName, wc_clean($option));


### PR DESCRIPTION
Because of the `check_ajax_referer` bulk edit exited and returned -1 when Mollie Voucher was enabled.

Now we check if wp_doing_ajax before check_ajax_referer. In that case, bulk edit works as expected. 