### PR TITLE
Replace backend ApplePay filtering with the frontend filtering.

### DIFF
--- a/resources/js/applepay.js
+++ b/resources/js/applepay.js
@@ -1,27 +1,31 @@
 (function (ApplePaySession) {
 
-  document.addEventListener('DOMContentLoaded', function () {
-    var applePayMethodElement = document.querySelector(
-      '.payment_method_mollie_wc_gateway_applepay',
-    )
+  document.addEventListener('DOMContentLoaded', hideApplyPaymentMethodIfCantPay)
+  jQuery("body").on("updated_checkout", hideApplyPaymentMethodIfCantPay);
 
-    var woocommerceCheckoutForm = document.querySelector(
-      'form.woocommerce-checkout',
-    )
 
-    if (!woocommerceCheckoutForm) {
-      return
-    }
+  function hideApplyPaymentMethodIfCantPay(){
+      var applePayMethodElement = document.querySelector(
+          '.payment_method_mollie_wc_gateway_applepay',
+      )
 
-    if (!ApplePaySession || !ApplePaySession.canMakePayments()) {
-      applePayMethodElement &&
-      applePayMethodElement.parentNode.removeChild(applePayMethodElement)
-      return
-    }
+      var woocommerceCheckoutForm = document.querySelector(
+          'form.woocommerce-checkout, #order_review'
+      )
 
-    woocommerceCheckoutForm.insertAdjacentHTML(
-      'beforeend',
-      '<input type="hidden" name="mollie_apple_pay_method_allowed" value="1" />',
-    )
-  })
+      if (!woocommerceCheckoutForm) {
+          return
+      }
+
+      if (!ApplePaySession || !ApplePaySession.canMakePayments()) {
+          applePayMethodElement &&
+          applePayMethodElement.parentNode.removeChild(applePayMethodElement)
+          return
+      }
+
+      woocommerceCheckoutForm.insertAdjacentHTML(
+          'beforeend',
+          '<input type="hidden" name="mollie_apple_pay_method_allowed" value="1" />',
+      )
+  }
 })(window.ApplePaySession)

--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -196,7 +196,6 @@ class GatewayModule implements ServiceModule, ExecutableModule
             $mollieGateways = $container->get('gateway.instances');
             return array_merge($gateways, $mollieGateways);
         });
-        add_filter('woocommerce_payment_gateways', [$this, 'maybeDisableApplePayGateway'], 20);
         add_filter('woocommerce_payment_gateways', static function ($gateways) use ($container) {
             $orderMandatoryGatewayDisabler = $container->get(OrderMandatoryGatewayDisabler::class);
             assert($orderMandatoryGatewayDisabler instanceof OrderMandatoryGatewayDisabler);
@@ -347,58 +346,6 @@ class GatewayModule implements ServiceModule, ExecutableModule
         unset($gateways[$bankTransferGatewayClassName]);
 
         return  $gateways;
-    }
-
-    /**
-     * Disable Apple Pay Gateway
-     *
-     * @param ?array $gateways
-     * @return array
-     */
-    public function maybeDisableApplePayGateway(?array $gateways): array
-    {
-        if (!is_array($gateways)) {
-            return [];
-        }
-        $isWcApiRequest = (bool)filter_input(INPUT_GET, 'wc-api', FILTER_SANITIZE_SPECIAL_CHARS);
-        $wooCommerceSession = mollieWooCommerceSession();
-
-        /*
-         * There is only one case where we want to filter the gateway and it's when the checkout
-         * page render the available payments methods.
-         *
-         * For any other case we want to be sure apple pay gateway is included.
-         */
-        if (
-            $isWcApiRequest ||
-            !$wooCommerceSession instanceof \WC_Session ||
-            !doing_action('woocommerce_payment_gateways') ||
-            !wp_doing_ajax() && ! is_wc_endpoint_url('order-pay') ||
-            is_admin()
-        ) {
-            return $gateways;
-        }
-
-        if ($wooCommerceSession->get(self::APPLE_PAY_METHOD_ALLOWED_KEY, false)) {
-            return $gateways;
-        }
-
-        $applePayGatewayClassName = 'mollie_wc_gateway_applepay';
-        // phpcs:ignore
-        $postData = isset($_POST[self::POST_DATA_KEY]) ? wc_clean(wp_unslash($_POST[self::POST_DATA_KEY])) : '';
-        parse_str($postData, $postData);
-        $applePayAllowed = isset($postData[self::APPLE_PAY_METHOD_ALLOWED_KEY])
-            && $postData[self::APPLE_PAY_METHOD_ALLOWED_KEY];
-
-        if (!$applePayAllowed) {
-            unset($gateways[$applePayGatewayClassName]);
-        }
-
-        if ($applePayAllowed) {
-            $wooCommerceSession->set(self::APPLE_PAY_METHOD_ALLOWED_KEY, true);
-        }
-
-        return $gateways;
     }
 
     public function gatewaySurchargeHandling(Surcharge $surcharge)


### PR DESCRIPTION
I completely removed the method `\Mollie\WooCommerce\Gateway\GatewayModule::maybeDisableApplePayGateway`. It was not working anymore. Apple Pay is now removed on the frontend using Javascript and Apple Pay JS. `applepay.js` script handles **checkout** and **pay for order** page.