### PR TITLE
Fix/piwoo 278

### DIFF
--- a/resources/js/gatewaySurcharge.js
+++ b/resources/js/gatewaySurcharge.js
@@ -30,26 +30,21 @@
                         },
                         success: (response) => {
                             let result = response.data
-
-                            if(result){
-                                const productTotal = "</th><td class='product-total'><span class='woocommerce-Price-amount amount'><bdi><span class='woocommerce-Price-currencySymbol'>"+ result.currency +"</span>"+ result.newTotal +"</bdi></span></td>"
-
-                                if(!result.amount){
-                                    if($('#order_review table:first-child tfoot tr').text().indexOf(gatewayLabel) !== -1){
-                                        $('#order_review table:first-child tfoot tr:contains("' +  gatewayLabel + '")').remove()
-                                        $('#order_review table:first-child tfoot tr:last td').replaceWith(productTotal)
-                                    }
-                                }else{
-                                    const tableRow = "<tr><th scope='row' colspan='2'>"+ result.name + "</th><td class='product-total'><span class='woocommerce-Price-amount amount'><bdi><span class='woocommerce-Price-currencySymbol'>"+ result.currency +"</span>"+ (result.amount).toFixed(2) +"</bdi></span></td></tr>"
-                                    if($('#order_review table:first-child tfoot tr').text().indexOf(gatewayLabel) !== -1){
-                                        $('#order_review table:first-child tfoot tr:contains("' +  gatewayLabel + '")').replaceWith(tableRow)
-                                        $('#order_review table:first-child tfoot tr:last td').replaceWith(productTotal)
-                                    }else{
-                                        $('#order_review table:first-child tfoot tr:first').after(tableRow)
-                                        $('#order_review table:first-child tfoot tr:last td').replaceWith(productTotal)
-                                    }
-                                }
+                            if(!result?.template){
+                                console.warn("Missing template in the response.");
+                                return;
                             }
+
+                            const {template} = result;
+                            const DOMTemplate = jQuery.parseHTML(template);
+                            const newShopTable = jQuery(DOMTemplate).find(".shop_table");
+
+                            if(!newShopTable.length){
+                                console.warn("Template changed, can't update the totals.");
+                                return;
+                            }
+
+                            jQuery(".shop_table").html(jQuery(newShopTable).html());
                         },
                         error: (jqXHR, textStatus, errorThrown) => {
                             console.warn(textStatus, errorThrown)

--- a/tests/php/Functional/Shared/SurchargeHandlerTest.php
+++ b/tests/php/Functional/Shared/SurchargeHandlerTest.php
@@ -76,57 +76,6 @@ class SurchargeHandlerTest extends TestCase
      *
      * @test
      */
-    public function addsSurchargeFeesInOrderPayPage()
-    {
-        $paymentSurcharge = Surcharge::FIXED_FEE;
-        $fixedFee = 10.00;
-        $percentage = 0;
-        $feeLimit = 1;
-        $expectedLabel = 'Gateway Fee';
-        $expectedAmount =  10.00;
-        $newTotal = 20.00;
-        $expectedData = [
-            'amount' => $expectedAmount,
-            'name' => $expectedLabel,
-            'currency' => 'EUR',
-            'newTotal' => $newTotal,
-        ];
-        expect('get_option')->andReturn(
-            'Gateway Fee', $this->helperMocks->paymentMethodSettings(
-                [
-                    'payment_surcharge' => $paymentSurcharge,
-                    'surcharge_limit' => $feeLimit,
-                    'fixed_fee' => $fixedFee,
-                    'percentage' => $percentage,
-                ]
-            )
-        );
-        $testee = $this->buildTesteeMock(
-            GatewaySurchargeHandler::class,
-            [new Surcharge()],
-            ['canProcessOrder', 'canProcessGateway', 'orderRemoveFee', 'orderAddFee']
-        )->getMock();
-
-        $testee->expects($this->once())
-            ->method('canProcessOrder')
-            ->willReturn($this->wcOrder(1,'key1'));
-
-        $testee->expects($this->once())
-            ->method('canProcessGateway')
-            ->willReturn('mollie_wc_gateway_ideal');
-        expect('wc_tax_enabled')->andReturn(false);
-        //this method uses all woo functions outside our scope
-        $testee->expects($this->once())
-            ->method('orderRemoveFee');
-
-        //this method uses all woo functions outside our scope
-        $testee->expects($this->once())
-            ->method('orderAddFee');
-        expect('get_woocommerce_currency_symbol')->andReturn('EUR');
-
-        expect('wp_send_json_success')->with($expectedData);
-        $testee->updateSurchargeOrderPay();
-    }
 
     protected function cartMock()
     {
@@ -159,41 +108,7 @@ class SurchargeHandlerTest extends TestCase
      *
      * @throws PHPUnit_Framework_Exception
      */
-    private function wcOrder($id, $orderKey)
-    {
-        $item = $this->createConfiguredMock(
-            'WC_Order',
-            [
-                'get_id' => $id,
-                'get_order_key' => $orderKey,
-                'get_total' => 20.00,
-                'get_items' => [],
-                'get_billing_first_name' => 'billingggivenName',
-                'get_billing_last_name' => 'billingfamilyName',
-                'get_billing_email' => 'billingemail',
-                'get_shipping_first_name' => 'shippinggivenName',
-                'get_shipping_last_name' => 'shippingfamilyName',
-                'get_billing_address_1' => 'shippingstreetAndNumber',
-                'get_billing_address_2' => 'billingstreetAdditional',
-                'get_billing_postcode' => 'billingpostalCode',
-                'get_billing_city' => 'billingcity',
-                'get_billing_state' => 'billingregion',
-                'get_billing_country' => 'billingcountry',
-                'get_shipping_address_1' => 'shippingstreetAndNumber',
-                'get_shipping_address_2' => 'shippingstreetAdditional',
-                'get_shipping_postcode' => 'shippingpostalCode',
-                'get_shipping_city' => 'shippingcity',
-                'get_shipping_state' => 'shippingregion',
-                'get_shipping_country' => 'shippingcountry',
-                'get_shipping_methods' => false,
-                'get_order_number' => 1,
-                'get_payment_method' => 'mollie_wc_gateway_ideal',
-                'get_currency' => 'EUR',
-            ]
-        );
 
-        return $item;
-    }
     protected function mollieGateway(){
         $gateway = $this->createConfiguredMock(
             MolliePaymentGateway::class,


### PR DESCRIPTION
When the payment method changes, form-pay.php template is loaded using AJAX and sent back as HTML string. `.shop_table` element is extracted from the HTML and replaced on the frontend.

Unit test for this functionality is removed. We should cover this scenario with E2E test.