### PR TITLE
[PIWOO-196] Check if WC_Subscription class exists instead the subscription plugin file

### DIFF
--- a/src/Shared/Data.php
+++ b/src/Shared/Data.php
@@ -77,7 +77,7 @@ class Data
 
     public function isSubscriptionPluginActive(): bool
     {
-        $subscriptionPlugin = is_plugin_active('woocommerce-subscriptions/woocommerce-subscriptions.php');
+        $subscriptionPlugin = class_exists('WC_Subscriptions');
         return apply_filters('mollie_wc_subscription_plugin_active', $subscriptionPlugin);
     }
 


### PR DESCRIPTION
Instead of checking the path of the subscription plugin we now check the class. If a class exists, the plugin is activated.