### PR TITLE
[PIWOO-327] Order is not canceled after exact expiry date set in gateway settings

### DIFF
--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -69,6 +69,7 @@ class MolliePayment extends MollieObject
         $storeCustomer = $settingsHelper->shouldStoreCustomer();
 
         $gateway = wc_get_payment_gateway_by_order($order);
+        $gatewaySettings = property_exists($gateway, "settings") ? $gateway->settings : [];
 
         if (!$gateway || !($gateway instanceof MolliePaymentGateway)) {
             return ['result' => 'failure'];
@@ -122,6 +123,19 @@ class MolliePayment extends MollieObject
             $encodedApplePayToken = json_encode($applePayToken);
             $paymentRequestData['applePayPaymentToken'] = $encodedApplePayToken;
         }
+
+        if (
+            $gateway->id === "mollie_wc_gateway_banktransfer" &&
+            !empty($gatewaySettings["activate_expiry_days_setting"]) &&
+            $gatewaySettings["activate_expiry_days_setting"] === 'yes' &&
+            !empty($gatewaySettings["order_dueDate"]) &&
+            is_numeric($gatewaySettings["order_dueDate"])
+        ) {
+            $dueDateTimestamp = time() + (intval($gatewaySettings["order_dueDate"]) * 24 * 60 * 60);
+            // https://docs.mollie.com/reference/v2/payments-api/create-payment#bank-transfer
+            $paymentRequestData["dueDate"] = date("Y-m-d", $dueDateTimestamp);
+        }
+
         return $paymentRequestData;
     }
 

--- a/src/Payment/PaymentModule.php
+++ b/src/Payment/PaymentModule.php
@@ -173,14 +173,14 @@ class PaymentModule implements ServiceModule, ExecutableModule
                 continue;
             }
             $heldDurationInSeconds = $heldDuration * 60;
-            if ($gateway === 'mollie_wc_gateway_bankTransfer') {
+            if ($gateway === 'Mollie_WC_Gateway_Banktransfer') {
                 $durationInHours = absint($heldDuration) * 24;
                 $durationInMinutes = $durationInHours * 60;
                 $heldDurationInSeconds = $durationInMinutes * 60;
             }
             $args = [
                 'limit' => -1,
-                'status' => 'pending',
+                'status' => ['wc-on-hold', 'wc-pending'],
                 'payment_method' => strtolower($gateway),
                 'date_modified' => '<' . (time() - $heldDurationInSeconds),
                 'return' => 'ids',


### PR DESCRIPTION
@mmaymo  I fixed the gateway name and changed statuses for wc_get_orders query. When a customer places the order, status of the order is wc-on-hold. I was not able to place the order with status wc-pending, but I left it there just to be safe.