### PR TITLE
[PIWOO-229] WooCommerce - Merchant Capture

### DIFF
--- a/inc/settings/mollie_advanced_settings.php
+++ b/inc/settings/mollie_advanced_settings.php
@@ -200,6 +200,36 @@ return [
         ) . '</a>)',
     ],
     [
+        'id' => $pluginName . '_place_payment_onhold',
+        'title' => __('Placing payments on Hold', 'mollie-payments-for-woocommerce'),
+        'type' => 'select',
+        'desc_tip' => true,
+        'options' => [
+            'immediate_capture' => __('Capture payments immediately', 'mollie-payments-for-woocommerce'),
+            'later_capture' => __('Authorize payments for a later capture', 'mollie-payments-for-woocommerce'),
+        ],
+        'default' => 'immediate_capture',
+        'desc' => sprintf(
+            __(
+                'Authorized payment can be captured or voided by changing the order status instead of doing it manually.',
+                'mollie-payments-for-woocommerce'
+            )
+        ),
+    ],
+    [
+        'id' => $pluginName . '_capture_or_void',
+        'title' => __(
+            'Capture or void on status change',
+            'mollie-payments-for-woocommerce'
+        ),
+        'type' => 'checkbox',
+        'default' => 'no',
+        'desc' => __(
+            'Capture authorized payments automatically when setting the order status to Processing or Completed. Void the payment by setting the order status Canceled.',
+            'mollie-payments-for-woocommerce'
+        ),
+    ],
+    [
         'id' => $pluginName . '_sectionend',
         'type' => 'sectionend',
     ],

--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce;
 
+use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
 use Mollie\WooCommerce\Vendor\Inpsyde\Modularity\Package;
 use Mollie\WooCommerce\Vendor\Inpsyde\Modularity\Properties\PluginProperties;
 use Mollie\WooCommerce\Activation\ActivationModule;
@@ -161,6 +162,7 @@ function initialize()
             new GatewayModule(),
             new VoucherModule(),
             new PaymentModule(),
+            new MerchantCaptureModule(),
             new UninstallModule(),
         ];
         $modules = apply_filters('mollie_wc_plugin_modules', $modules);

--- a/resources/js/advancedSettings.js
+++ b/resources/js/advancedSettings.js
@@ -1,9 +1,9 @@
 (
-    function ({_, jQuery }) {
+    function ({_, jQuery}) {
 
         function mollie_settings__insertTextAtCursor(target, text, dontIgnoreSelection) {
             if (target.setRangeText) {
-                if ( !dontIgnoreSelection ) {
+                if (!dontIgnoreSelection) {
                     // insert at end
                     target.setRangeText(text, target.value.length, target.value.length, "end");
                 } else {
@@ -16,13 +16,14 @@
             }
             target.focus();
         }
-        jQuery(document).ready(function($) {
+
+        jQuery(document).ready(function ($) {
             $(".mollie-settings-advanced-payment-desc-label")
                 .data("ignore-click", "false")
-                .on("mousedown", function(e) {
+                .on("mousedown", function (e) {
                     const input = document.getElementById("mollie-payments-for-woocommerce_api_payment_description");
-                    if ( document.activeElement && input === document.activeElement ) {
-                        $(this).on("mouseup.molliesettings", function(e) {
+                    if (document.activeElement && input === document.activeElement) {
+                        $(this).on("mouseup.molliesettings", function (e) {
                             $(this).data("ignore-click", "true");
                             $(this).off(".molliesettings");
                             const tag = $(this).data("tag");
@@ -31,15 +32,15 @@
                         });
                     }
                     let $this = $(this);
-                    $(window).on("mouseup.molliesettings drag.molliesettings blur.molliesettings", function(e) {
+                    $(window).on("mouseup.molliesettings drag.molliesettings blur.molliesettings", function (e) {
                         $this.off(".molliesettings");
                         $(window).off(".molliesettings");
                     });
                 })
-                .on("click", function(e) {
+                .on("click", function (e) {
                     e.preventDefault();
                     e.stopImmediatePropagation();
-                    if ( $(this).data("ignore-click") === "false" ) {
+                    if ($(this).data("ignore-click") === "false") {
                         const tag = $(this).data("tag");
                         const input = document.getElementById("mollie-payments-for-woocommerce_api_payment_description");
                         mollie_settings__insertTextAtCursor(input, tag, false);
@@ -48,9 +49,44 @@
                     }
                 })
             ;
+            registerManualCaptureFields();
         });
     }
 )
 (
     window
 )
+
+function registerManualCaptureFields() {
+    const onHoldSelect = jQuery('[name="mollie-payments-for-woocommerce_place_payment_onhold"]');
+    if (onHoldSelect.length === 0) {
+        return;
+    }
+    toggleManualCaptureFields(onHoldSelect);
+    onHoldSelect.on('change', function(){
+        toggleManualCaptureFields(onHoldSelect);
+    })
+}
+
+function toggleManualCaptureFields(onHoldSelect) {
+    const currentValue = onHoldSelect.find('option:selected');
+    if (currentValue.length === 0) {
+        return;
+    }
+
+    const captureStatusChangeField = jQuery('[name="mollie-payments-for-woocommerce_capture_or_void"]');
+    if (captureStatusChangeField.length === 0) {
+        return;
+    }
+
+    const captureStatusChangeFieldParent = captureStatusChangeField.closest('tr');
+    if (captureStatusChangeFieldParent.length === 0) {
+        return;
+    }
+
+    if (currentValue.val() === 'later_capture') {
+        captureStatusChangeFieldParent.show();
+    } else {
+        captureStatusChangeFieldParent.hide();
+    }
+}

--- a/src/Buttons/ApplePayButton/ApplePayDataObjectHttp.php
+++ b/src/Buttons/ApplePayButton/ApplePayDataObjectHttp.php
@@ -326,7 +326,7 @@ class ApplePayDataObjectHttp
                     sprintf('ApplePay Data Error: Missing value for %s', $requiredField)
                 );
                 $this->errors[]
- = [
+                = [
                     'errorCode' => $errorCode,
                     'contactField' => $errorValue,
                 ];

--- a/src/MerchantCapture/Capture/Action/AbstractPaymentCaptureAction.php
+++ b/src/MerchantCapture/Capture/Action/AbstractPaymentCaptureAction.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\Capture\Action;
+
+use Mollie\WooCommerce\SDK\Api;
+use Mollie\WooCommerce\Settings\Settings;
+use Psr\Log\LoggerInterface;
+
+class AbstractPaymentCaptureAction
+{
+    protected $apiHelper;
+    protected $settingsHelper;
+    protected $apiKey;
+    protected $order;
+    protected $logger;
+    protected $pluginId;
+
+    public function __construct(
+        int $orderId,
+        Api $apiHelper,
+        Settings $settingsHelper,
+        LoggerInterface $logger,
+        string $pluginId
+    ) {
+
+        $this->apiHelper = $apiHelper;
+        $this->settingsHelper = $settingsHelper;
+        $this->order = wc_get_order($orderId);
+        $this->logger = $logger;
+        $this->pluginId = $pluginId;
+        $this->setApiKey();
+    }
+
+    protected function setApiKey()
+    {
+        $this->apiKey = $this->settingsHelper->getApiKey();
+    }
+}

--- a/src/MerchantCapture/Capture/Action/CapturePayment.php
+++ b/src/MerchantCapture/Capture/Action/CapturePayment.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\Capture\Action;
+
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\WooCommerce\MerchantCapture\ManualCaptureStatus;
+use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
+
+class CapturePayment extends AbstractPaymentCaptureAction
+{
+    public function __invoke()
+    {
+        try {
+            $paymentId = $this->order->get_meta('_mollie_payment_id');
+
+            if (!$paymentId) {
+                $this->logger->error('Missing Mollie payment ID in order ' . $this->order->get_id());
+                $this->order->add_order_note(
+                    __(
+                        'The Mollie payment ID is missing, and we are unable to capture the funds.',
+                        'mollie-payments-for-woocommerce'
+                    )
+                );
+                return;
+            }
+
+            $paymentCapturesApi = $this->apiHelper->getApiClient($this->apiKey)->paymentCaptures;
+            $captureData = [
+                'amount' => [
+                    'currency' => $this->order->get_currency(),
+                    'value' => $this->order->get_total(),
+                ],
+            ];
+            $this->logger->debug(
+                'SEND AN ORDER CAPTURE, orderId: ' . $this->order->get_id(
+                ) . ' transactionId: ' . $paymentId . 'Capture data: ' . json_encode($captureData)
+            );
+            $paymentCapturesApi->createForId($paymentId, $captureData);
+            $this->order->update_meta_data(
+                MerchantCaptureModule::ORDER_PAYMENT_STATUS_META_KEY,
+                ManualCaptureStatus::STATUS_WAITING
+            );
+            $this->order->add_order_note(
+                sprintf(
+                    __(
+                        'The payment capture of %s has been sent successfully, and we are currently awaiting confirmation.',
+                        'mollie-payments-for-woocommerce'
+                    ),
+                    wc_price($this->order->get_total())
+                )
+            );
+            $this->order->save();
+        } catch (ApiException $exception) {
+            $this->logger->error($exception->getMessage());
+            $this->order->add_order_note(
+                __(
+                    'Payment Capture Failed. We encountered an issue while processing the payment capture.',
+                    'mollie-payments-for-woocommerce'
+                )
+            );
+        }
+    }
+}

--- a/src/MerchantCapture/Capture/Action/VoidPayment.php
+++ b/src/MerchantCapture/Capture/Action/VoidPayment.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\Capture\Action;
+
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\WooCommerce\MerchantCapture\ManualCaptureStatus;
+use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
+
+class VoidPayment extends AbstractPaymentCaptureAction
+{
+    public function __invoke()
+    {
+        $paymentId = $this->order->get_meta('_mollie_payment_id');
+        $paymentCapturesApi = $this->apiHelper->getApiClient($this->apiKey)->payments;
+        try {
+            $paymentCapturesApi->cancel($paymentId);
+            $this->order->update_meta_data(
+                MerchantCaptureModule::ORDER_PAYMENT_STATUS_META_KEY,
+                ManualCaptureStatus::STATUS_VOIDED
+            );
+            $this->order->save();
+        } catch (ApiException $exception) {
+            $this->logger->error($exception->getMessage());
+            $this->order->add_order_note(
+                __(
+                    'Payment Void Failed. We encountered an issue while canceling the pre-authorized payment.',
+                    'mollie-payments-for-woocommerce'
+                )
+            );
+        }
+    }
+}

--- a/src/MerchantCapture/Capture/Type/ManualCapture.php
+++ b/src/MerchantCapture/Capture/Type/ManualCapture.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\Capture\Type;
+
+use Mollie\WooCommerce\MerchantCapture\Capture\Action\CapturePayment;
+use Mollie\WooCommerce\Vendor\Psr\Container\ContainerInterface;
+
+class ManualCapture
+{
+    /**
+     * @var ContainerInterface $container
+     */
+    protected $container;
+    protected const MOLLIE_MANUAL_CAPTURE_ACTION = 'mollie_capture_authorized_payment';
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        add_action('woocommerce_order_actions', [$this, 'enableOrderCaptureButton'], 10, 2);
+        add_action('woocommerce_order_action_' . self::MOLLIE_MANUAL_CAPTURE_ACTION, [$this, 'manualCapture']);
+        add_filter('woocommerce_mollie_wc_gateway_creditcard_args', [$this, 'sendManualCaptureMode']);
+    }
+
+    public function enableOrderCaptureButton(array $actions, \WC_Order $order): array
+    {
+        if (!$this->container->get('merchant.manual_capture.can_capture_the_order')($order)) {
+            return $actions;
+        }
+        $actions[self::MOLLIE_MANUAL_CAPTURE_ACTION] = __(
+            'Capture authorized Mollie payment',
+            'mollie-payments-for-woocommerce'
+        );
+        return $actions;
+    }
+
+    public function sendManualCaptureMode(array $paymentData): array
+    {
+        if ($this->container->get('merchant.manual_capture.enabled')) {
+            $paymentData['captureMode'] = 'manual';
+        }
+        return $paymentData;
+    }
+
+    public function manualCapture(\WC_Order $order)
+    {
+
+        ($this->container->get(CapturePayment::class))($order->get_id());
+    }
+}

--- a/src/MerchantCapture/Capture/Type/StateChangeCapture.php
+++ b/src/MerchantCapture/Capture/Type/StateChangeCapture.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\Capture\Type;
+
+use Mollie\WooCommerce\MerchantCapture\Capture\Action\CapturePayment;
+use Mollie\WooCommerce\MerchantCapture\Capture\Action\VoidPayment;
+use Mollie\WooCommerce\Shared\SharedDataDictionary;
+use Mollie\WooCommerce\Vendor\Psr\Container\ContainerInterface;
+
+class StateChangeCapture
+{
+    /**
+     * @var ContainerInterface $container
+     */
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        add_action('woocommerce_order_status_changed', [$this, "orderStatusChange"], 10, 3);
+    }
+
+    public function orderStatusChange(int $orderId, string $oldStatus, string $newStatus)
+    {
+        $stateChangeCaptureEnabled = $this->container->get('merchant.manual_capture.on_status_change_enabled');
+        if (empty($stateChangeCaptureEnabled) || $stateChangeCaptureEnabled === 'no') {
+            return;
+        }
+
+        if (!in_array($oldStatus, $this->container->get('merchant.manual_capture.void_statuses'))) {
+            return;
+        }
+
+        if (in_array($newStatus, [SharedDataDictionary::STATUS_PROCESSING, SharedDataDictionary::STATUS_COMPLETED])) {
+            $this->capturePayment($orderId);
+            return;
+        }
+
+        if ($newStatus === SharedDataDictionary::STATUS_CANCELLED) {
+            $this->voidPayment($orderId);
+        }
+    }
+
+    protected function capturePayment(int $orderId)
+    {
+        ($this->container->get(CapturePayment::class))($orderId);
+    }
+
+    protected function voidPayment(int $orderId)
+    {
+        ($this->container->get(VoidPayment::class))($orderId);
+    }
+}

--- a/src/MerchantCapture/ManualCaptureStatus.php
+++ b/src/MerchantCapture/ManualCaptureStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture;
+
+class ManualCaptureStatus
+{
+    public const STATUS_AUTHORIZED = 'authorized';
+
+    public const STATUS_CAPTURED = 'captured';
+    public const STATUS_VOIDED = 'voided';
+    public const STATUS_WAITING = 'waiting';
+}

--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture;
+
+use Mollie\Api\Resources\Payment;
+use Mollie\WooCommerce\MerchantCapture\Capture\Action\CapturePayment;
+use Mollie\WooCommerce\MerchantCapture\Capture\Action\VoidPayment;
+use Mollie\WooCommerce\MerchantCapture\Capture\Type\ManualCapture;
+use Mollie\WooCommerce\MerchantCapture\Capture\Type\StateChangeCapture;
+use Mollie\WooCommerce\MerchantCapture\UI\OrderActionBlock;
+use Mollie\WooCommerce\MerchantCapture\UI\StatusRenderer;
+use Mollie\WooCommerce\SDK\Api;
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerce\Shared\SharedDataDictionary;
+use Mollie\WooCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
+use Mollie\WooCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
+use Mollie\WooCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
+use Mollie\WooCommerce\Vendor\Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface as Logger;
+use WC_Order;
+
+class MerchantCaptureModule implements ExecutableModule, ServiceModule
+{
+    use ModuleClassNameIdTrait;
+
+    public const ORDER_PAYMENT_STATUS_META_KEY = '_mollie_payment_status';
+
+    public function services(): array
+    {
+        return [
+                'merchant.manual_capture.enabled' => static function () {
+                    $captureType = get_option('mollie-payments-for-woocommerce_place_payment_onhold');
+                    return $captureType === 'later_capture';
+                },
+                'merchant.manual_capture.supported_methods' => static function () {
+                    return ['mollie_wc_gateway_creditcard'];
+                },
+                'merchant.manual_capture.void_statuses' => static function () {
+                    return apply_filters('mollie_wc_gateway_void_order_state', [SharedDataDictionary::STATUS_ON_HOLD]);
+                },
+                'merchant.manual_capture.capture_statuses' => static function () {
+                    return apply_filters('mollie_wc_gateway_capture_order_state', [SharedDataDictionary::STATUS_ON_HOLD]);
+                },
+                'merchant.manual_capture.is_authorized' => static function ($container) {
+                    return static function (WC_Order $order) use ($container) {
+                        $orderIsAuthorized = $order->get_meta(
+                            self::ORDER_PAYMENT_STATUS_META_KEY
+                        ) === ManualCaptureStatus::STATUS_AUTHORIZED;
+                        $isManualCaptureMethod = in_array(
+                            $order->get_payment_method(),
+                            $container->get('merchant.manual_capture.supported_methods')
+                        );
+
+                        return $isManualCaptureMethod && $orderIsAuthorized;
+                    };
+                },
+                'merchant.manual_capture.is_waiting' => static function ($container) {
+                    return static function (WC_Order $order) use ($container) {
+                        $orderIsWaiting = $order->get_meta(
+                            self::ORDER_PAYMENT_STATUS_META_KEY
+                        ) === ManualCaptureStatus::STATUS_WAITING;
+                        $isManualCaptureMethod = in_array(
+                            $order->get_payment_method(),
+                            $container->get('merchant.manual_capture.supported_methods')
+                        );
+
+                        return $isManualCaptureMethod && $orderIsWaiting;
+                    };
+                },
+                'merchant.manual_capture.can_capture_the_order' => static function ($container) {
+                    return static function (WC_Order $order) use ($container) {
+                        $orderIsAuthorized = $order->get_meta(
+                            self::ORDER_PAYMENT_STATUS_META_KEY
+                        ) === ManualCaptureStatus::STATUS_AUTHORIZED;
+                        $isManualCaptureMethod = in_array(
+                            $order->get_payment_method(),
+                            $container->get('merchant.manual_capture.supported_methods')
+                        );
+                        $isCorrectState = in_array(
+                            $order->get_status(),
+                            $container->get('merchant.manual_capture.capture_statuses')
+                        );
+                        return $isManualCaptureMethod && $orderIsAuthorized && $isCorrectState;
+                    };
+                },
+                'merchant.manual_capture.on_status_change_enabled' => static function () {
+                    return get_option('mollie-payments-for-woocommerce_capture_or_void', false);
+                },
+                CapturePayment::class => static function ($container) {
+                    return static function (int $orderId) use ($container) {
+                        /** @var Api $api */
+                        $api = $container->get('SDK.api_helper');
+
+                        /** @var Settings $settings */
+                        $settings = $container->get('settings.settings_helper');
+
+                        /** @var Logger $logger */
+                        $logger = $container->get(Logger::class);
+
+                        $pluginId = $container->get('shared.plugin_id');
+
+                        return (new CapturePayment($orderId, $api, $settings, $logger, $pluginId))();
+                    };
+                },
+                VoidPayment::class => static function ($container) {
+                    return static function (int $orderId) use ($container) {
+                        /** @var Api $api */
+                        $api = $container->get('SDK.api_helper');
+
+                        /** @var Settings $settings */
+                        $settings = $container->get('settings.settings_helper');
+
+                        /** @var Logger $logger */
+                        $logger = $container->get(Logger::class);
+
+                        $pluginId = $container->get('shared.plugin_id');
+
+                        return (new VoidPayment($orderId, $api, $settings, $logger, $pluginId))();
+                    };
+                },
+        ];
+    }
+
+    public function run(ContainerInterface $container): bool
+    {
+        $pluginId = $container->get('shared.plugin_id');
+        add_action($pluginId . '_after_webhook_action', static function (Payment $payment, WC_Order $order) use ($container) {
+            if ($payment->isAuthorized()) {
+                if (!$payment->getAmountCaptured() == 0.0) {
+                    return;
+                }
+                $order->set_status(SharedDataDictionary::STATUS_ON_HOLD);
+                $order->update_meta_data(self::ORDER_PAYMENT_STATUS_META_KEY, ManualCaptureStatus::STATUS_AUTHORIZED);
+                $order->save();
+            } elseif ($payment->isPaid() && ($container->get('merchant.manual_capture.is_waiting'))($order)) {
+                $order->update_meta_data(self::ORDER_PAYMENT_STATUS_META_KEY, ManualCaptureStatus::STATUS_CAPTURED);
+                $order->save();
+            }
+        }, 10, 2);
+
+        add_action('woocommerce_order_refunded', static function (int $orderId) use ($container) {
+            $order = wc_get_order($orderId);
+            if (!is_a($order, WC_Order::class)) {
+                return;
+            }
+            $merchantCanCapture = ($container->get('merchant.manual_capture.is_authorized'))($order);
+            if ($merchantCanCapture) {
+                ($container->get(VoidPayment::class))($order->get_id());
+            }
+        });
+        add_action('woocommerce_order_actions_start', static function (int $orderId) use ($container) {
+            $order = wc_get_order($orderId);
+            if (!is_a($order, WC_Order::class)) {
+                return;
+            }
+            $paymentStatus = $order->get_meta(MerchantCaptureModule::ORDER_PAYMENT_STATUS_META_KEY, true);
+            $actionBlockParagraphs = [];
+
+            ob_start();
+            (new StatusRenderer())($paymentStatus);
+
+            $actionBlockParagraphs[] = ob_get_clean();
+            if (($container->get('merchant.manual_capture.can_capture_the_order'))($order)) {
+                $actionBlockParagraphs[] = __(
+                    'To capture the authorized payment, select capture action from the list below.',
+                    'mollie-payments-for-woocommerce'
+                );
+            } elseif (($container->get('merchant.manual_capture.is_authorized'))($order)) {
+                $actionBlockParagraphs[] = __(
+                    'Before capturing the authorized payment, ensure to set the order status to On Hold.',
+                    'mollie-payments-for-woocommerce'
+                );
+            }
+            (new OrderActionBlock())($actionBlockParagraphs);
+        });
+        add_filter(
+            'mollie_wc_gateway_disable_ship_and_capture',
+            static function ($disableShipAndCapture, WC_Order $order) use ($container) {
+                if ($disableShipAndCapture) {
+                    return true;
+                }
+                return $container->get('merchant.manual_capture.is_waiting')($order);
+            },
+            10,
+            2
+        );
+        new OrderListPaymentColumn();
+        new ManualCapture($container);
+        new StateChangeCapture($container);
+        return true;
+    }
+}

--- a/src/MerchantCapture/OrderListPaymentColumn.php
+++ b/src/MerchantCapture/OrderListPaymentColumn.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture;
+
+use Mollie\WooCommerce\MerchantCapture\UI\StatusRenderer;
+
+class OrderListPaymentColumn
+{
+    public function __construct()
+    {
+        add_filter('manage_edit-shop_order_columns', [$this, 'renderColumn']);
+        add_action('manage_shop_order_posts_custom_column', [$this, 'renderColumnValue'], 10, 2);
+    }
+
+    public function renderColumn(array $columns): array
+    {
+        $newColumns = [];
+        $mollieColumnAdded = false;
+
+        foreach ($columns as $columnId => $column) {
+            $newColumns[$columnId] = $column;
+            if ($columnId === 'order_number') {
+                $newColumns['mollie_capture_payment_status'] = __(
+                    'Payment Status',
+                    'mollie-payments-for-woocommerce'
+                );
+                $mollieColumnAdded = true;
+            }
+        }
+
+        if (!$mollieColumnAdded) {
+            $newColumns['mollie_capture_payment_status'] = __('Payment Status', 'mollie-payments-for-woocommerce');
+        }
+
+        return $newColumns;
+    }
+
+    public function renderColumnValue(string $column, int $orderId)
+    {
+        if ($column !== 'mollie_capture_payment_status') {
+            return;
+        }
+        /** @var \WC_Order $order */
+        $order = wc_get_order($orderId);
+
+        if (!is_a($order, \WC_Order::class)) {
+            return;
+        }
+
+        $molliePaymentStatus = $order->get_meta(MerchantCaptureModule::ORDER_PAYMENT_STATUS_META_KEY);
+
+        (new StatusRenderer())($molliePaymentStatus);
+    }
+}

--- a/src/MerchantCapture/UI/OrderActionBlock.php
+++ b/src/MerchantCapture/UI/OrderActionBlock.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\UI;
+
+class OrderActionBlock
+{
+    public function __invoke(array $paragraphs)
+    {
+        echo "<li class='wide'>";
+        foreach ($paragraphs as $paragraph) {
+            ?>
+            <p><?= wp_kses($paragraph, ['mark' => ['class' => []], 'span' => []]); ?></p>
+            <?php
+        }
+        echo '</li>';
+    }
+}

--- a/src/MerchantCapture/UI/StatusButton.php
+++ b/src/MerchantCapture/UI/StatusButton.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\UI;
+
+class StatusButton
+{
+    public function __invoke(string $text, string $status)
+    {
+        ?>
+        <mark class="order-status status-<?= esc_html($status); ?>"><span><?= esc_html($text); ?></span></mark>
+        <?php
+    }
+}

--- a/src/MerchantCapture/UI/StatusRenderer.php
+++ b/src/MerchantCapture/UI/StatusRenderer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture\UI;
+
+use Mollie\WooCommerce\MerchantCapture\ManualCaptureStatus;
+use Mollie\WooCommerce\Shared\SharedDataDictionary;
+
+class StatusRenderer
+{
+    public function __invoke(string $molliePaymentStatus)
+    {
+        if ($molliePaymentStatus === ManualCaptureStatus::STATUS_AUTHORIZED) {
+            (new StatusButton())(
+                __('Payment authorized', 'mollie-payments-for-woocommerce'),
+                SharedDataDictionary::STATUS_ON_HOLD
+            );
+        } elseif ($molliePaymentStatus === ManualCaptureStatus::STATUS_VOIDED) {
+            (new StatusButton())(
+                __('Payment voided', 'mollie-payments-for-woocommerce'),
+                SharedDataDictionary::STATUS_CANCELLED
+            );
+        } elseif ($molliePaymentStatus === ManualCaptureStatus::STATUS_CAPTURED) {
+            (new StatusButton())(
+                __('Payment captured', 'mollie-payments-for-woocommerce'),
+                SharedDataDictionary::STATUS_COMPLETED
+            );
+        } elseif ($molliePaymentStatus === ManualCaptureStatus::STATUS_WAITING) {
+            (new StatusButton())(
+                __('Payment waiting', 'mollie-payments-for-woocommerce'),
+                SharedDataDictionary::STATUS_PENDING
+            );
+        }
+    }
+}

--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -172,6 +172,7 @@ class MollieOrderService
             ));
         }
 
+        do_action($this->pluginId . '_after_webhook_action', $payment, $order);
         // Status 200
     }
     /**

--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -453,6 +453,10 @@ class MolliePayment extends MollieObject
                 return new WP_Error('1', $errorMessage);
             }
 
+            if ($paymentObject->isAuthorized()) {
+                return true;
+            }
+
             if (! $paymentObject->isPaid()) {
                 $errorMessage = "Can not refund payment $paymentObject->id for WooCommerce order $orderId as it is not paid.";
 

--- a/src/Payment/PaymentModule.php
+++ b/src/Payment/PaymentModule.php
@@ -339,7 +339,7 @@ class PaymentModule implements ServiceModule, ExecutableModule
 
         // To disable automatic shipping and capturing of the Mollie order when a WooCommerce order status is updated to completed,
         // store an option 'mollie-payments-for-woocommerce_disableShipOrderAtMollie' with value 1
-        if (get_option($this->pluginId . '_' . 'disableShipOrderAtMollie', '0') === '1') {
+        if (apply_filters('mollie_wc_gateway_disable_ship_and_capture', get_option($this->pluginId . '_' . 'disableShipOrderAtMollie', '0') === '1', $order)) {
             return;
         }
 

--- a/src/Payment/PaymentService.php
+++ b/src/Payment/PaymentService.php
@@ -25,8 +25,6 @@ class PaymentService
     public const PAYMENT_METHOD_TYPE_ORDER = 'order';
     public const PAYMENT_METHOD_TYPE_PAYMENT = 'payment';
 
-    public const PAYMENT_METHOD_TYPE_CAPTURE = 'capture';
-
     /**
      * @var MolliePaymentGatewayI
      */

--- a/src/Payment/PaymentService.php
+++ b/src/Payment/PaymentService.php
@@ -24,6 +24,9 @@ class PaymentService
 {
     public const PAYMENT_METHOD_TYPE_ORDER = 'order';
     public const PAYMENT_METHOD_TYPE_PAYMENT = 'payment';
+
+    public const PAYMENT_METHOD_TYPE_CAPTURE = 'capture';
+
     /**
      * @var MolliePaymentGatewayI
      */
@@ -369,8 +372,7 @@ class PaymentService
                     : '',
                 'orderNumber' => isset($data['orderNumber'])
                     ? $data['orderNumber'] : '',
-                'lines' => isset($data['lines']) ? $data['lines'] : '',
-            ];
+                'lines' => isset($data['lines']) ? $data['lines'] : '', ];
 
             $this->logger->debug(json_encode($apiCallLog));
             $paymentOrder = $paymentObject;
@@ -550,6 +552,7 @@ class PaymentService
                 $apiKey
             );
         }
+
         return $paymentObject;
     }
 

--- a/src/PaymentMethods/Kbc.php
+++ b/src/PaymentMethods/Kbc.php
@@ -6,10 +6,10 @@ namespace Mollie\WooCommerce\PaymentMethods;
 
 class Kbc extends AbstractPaymentMethod implements PaymentMethodI
 {
-protected const DEFAULT_ISSUERS_DROPDOWN = 'yes';
-protected function getConfig(): array
-{
-    return [
+    protected const DEFAULT_ISSUERS_DROPDOWN = 'yes';
+    protected function getConfig(): array
+    {
+        return [
         'id' => 'kbc',
         'defaultTitle' => __('KBC/CBC Payment Button', 'mollie-payments-for-woocommerce'),
         'settingsDescription' => '',
@@ -23,10 +23,10 @@ protected function getConfig(): array
         'filtersOnBuild' => false,
         'confirmationDelayed' => true,
         'SEPA' => true,
-    ];
-}
+        ];
+    }
 
-public function getFormFields($generalFormFields): array
+    public function getFormFields($generalFormFields): array
     {
         $paymentMethodFormFieds =   [
             'issuers_dropdown_shown' => [

--- a/src/SDK/WordPressHttpAdapter.php
+++ b/src/SDK/WordPressHttpAdapter.php
@@ -18,6 +18,7 @@ class WordPressHttpAdapter implements MollieHttpAdapterInterface
      * HTTP status code for an empty ok response.
      */
     const HTTP_NO_CONTENT = 204;
+    const PAYMENT_HTTP_NO_CONTENT = 202;
 
     /**
      * @param string $httpMethod
@@ -65,7 +66,7 @@ class WordPressHttpAdapter implements MollieHttpAdapterInterface
         $statusCode = wp_remote_retrieve_response_code($response);
         $httpBody = wp_remote_retrieve_body($response);
         if (empty($httpBody)) {
-            if ($statusCode === self::HTTP_NO_CONTENT) {
+            if ($statusCode === self::HTTP_NO_CONTENT || $statusCode === self::PAYMENT_HTTP_NO_CONTENT) {
                 return null;
             }
 


### PR DESCRIPTION
Here are some important notes about the PR:

- I created a new module MerchantCapture. Here you can find everything related to the Manual Capture except module settings which are located here: `inc/settings/mollie_advanced_settings.php`
- In `src/SDK/WordPressHttpAdapter.php` I added another `nobody` code. Please check it. If you think it can cause problems, we have to find another way. When we cancel the payment successful response is 202.
- In `src/Payment/MollieOrderService.php` I added a new action hook.
- In `src/Payment/PaymentModule.php` I added a filter for disabling shipping or capture settings.
- Most of the other changes were done by phpcbf.