### PR TITLE
[PIWOO-363] Feature flag for Merchant capture module

### DIFF
--- a/inc/settings/mollie_advanced_settings.php
+++ b/inc/settings/mollie_advanced_settings.php
@@ -17,7 +17,7 @@ $api_payment_description_labels = [
     '{customer.company}' => _x('Customer\'s company name', 'Label {customer.company} description for payment description options', 'mollie-payments-for-woocommerce'),
 ];
 
-return [
+$mollieAdvancedSettings =  [
     [
         'id' => $pluginName . '_title',
         'title' => __('Mollie advanced settings', 'mollie-payments-for-woocommerce'),
@@ -198,39 +198,8 @@ return [
         'desc' => __("Remove options and scheduled actions from database when uninstalling the plugin.", "mollie-payments-for-woocommerce") . ' (<a href="' . esc_url($cleanDB_mollie_url) . '">' . strtolower(
             __('Clear now', 'mollie-payments-for-woocommerce')
         ) . '</a>)',
-    ],
-    [
-        'id' => $pluginName . '_place_payment_onhold',
-        'title' => __('Placing payments on Hold', 'mollie-payments-for-woocommerce'),
-        'type' => 'select',
-        'desc_tip' => true,
-        'options' => [
-            'immediate_capture' => __('Capture payments immediately', 'mollie-payments-for-woocommerce'),
-            'later_capture' => __('Authorize payments for a later capture', 'mollie-payments-for-woocommerce'),
-        ],
-        'default' => 'immediate_capture',
-        'desc' => sprintf(
-            __(
-                'Authorized payment can be captured or voided by changing the order status instead of doing it manually.',
-                'mollie-payments-for-woocommerce'
-            )
-        ),
-    ],
-    [
-        'id' => $pluginName . '_capture_or_void',
-        'title' => __(
-            'Capture or void on status change',
-            'mollie-payments-for-woocommerce'
-        ),
-        'type' => 'checkbox',
-        'default' => 'no',
-        'desc' => __(
-            'Capture authorized payments automatically when setting the order status to Processing or Completed. Void the payment by setting the order status Canceled.',
-            'mollie-payments-for-woocommerce'
-        ),
-    ],
-    [
-        'id' => $pluginName . '_sectionend',
-        'type' => 'sectionend',
-    ],
+    ]
 ];
+
+
+return apply_filters('inpsyde.mollie-advanced-settings', $mollieAdvancedSettings, $pluginName);

--- a/inc/settings/mollie_advanced_settings.php
+++ b/inc/settings/mollie_advanced_settings.php
@@ -198,8 +198,7 @@ $mollieAdvancedSettings =  [
         'desc' => __("Remove options and scheduled actions from database when uninstalling the plugin.", "mollie-payments-for-woocommerce") . ' (<a href="' . esc_url($cleanDB_mollie_url) . '">' . strtolower(
             __('Clear now', 'mollie-payments-for-woocommerce')
         ) . '</a>)',
-    ]
+    ],
 ];
-
 
 return apply_filters('inpsyde.mollie-advanced-settings', $mollieAdvancedSettings, $pluginName);

--- a/src/MerchantCapture/MollieCaptureSettings.php
+++ b/src/MerchantCapture/MollieCaptureSettings.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\MerchantCapture;
+
+class MollieCaptureSettings
+{
+    public function settings(array $advancedSettings, string $pluginName): array
+    {
+        $mollieCaptureSettings = [
+            [
+                'id' => $pluginName . '_place_payment_onhold',
+                'title' => __('Placing payments on Hold', 'mollie-payments-for-woocommerce'),
+                'type' => 'select',
+                'desc_tip' => true,
+                'options' => [
+                    'immediate_capture' => __('Capture payments immediately', 'mollie-payments-for-woocommerce'),
+                    'later_capture' => __('Authorize payments for a later capture', 'mollie-payments-for-woocommerce'),
+                ],
+                'default' => 'immediate_capture',
+                'desc' => sprintf(
+                    __(
+                        'Authorized payment can be captured or voided by changing the order status instead of doing it manually.',
+                        'mollie-payments-for-woocommerce'
+                    )
+                ),
+            ],
+            [
+                'id' => $pluginName . '_capture_or_void',
+                'title' => __(
+                    'Capture or void on status change',
+                    'mollie-payments-for-woocommerce'
+                ),
+                'type' => 'checkbox',
+                'default' => 'no',
+                'desc' => __(
+                    'Capture authorized payments automatically when setting the order status to Processing or Completed. Void the payment by setting the order status Canceled.',
+                    'mollie-payments-for-woocommerce'
+                ),
+            ],
+            [
+                'id' => $pluginName . '_sectionend',
+                'type' => 'sectionend',
+            ],
+        ];
+
+        return array_merge($advancedSettings, $mollieCaptureSettings);
+    }
+}


### PR DESCRIPTION
The module is completely isolated from the rest of the code. To achieve that, I had to apply filters to advanced settings array `inc/settings/mollie_advanced_settings.php`. 


Filter is called:` inpsyde.mollie-advanced-settings`
It sends two parameters: `settings` & `pluginName`

Starter point of the MerchantCaptureModule was moved inside `init` hook. It was done, because we want to filter the flag value outside of the plugin.

To enable MerchantCaptureModule, you have to use the following filter:
`add_filter('mollie_wc_gateway_enable_merchant_capture_module', '__return_true');`
