### PR TITLE
[PIWOO-361] Disable authorisation when subscription product is in the cart

### DIFF
--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mollie Payments for WooCommerce
  * Plugin URI: https://www.mollie.com
  * Description: Accept payments in WooCommerce with the official Mollie plugin
- * Version: 7.4.1-beta
+ * Version: 7.4.1
  * Author: Mollie
  * Author URI: https://www.mollie.com
  * Requires at least: 5.0
@@ -12,7 +12,7 @@
  * Domain Path: /languages
  * License: GPLv2 or later
  * WC requires at least: 3.9
- * WC tested up to: 8.0
+ * WC tested up to: 8.2
  * Requires PHP: 7.2
  */
 declare(strict_types=1);

--- a/src/MerchantCapture/Capture/Type/ManualCapture.php
+++ b/src/MerchantCapture/Capture/Type/ManualCapture.php
@@ -37,7 +37,10 @@ class ManualCapture
 
     public function sendManualCaptureMode(array $paymentData): array
     {
-        if ($this->container->get('merchant.manual_capture.enabled')) {
+        if (
+            $this->container->get('merchant.manual_capture.enabled') &&
+            $this->container->get('merchant.manual_capture.cart_can_be_captured')
+        ) {
             $paymentData['captureMode'] = 'manual';
         }
         return $paymentData;

--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -88,6 +88,25 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
                 'merchant.manual_capture.on_status_change_enabled' => static function () {
                     return get_option('mollie-payments-for-woocommerce_capture_or_void', false);
                 },
+                'merchant.manual_capture.cart_can_be_captured' => static function (): bool {
+                    if (!class_exists(\WC_Product_Subscription::class)) {
+                        return true;
+                    }
+                    $cart = WC()->cart;
+                    if (!is_a($cart, \WC_Cart::class)) {
+                        return false;
+                    }
+                    $cartItems = $cart->get_cart_contents();
+
+                    foreach ($cartItems as $cartItemData) {
+                        $cartItem = $cartItemData['data'];
+
+                        if (is_a($cartItem, \WC_Product_Subscription::class)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                },
                 CapturePayment::class => static function ($container) {
                     return static function (int $orderId) use ($container) {
                         /** @var Api $api */

--- a/src/MerchantCapture/OrderListPaymentColumn.php
+++ b/src/MerchantCapture/OrderListPaymentColumn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\MerchantCapture;
 
+use Automattic\WooCommerce\Admin\Overrides\Order;
 use Mollie\WooCommerce\MerchantCapture\UI\StatusRenderer;
 
 class OrderListPaymentColumn
@@ -12,6 +13,12 @@ class OrderListPaymentColumn
     {
         add_filter('manage_edit-shop_order_columns', [$this, 'renderColumn']);
         add_action('manage_shop_order_posts_custom_column', [$this, 'renderColumnValue'], 10, 2);
+
+        # HPOS hooks
+        add_filter('woocommerce_shop_order_list_table_columns', [$this, 'renderColumn']);
+        add_action('woocommerce_shop_order_list_table_custom_column', function (string $column, Order $order) {
+            $this->renderColumnValue($column, $order->get_id());
+        }, 10, 2);
     }
 
     public function renderColumn(array $columns): array


### PR DESCRIPTION
A new condition for manual capture was added. If we find a subscription product in the cart, we don't enable manual capture but proceed with automatic capture. 