### PR TITLE
Fix package name in build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,5 @@ jobs:
       PHP_VERSION: 7.2
       PLUGIN_MAIN_FILE: mollie-payments-for-woocommerce.php
       ARCHIVE_NAME: mollie-payments-for-woocommerce
-      PRE_SCRIPT: |
-        ls
-        pwd
-        cd .. && mv WooCommerce mollie-payments-for-woocommerce && cd mollie-payments-for-woocommerce
+      POST_SCRIPT: |
+        mv dist/WooCommerce dist/mollie-payments-for-woocommerce

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,6 @@ jobs:
       PLUGIN_MAIN_FILE: mollie-payments-for-woocommerce.php
       ARCHIVE_NAME: mollie-payments-for-woocommerce
       PRE_SCRIPT: |
+        ls
+        pwd
         cd .. && mv WooCommerce mollie-payments-for-woocommerce && cd mollie-payments-for-woocommerce

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,4 @@ jobs:
       PLUGIN_MAIN_FILE: mollie-payments-for-woocommerce.php
       ARCHIVE_NAME: mollie-payments-for-woocommerce
       PRE_SCRIPT: |
-        echo 'hello world!';
+        cd .. && mv WooCommerce mollie-payments-for-woocommerce && cd mollie-payments-for-woocommerce


### PR DESCRIPTION
This PR continues the work of the previous merged one to fix the build of the release package from the GitHub action.
The process that now copies into dist, in the reusable workflow, uses the name of the directory, and in our case is not the name we want in the package, so we need to rename the folder before is uploaded as an artefact. 