### PR TITLE
[PIWOO-423] TypeError when WooCommerce Analytics is disabled

### DIFF
--- a/src/MerchantCapture/OrderListPaymentColumn.php
+++ b/src/MerchantCapture/OrderListPaymentColumn.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\MerchantCapture;
 
-use Automattic\WooCommerce\Admin\Overrides\Order;
+use WC_Order;
 use Mollie\WooCommerce\MerchantCapture\UI\StatusRenderer;
 
 class OrderListPaymentColumn
@@ -16,7 +16,7 @@ class OrderListPaymentColumn
 
         # HPOS hooks
         add_filter('woocommerce_shop_order_list_table_columns', [$this, 'renderColumn']);
-        add_action('woocommerce_shop_order_list_table_custom_column', function (string $column, Order $order) {
+        add_action('woocommerce_shop_order_list_table_custom_column', function (string $column, WC_Order $order) {
             $this->renderColumnValue($column, $order->get_id());
         }, 10, 2);
     }


### PR DESCRIPTION
Handles: [PIWOO-423](https://mollie.atlassian.net/browse/PIWOO-423)

The issue occurred when Woocommerce Analytics was disabled and HPOS enabled.

This PR changes the type that we receive in the action `woocommerce_shop_order_list_table_custom_column` from `Automattic\WooCommerce\Admin\Overrides\Order` to `WC_Order`.



[PIWOO-423]: https://mollie.atlassian.net/browse/PIWOO-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ