### PR TITLE
[PIWOO-424] Payment Status column displayed in orders overview when capturing payments immediately

### DIFF
--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -246,7 +246,7 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
                 10,
                 2
             );
-            new OrderListPaymentColumn();
+            new OrderListPaymentColumn($container);
             new ManualCapture($container);
             new StateChangeCapture($container);
         });

--- a/src/MerchantCapture/OrderListPaymentColumn.php
+++ b/src/MerchantCapture/OrderListPaymentColumn.php
@@ -6,11 +6,15 @@ namespace Mollie\WooCommerce\MerchantCapture;
 
 use Automattic\WooCommerce\Admin\Overrides\Order;
 use Mollie\WooCommerce\MerchantCapture\UI\StatusRenderer;
+use Mollie\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 class OrderListPaymentColumn
 {
-    public function __construct()
+    /** @var ContainerInterface $container */
+    private $container;
+    public function __construct($container)
     {
+        $this->container = $container;
         add_filter('manage_edit-shop_order_columns', [$this, 'renderColumn']);
         add_action('manage_shop_order_posts_custom_column', [$this, 'renderColumnValue'], 10, 2);
 
@@ -23,6 +27,10 @@ class OrderListPaymentColumn
 
     public function renderColumn(array $columns): array
     {
+        if (!$this->container->get('merchant.manual_capture.enabled')) {
+            return $columns;
+        }
+
         $newColumns = [];
         $mollieColumnAdded = false;
 


### PR DESCRIPTION
Handles: [PIWOO-424](https://mollie.atlassian.net/browse/PIWOO-424)

This PR passes a container to our `\Mollie\WooCommerce\MerchantCapture\OrderListPaymentColumn` class. Before rendering the Payment status column, we check if manual capture is enabled.

[PIWOO-424]: https://mollie.atlassian.net/browse/PIWOO-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ