### PR TITLE
[PIWOO-422] TypeError merchant capture feature

### DIFF
--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -153,7 +153,11 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
 
             add_action(
                 $pluginId . '_after_webhook_action',
-                static function (Payment $payment, WC_Order $order) use ($container) {
+                static function ($payment, WC_Order $order) use ($container) {
+
+                    if (!$payment instanceof Payment) {
+                        return;
+                    }
 
                     if ($payment->isAuthorized()) {
                         if (!$payment->getAmountCaptured() == 0.0) {

--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -179,7 +179,9 @@ class MollieOrderService
             ));
         }
 
-        do_action($this->pluginId . '_after_webhook_action', $payment, $order);
+        if ($payment instanceof Payment) {
+            do_action($this->pluginId . '_after_webhook_action', $payment, $order);
+        }
         // Status 200
     }
     /**

--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -179,9 +179,7 @@ class MollieOrderService
             ));
         }
 
-        if ($payment instanceof Payment) {
-            do_action($this->pluginId . '_after_webhook_action', $payment, $order);
-        }
+        do_action($this->pluginId . '_after_webhook_action', $payment, $order);
         // Status 200
     }
     /**


### PR DESCRIPTION
Handles: [PIWOO-422](https://mollie.atlassian.net/browse/PIWOO-422)

In the Webhook method, we have to check if the payment object is a payment. If it is not, we don't have to run it. 

@mmaymo Maybe it would be better to remove the Payment type from this function https://github.com/mollie/WooCommerce/blob/develop/src/MerchantCapture/MerchantCaptureModule.php#L156
and check here what kind of object we received. What do you think?

[PIWOO-422]: https://mollie.atlassian.net/browse/PIWOO-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ