### PR TITLE
Fix/order status subscriptions error

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -66,7 +66,7 @@ return [
     'exclude-classes' => array_merge($wp_classes, [
         'WooCommerce',
         '/^WC_/',
-        '^WCS_Retry_Manager'
+        '\WCS_Retry_Manager'
     ]),     // list<string|regex>
     'exclude-functions' => array_merge($wp_functions, [
         '/^wc/',

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -55,7 +55,8 @@ return [
         'Automattic',
         '^WooCommerce',
         'Inpsyde\Assets',
-        'Mollie'
+        'Mollie',
+        '^WCS_Retry_Manager'
     ], // list<string|regex>
     'exclude-constants' => array_merge($wp_constants, [
         'WC_VERSION',

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -56,7 +56,6 @@ return [
         '^WooCommerce',
         'Inpsyde\Assets',
         'Mollie',
-        '^WCS_Retry_Manager'
     ], // list<string|regex>
     'exclude-constants' => array_merge($wp_constants, [
         'WC_VERSION',
@@ -67,6 +66,7 @@ return [
     'exclude-classes' => array_merge($wp_classes, [
         'WooCommerce',
         '/^WC_/',
+        '^WCS_Retry_Manager'
     ]),     // list<string|regex>
     'exclude-functions' => array_merge($wp_functions, [
         '/^wc/',


### PR DESCRIPTION
This PR removes the class WCS_Retry_Manager from scoping, this was throwing an error on process renewals that was preventing the status to change to active