### PR TITLE
Add all EditorConfig keys

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,12 @@
 root = true
 
 [*]
+charset = utf-8
 end_of_line = lf
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
+indent_size = 4
 tab_width = 4
 
 [*.txt]


### PR DESCRIPTION
Some of the six keys were missing.

> **tab_width:** ... This defaults to the value of indent_size and doesn't usually need to be specified.

https://editorconfig.org/#supported-properties
