### PR TITLE
Only show billie billing company field when missing from checkout

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -734,6 +734,9 @@ class GatewayModule implements ServiceModule, ExecutableModule
         if ($fields['payment_method'] !== $gatewayName) {
             return $fields;
         }
+        if (!empty($fields['billing_company'])) {
+            return $fields;
+        }
         if (!isset($fields[$field])) {
             $fieldPosted = filter_input(INPUT_POST, $field, FILTER_SANITIZE_SPECIAL_CHARS) ?? false;
             if ($fieldPosted) {

--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -1109,7 +1109,7 @@ class MollieObject
         $isBillieMethodId = $gateway->id === 'mollie_wc_gateway_billie';
         if ($isBillieMethodId) {
             //phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-            $fieldPosted = wc_clean(wp_unslash($_POST["billing_company"] ?? ''));
+            $fieldPosted = wc_clean(wp_unslash($_POST["billing_company_billie"] ?? $_POST["billing_company"] ?? ''));
             if ($fieldPosted === '' || !is_string($fieldPosted)) {
                 return null;
             }

--- a/src/PaymentMethods/PaymentFieldsStrategies/BillieFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/BillieFieldsStrategy.php
@@ -17,7 +17,7 @@ class BillieFieldsStrategy implements PaymentFieldsStrategyI
             $showCompanyField = empty($order->get_billing_company());
         }
 
-        if (is_checkout() && !is_checkout_pay_page()) {
+        if (is_checkout() && !is_checkout_pay_page() && !isset(WC()->checkout()->get_checkout_fields()['billing']['billing_company'])) {
             $showCompanyField = true;
         }
 


### PR DESCRIPTION
This PR uses the `billing_company` field by default and only adds `billing_company_billie` when the field is missing from the checkout. This prevents users from entering the same company name twice. See original issue #962 here.