### PR TITLE
Mollie Components are not enabled by default on new installations

### DIFF
--- a/src/PaymentMethods/Creditcard.php
+++ b/src/PaymentMethods/Creditcard.php
@@ -68,7 +68,7 @@ class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
 
     protected function defaultComponentsEnabled()
     {
-        $isNewInstall = get_option(SharedDataDictionary::NEW_INSTALL_PARAM_NAME, false);
+        $isNewInstall = get_option(SharedDataDictionary::NEW_INSTALL_PARAM_NAME, 'yes');
         if ($isNewInstall === 'yes') {
             return 'yes';
         }

--- a/src/Settings/SettingsModule.php
+++ b/src/Settings/SettingsModule.php
@@ -78,7 +78,7 @@ class SettingsModule implements ServiceModule, ExecutableModule
                 return $settingsHelper->isTestModeEnabled();
             },
             'settings.IsDebugEnabled' => static function (): bool {
-                $debugEnabled = get_option('mollie-payments-for-woocommerce_debug', true);
+                $debugEnabled = get_option('mollie-payments-for-woocommerce_debug', 'yes');
                 return $debugEnabled === 'yes';
             },
             'settings.advanced_default_options' => static function (ContainerInterface $container) {


### PR DESCRIPTION
- Fix Mollie components not active on ne installations
- Fix Debug Log is not working on new installs

See [PIWOO-573](https://mollie.atlassian.net/browse/PIWOO-573)

[PIWOO-573]: https://mollie.atlassian.net/browse/PIWOO-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ