### PR TITLE
Fix/translation error in blocks

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -132,6 +132,10 @@
       <path value="$PROJECT_DIR$/.ddev/wordpress/wp-content/plugins/query-monitor/vendor/composer" />
       <path value="$PROJECT_DIR$/.ddev/wordpress/wp-content/plugins/environment-configurator/vendor/psr/container" />
       <path value="$PROJECT_DIR$/.ddev/wordpress/wp-content/plugins/environment-configurator/vendor/inpsyde/modularity" />
+      <path value="$PROJECT_DIR$/vendor/psr/container" />
+      <path value="$PROJECT_DIR$/vendor/inpsyde/modularity" />
+      <path value="$PROJECT_DIR$/vendor/sniccowp/php-scoper-wordpress-excludes" />
+      <path value="$PROJECT_DIR$/vendor/dhii/services" />
     </include_path>
   </component>
   <component name="PhpInterpreters">
@@ -241,7 +245,7 @@
       </server>
     </servers>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="7.2">
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.4">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
   <component name="PhpStanOptionsConfiguration">

--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -162,4 +162,4 @@ function initialize()
     }
 }
 
-add_action('after_setup_theme', __NAMESPACE__ . '\\initialize');
+add_action('plugins_loaded', __NAMESPACE__ . '\\initialize');

--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -312,8 +312,6 @@ class GatewayModule implements ServiceModule, ExecutableModule
             $this->molliePayPalButtonHandling($paypalGateway, $notice, $logger, $pluginUrl);
         }
 
-
-
         $maybeDisableVoucher = new MaybeDisableGateway();
         $dataService = $container->get('settings.data_helper');
         assert($dataService instanceof Data);

--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -289,30 +289,29 @@ class GatewayModule implements ServiceModule, ExecutableModule
         $surchargeService = $container->get(Surcharge::class);
         assert($surchargeService instanceof Surcharge);
         $this->gatewaySurchargeHandling($surchargeService);
-        add_action('after_setup_theme', function () use ($container) {
-            $notice = $container->get(AdminNotice::class);
-            assert($notice instanceof AdminNotice);
-            $logger = $container->get(Logger::class);
-            assert($logger instanceof Logger);
-            $pluginUrl = $container->get('shared.plugin_url');
-            $apiHelper = $container->get('SDK.api_helper');
-            assert($apiHelper instanceof Api);
-            $settingsHelper = $container->get('settings.settings_helper');
-            assert($settingsHelper instanceof Settings);
-            $appleGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_applepay']) ? $container->get(
-                'gateway.instances'
-            )['mollie_wc_gateway_applepay'] : false;
-            if ($appleGateway) {
-                $this->mollieApplePayDirectHandling($notice, $logger, $apiHelper, $settingsHelper, $appleGateway);
-            }
+        $notice = $container->get(AdminNotice::class);
+        assert($notice instanceof AdminNotice);
+        $logger = $container->get(Logger::class);
+        assert($logger instanceof Logger);
+        $pluginUrl = $container->get('shared.plugin_url');
+        $apiHelper = $container->get('SDK.api_helper');
+        assert($apiHelper instanceof Api);
+        $settingsHelper = $container->get('settings.settings_helper');
+        assert($settingsHelper instanceof Settings);
+        $appleGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_applepay']) ? $container->get(
+            'gateway.instances'
+        )['mollie_wc_gateway_applepay'] : false;
+        if ($appleGateway) {
+            $this->mollieApplePayDirectHandling($notice, $logger, $apiHelper, $settingsHelper, $appleGateway);
+        }
 
-            $paypalGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_paypal']) ? $container->get(
-                'gateway.instances'
-            )['mollie_wc_gateway_paypal'] : false;
-            if ($paypalGateway) {
-                $this->molliePayPalButtonHandling($paypalGateway, $notice, $logger, $pluginUrl);
-            }
-        });
+        $paypalGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_paypal']) ? $container->get(
+            'gateway.instances'
+        )['mollie_wc_gateway_paypal'] : false;
+        if ($paypalGateway) {
+            $this->molliePayPalButtonHandling($paypalGateway, $notice, $logger, $pluginUrl);
+        }
+
 
 
         $maybeDisableVoucher = new MaybeDisableGateway();

--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -285,31 +285,35 @@ class GatewayModule implements ServiceModule, ExecutableModule
 
         // Set order to paid and processed when eventually completed without Mollie
         add_action('woocommerce_payment_complete', [$this, 'setOrderPaidByOtherGateway'], 10, 1);
-        $appleGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_applepay']) ? $container->get(
-            'gateway.instances'
-        )['mollie_wc_gateway_applepay'] : false;
-        $notice = $container->get(AdminNotice::class);
-        assert($notice instanceof AdminNotice);
-        $logger = $container->get(Logger::class);
-        assert($logger instanceof Logger);
-        $pluginUrl = $container->get('shared.plugin_url');
-        $apiHelper = $container->get('SDK.api_helper');
-        assert($apiHelper instanceof Api);
-        $settingsHelper = $container->get('settings.settings_helper');
-        assert($settingsHelper instanceof Settings);
+
         $surchargeService = $container->get(Surcharge::class);
         assert($surchargeService instanceof Surcharge);
         $this->gatewaySurchargeHandling($surchargeService);
-        if ($appleGateway) {
-            $this->mollieApplePayDirectHandling($notice, $logger, $apiHelper, $settingsHelper, $appleGateway);
-        }
+        add_action('after_setup_theme', function () use ($container) {
+            $notice = $container->get(AdminNotice::class);
+            assert($notice instanceof AdminNotice);
+            $logger = $container->get(Logger::class);
+            assert($logger instanceof Logger);
+            $pluginUrl = $container->get('shared.plugin_url');
+            $apiHelper = $container->get('SDK.api_helper');
+            assert($apiHelper instanceof Api);
+            $settingsHelper = $container->get('settings.settings_helper');
+            assert($settingsHelper instanceof Settings);
+            $appleGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_applepay']) ? $container->get(
+                'gateway.instances'
+            )['mollie_wc_gateway_applepay'] : false;
+            if ($appleGateway) {
+                $this->mollieApplePayDirectHandling($notice, $logger, $apiHelper, $settingsHelper, $appleGateway);
+            }
 
-        $paypalGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_paypal']) ? $container->get(
-            'gateway.instances'
-        )['mollie_wc_gateway_paypal'] : false;
-        if ($paypalGateway) {
-            $this->molliePayPalButtonHandling($paypalGateway, $notice, $logger, $pluginUrl);
-        }
+            $paypalGateway = isset($container->get('gateway.instances')['mollie_wc_gateway_paypal']) ? $container->get(
+                'gateway.instances'
+            )['mollie_wc_gateway_paypal'] : false;
+            if ($paypalGateway) {
+                $this->molliePayPalButtonHandling($paypalGateway, $notice, $logger, $pluginUrl);
+            }
+        });
+
 
         $maybeDisableVoucher = new MaybeDisableGateway();
         $dataService = $container->get('settings.data_helper');

--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -127,8 +127,9 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
         );
         $this->supports = $this->paymentMethod->getProperty('supports');
 
-        // Load the settings.
-        $this->init_form_fields();
+        // Load the settings when translations are ready
+        add_action('after_setup_theme', [$this, 'init_form_fields']);
+
         $this->init_settings();
         $this->title = $this->paymentMethod->title();
 

--- a/src/Gateway/MolliePaymentGateway.php
+++ b/src/Gateway/MolliePaymentGateway.php
@@ -128,7 +128,7 @@ class MolliePaymentGateway extends WC_Payment_Gateway implements MolliePaymentGa
         $this->supports = $this->paymentMethod->getProperty('supports');
 
         // Load the settings when translations are ready
-        add_action('after_setup_theme', [$this, 'init_form_fields']);
+        add_action('init', [$this, 'init_form_fields']);
 
         $this->init_settings();
         $this->title = $this->paymentMethod->title();

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -65,8 +65,8 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         $this->config = $this->getConfig();
         $this->settings = $this->getSettings();
         $this->apiPaymentMethod = $apiPaymentMethod;
-        add_action('after_setup_theme', [$this, 'initializeTranslations']);
-        add_action('after_setup_theme', [$this, 'updateSettingsWithDefaults']);
+        add_action('init', [$this, 'initializeTranslations']);
+        add_action('init', [$this, 'updateSettingsWithDefaults']);
     }
 
     public function title(): string

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -44,6 +44,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
      * @var array
      */
     private $apiPaymentMethod;
+    protected bool $translationsInitialized = false;
 
     public function __construct(
         IconFactory $iconFactory,
@@ -61,6 +62,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         $this->config = $this->getConfig();
         $this->settings = $this->getSettings();
         $this->apiPaymentMethod = $apiPaymentMethod;
+        add_action('after_setup_theme', [$this, 'initializeTranslations']);
     }
 
     public function title(): string

--- a/src/PaymentMethods/AbstractPaymentMethod.php
+++ b/src/PaymentMethods/AbstractPaymentMethod.php
@@ -44,6 +44,9 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
      * @var array
      */
     private $apiPaymentMethod;
+    /**
+     * @var bool
+     */
     protected bool $translationsInitialized = false;
 
     public function __construct(
@@ -63,6 +66,7 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
         $this->settings = $this->getSettings();
         $this->apiPaymentMethod = $apiPaymentMethod;
         add_action('after_setup_theme', [$this, 'initializeTranslations']);
+        add_action('after_setup_theme', [$this, 'updateSettingsWithDefaults']);
     }
 
     public function title(): string
@@ -225,6 +229,20 @@ abstract class AbstractPaymentMethod implements PaymentMethodI
      * @return array
      */
     public function getSettings(): array
+    {
+        $optionName = 'mollie_wc_gateway_' . $this->id . '_settings';
+        $settings = get_option($optionName, false);
+        if (!$settings) {
+            $settings = [];
+        }
+        return $settings;
+    }
+
+    /**
+     * Update the payment method's settings with defaults if not exist
+     * @return array
+     */
+    public function updateSettingsWithDefaults(): array
     {
         $optionName = 'mollie_wc_gateway_' . $this->id . '_settings';
         $settings = get_option($optionName, false);

--- a/src/PaymentMethods/Alma.php
+++ b/src/PaymentMethods/Alma.php
@@ -10,7 +10,7 @@ class Alma extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'alma',
-            'defaultTitle' => __('Alma', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Alma',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -29,7 +29,15 @@ class Alma extends AbstractPaymentMethod implements PaymentMethodI
             'docs' => 'https://www.mollie.com/gb/payments/alma',
         ];
     }
-
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Alma', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
+    }
     public function getFormFields($generalFormFields): array
     {
         return $generalFormFields;

--- a/src/PaymentMethods/Applepay.php
+++ b/src/PaymentMethods/Applepay.php
@@ -10,8 +10,8 @@ class Applepay extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'applepay',
-            'defaultTitle' => __('Apple Pay', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __('To accept payments via Apple Pay', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Apple Pay',
+            'settingsDescription' => 'To accept payments via Apple Pay',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => true,
@@ -28,6 +28,19 @@ class Applepay extends AbstractPaymentMethod implements PaymentMethodI
         ];
     }
 
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Apple Pay', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Apple Pay',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->translationsInitialized = true;
+    }
     public function getFormFields($generalFormFields): array
     {
 

--- a/src/PaymentMethods/Bancomatpay.php
+++ b/src/PaymentMethods/Bancomatpay.php
@@ -10,7 +10,7 @@ class Bancomatpay extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'bancomatpay',
-            'defaultTitle' => __('Bancomat Pay', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Bancomat Pay',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -23,6 +23,16 @@ class Bancomatpay extends AbstractPaymentMethod implements PaymentMethodI
             'confirmationDelayed' => false,
             'docs' => 'https://www.mollie.com/gb/payments/bancomat-pay',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Bancomat Pay', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Bancontact.php
+++ b/src/PaymentMethods/Bancontact.php
@@ -10,7 +10,7 @@ class Bancontact extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'bancontact',
-            'defaultTitle' => __('Bancontact', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Bancontact',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,16 @@ class Bancontact extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => true,
             'docs' => 'https://www.mollie.com/gb/payments/bancontact',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Bancontact', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Banktransfer.php
+++ b/src/PaymentMethods/Banktransfer.php
@@ -29,7 +29,7 @@ class Banktransfer extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'banktransfer',
-            'defaultTitle' => __('Bank Transfer', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Bank Transfer',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -45,6 +45,17 @@ class Banktransfer extends AbstractPaymentMethod implements PaymentMethodI
             'docs' => 'https://www.mollie.com/gb/payments/bank-transfer',
         ];
     }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Bank Transfer', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
+    }
+
 
     public function getFormFields($generalFormFields): array
     {

--- a/src/PaymentMethods/Belfius.php
+++ b/src/PaymentMethods/Belfius.php
@@ -10,7 +10,7 @@ class Belfius extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'belfius',
-            'defaultTitle' => __('Belfius Direct Net', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Belfius Direct Net',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -26,6 +26,15 @@ class Belfius extends AbstractPaymentMethod implements PaymentMethodI
         ];
     }
 
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Belfius Direct Net', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
+    }
     public function getFormFields($generalFormFields): array
     {
         return $generalFormFields;

--- a/src/PaymentMethods/Billie.php
+++ b/src/PaymentMethods/Billie.php
@@ -20,11 +20,8 @@ class Billie extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'billie',
-            'defaultTitle' => __('Billie', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Billie, all default WooCommerce checkout fields should be enabled and required.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Billie',
+            'settingsDescription' => 'To accept payments via Billie, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => true,
             'instructions' => false,
@@ -36,13 +33,33 @@ class Billie extends AbstractPaymentMethod implements PaymentMethodI
             'confirmationDelayed' => false,
             'SEPA' => false,
             'orderMandatory' => true,
-            'errorMessage' => __(
-                'Company field is empty. The company field is required.',
-                'mollie-payments-for-woocommerce'
-            ),
-            'companyPlaceholder' => __('Please enter your company name here.', 'mollie-payments-for-woocommerce'),
+            'errorMessage' => 'Company field is empty. The company field is required.',
+            'companyPlaceholder' => 'Please enter your company name here.',
             'docs' => 'https://www.mollie.com/gb/payments/billie',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Billie', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Billie, all default WooCommerce checkout fields should be enabled and required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->config['errorMessage'] = __(
+            'Company field is empty. The company field is required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->config['companyPlaceholder'] = __(
+            'Please enter your company name here.',
+            'mollie-payments-for-woocommerce'
+        );
+
+        $this->translationsInitialized = true;
     }
 
     /**

--- a/src/PaymentMethods/Blik.php
+++ b/src/PaymentMethods/Blik.php
@@ -10,7 +10,7 @@ class Blik extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'blik',
-            'defaultTitle' => __('BLIK', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'BLIK',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,16 @@ class Blik extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/blik',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('BLIK', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Creditcard.php
+++ b/src/PaymentMethods/Creditcard.php
@@ -13,7 +13,7 @@ class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'creditcard',
-            'defaultTitle' => __('Credit card', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Credit card',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => $this->hasPaymentFields(),
@@ -29,6 +29,15 @@ class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
             'Subscription' => true,
             'docs' => 'https://www.mollie.com/gb/payments/credit-card',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Credit card', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Directdebit.php
+++ b/src/PaymentMethods/Directdebit.php
@@ -10,8 +10,8 @@ class Directdebit extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'directdebit',
-            'defaultTitle' => __('SEPA Direct Debit', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __("SEPA Direct Debit is used for recurring payments with WooCommerce Subscriptions, and will not be shown in the WooCommerce checkout for regular payments! You also need to enable iDEAL and/or other 'first' payment methods if you want to use SEPA Direct Debit.", 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'SEPA Direct Debit', 'mollie-payments-for-woocommerce',
+            'settingsDescription' => "SEPA Direct Debit is used for recurring payments with WooCommerce Subscriptions, and will not be shown in the WooCommerce checkout for regular payments! You also need to enable iDEAL and/or other 'first' payment methods if you want to use SEPA Direct Debit.",
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => true,
@@ -24,6 +24,16 @@ class Directdebit extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/direct-debit',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('SEPA Direct Debit', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __("SEPA Direct Debit is used for recurring payments with WooCommerce Subscriptions, and will not be shown in the WooCommerce checkout for regular payments! You also need to enable iDEAL and/or other 'first' payment methods if you want to use SEPA Direct Debit.", 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Eps.php
+++ b/src/PaymentMethods/Eps.php
@@ -10,7 +10,7 @@ class Eps extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'eps',
-            'defaultTitle' => __('EPS', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'EPS',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,16 @@ class Eps extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => true,
             'docs' => 'https://www.mollie.com/gb/payments/eps',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('EPS', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Giftcard.php
+++ b/src/PaymentMethods/Giftcard.php
@@ -59,9 +59,9 @@ class Giftcard extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'giftcard',
-            'defaultTitle' => __('Gift cards', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Gift cards', 'mollie-payments-for-woocommerce',
             'settingsDescription' => '',
-            'defaultDescription' => __('Select your gift card', 'mollie-payments-for-woocommerce'),
+            'defaultDescription' => 'Select your gift card',
             'paymentFields' => true,
             'instructions' => false,
             'supports' => [
@@ -72,6 +72,16 @@ class Giftcard extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/gift-cards',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Gift cards', 'mollie-payments-for-woocommerce');
+        $this->config['defaultDescription'] = __('Select your gift card', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Giropay.php
+++ b/src/PaymentMethods/Giropay.php
@@ -10,7 +10,7 @@ class Giropay extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'giropay',
-            'defaultTitle' => __('Giropay', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Giropay',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,16 @@ class Giropay extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => true,
             'docs' => 'https://help.mollie.com/hc/en-gb/articles/19745480480786-Giropay-Depreciation-FAQ',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Giropay', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Ideal.php
+++ b/src/PaymentMethods/Ideal.php
@@ -12,7 +12,7 @@ class Ideal extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'ideal',
-            'defaultTitle' => __('iDEAL', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'iDEAL',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -28,6 +28,15 @@ class Ideal extends AbstractPaymentMethod implements PaymentMethodI
         ];
     }
 
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('iDEAL', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
+    }
+
     public function getFormFields($generalFormFields): array
     {
         $notice = [
@@ -36,12 +45,12 @@ class Ideal extends AbstractPaymentMethod implements PaymentMethodI
                     sprintf(
                     /* translators: Placeholder 1: paragraph opening tag Placeholder 2: link url Placeholder 3: link closing tag 4: link url Placeholder  5: closing tags */
                         __(
-                            '%1$s Note: In June 2024, Mollie upgraded its iDEAL implementation to iDEAL 2.0. 
-                            As a result, the bank selector dropdown is no longer displayed on the checkout page when using the Mollie plugin. 
-                            Buyers will now select their bank directly on the iDEAL website. 
-                            The only action required from you is to update your iDEAL gateway description to remove any prompts for buyers to select a bank during checkout. 
-                            No further manual action is needed. For more details about the iDEAL 2.0 migration, please visit the 
-                            %2$s Mollie Help Center %3$s or read this 
+                            '%1$s Note: In June 2024, Mollie upgraded its iDEAL implementation to iDEAL 2.0.
+                            As a result, the bank selector dropdown is no longer displayed on the checkout page when using the Mollie plugin.
+                            Buyers will now select their bank directly on the iDEAL website.
+                            The only action required from you is to update your iDEAL gateway description to remove any prompts for buyers to select a bank during checkout.
+                            No further manual action is needed. For more details about the iDEAL 2.0 migration, please visit the
+                            %2$s Mollie Help Center %3$s or read this
                             %4$s this blog post. %5$s',
                             'mollie-payments-for-woocommerce'
                         ),

--- a/src/PaymentMethods/In3.php
+++ b/src/PaymentMethods/In3.php
@@ -10,9 +10,9 @@ class In3 extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'in3',
-            'defaultTitle' => __('in3', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'in3',
             'settingsDescription' => '',
-            'defaultDescription' => __('Pay in 3 instalments, 0% interest', 'mollie-payments-for-woocommerce'),
+            'defaultDescription' => 'Pay in 3 instalments, 0% interest',
             'paymentFields' => true,
             'additionalFields' => ['birthdate', 'phone'],
             'instructions' => false,
@@ -23,14 +23,27 @@ class In3 extends AbstractPaymentMethod implements PaymentMethodI
             'filtersOnBuild' => false,
             'confirmationDelayed' => false,
             'orderMandatory' => true,
-            'errorMessage' => __(
-                'Required field is empty or invalid. Phone (+316xxxxxxxx) and birthdate fields are required.',
-                'mollie-payments-for-woocommerce'
-            ),
-            'phonePlaceholder' => __('Please enter your phone here. +316xxxxxxxx', 'mollie-payments-for-woocommerce'),
-            'birthdatePlaceholder' => __('Please enter your birthdate here.', 'mollie-payments-for-woocommerce'),
+            'errorMessage' => 'Required field is empty or invalid. Phone (+316xxxxxxxx) and birthdate fields are required.',
+            'phonePlaceholder' => 'Please enter your phone here. +316xxxxxxxx',
+            'birthdatePlaceholder' => 'Please enter your birthdate here.',
             'docs' => 'https://www.mollie.com/gb/payments/ideal-in3',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('in3', 'mollie-payments-for-woocommerce');
+        $this->config['defaultDescription'] = __('Pay in 3 instalments, 0% interest', 'mollie-payments-for-woocommerce');
+        $this->config['errorMessage'] = __(
+            'Required field is empty or invalid. Phone (+316xxxxxxxx) and birthdate fields are required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->config['phonePlaceholder'] = __('Please enter your phone here. +316xxxxxxxx', 'mollie-payments-for-woocommerce');
+        $this->config['birthdatePlaceholder'] = __('Please enter your birthdate here.', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Kbc.php
+++ b/src/PaymentMethods/Kbc.php
@@ -11,9 +11,9 @@ class Kbc extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
         'id' => 'kbc',
-        'defaultTitle' => __('KBC/CBC Payment Button', 'mollie-payments-for-woocommerce'),
+        'defaultTitle' => 'KBC/CBC Payment Button',
         'settingsDescription' => '',
-        'defaultDescription' => __('Select your bank', 'mollie-payments-for-woocommerce'),
+        'defaultDescription' => 'Select your bank',
         'paymentFields' => true,
         'instructions' => false,
         'supports' => [
@@ -25,6 +25,16 @@ class Kbc extends AbstractPaymentMethod implements PaymentMethodI
         'SEPA' => true,
             'docs' => 'https://www.mollie.com/gb/payments/kbc-cbc',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('KBC/CBC Payment Button', 'mollie-payments-for-woocommerce');
+        $this->config['defaultDescription'] = __('Select your bank', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Klarna.php
+++ b/src/PaymentMethods/Klarna.php
@@ -10,11 +10,8 @@ class Klarna extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'klarna',
-            'defaultTitle' => __('Pay with Klarna', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Pay with Klarna',
+            'settingsDescription' => 'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => false,
@@ -28,6 +25,19 @@ class Klarna extends AbstractPaymentMethod implements PaymentMethodI
             'orderMandatory' => true,
             'docs' => 'https://www.mollie.com/gb/payments/klarna',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Pay with Klarna', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Klarnapaylater.php
+++ b/src/PaymentMethods/Klarnapaylater.php
@@ -10,11 +10,8 @@ class Klarnapaylater extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'klarnapaylater',
-            'defaultTitle' => __('Klarna Pay later', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Klarna Pay later',
+            'settingsDescription' => 'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => false,
@@ -28,6 +25,19 @@ class Klarnapaylater extends AbstractPaymentMethod implements PaymentMethodI
             'orderMandatory' => true,
             'docs' => 'https://www.mollie.com/gb/payments/klarna',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Klarna Pay later', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Klarnapaynow.php
+++ b/src/PaymentMethods/Klarnapaynow.php
@@ -10,11 +10,8 @@ class Klarnapaynow extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'klarnapaynow',
-            'defaultTitle' => __('Klarna Pay Now', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Klarna Pay Now',
+            'settingsDescription' => 'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => false,
@@ -28,6 +25,19 @@ class Klarnapaynow extends AbstractPaymentMethod implements PaymentMethodI
             'orderMandatory' => true,
             'docs' => 'https://www.mollie.com/gb/payments/klarna',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Klarna Pay Now', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Klarnasliceit.php
+++ b/src/PaymentMethods/Klarnasliceit.php
@@ -10,11 +10,8 @@ class Klarnasliceit extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'klarnasliceit',
-            'defaultTitle' => __('Klarna Slice it', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Klarna Slice it', 'mollie-payments-for-woocommerce',
+            'settingsDescription' => 'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => false,
@@ -28,6 +25,19 @@ class Klarnasliceit extends AbstractPaymentMethod implements PaymentMethodI
             'orderMandatory' => true,
             'docs' => 'https://www.mollie.com/gb/payments/klarna',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Klarna Slice it', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Mybank.php
+++ b/src/PaymentMethods/Mybank.php
@@ -10,8 +10,8 @@ class Mybank extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'mybank',
-            'defaultTitle' => __('MyBank', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __('To accept payments via MyBank', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'MyBank',
+            'settingsDescription' => 'To accept payments via MyBank',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => true,
@@ -24,6 +24,16 @@ class Mybank extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => '',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('MyBank', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __('To accept payments via MyBank', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Payconiq.php
+++ b/src/PaymentMethods/Payconiq.php
@@ -10,7 +10,7 @@ class Payconiq extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'payconiq',
-            'defaultTitle' => __('payconiq', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'payconiq',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -21,6 +21,15 @@ class Payconiq extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => '',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('payconiq', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Paypal.php
+++ b/src/PaymentMethods/Paypal.php
@@ -10,7 +10,7 @@ class Paypal extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'paypal',
-            'defaultTitle' => __('PayPal', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'PayPal',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,15 @@ class Paypal extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/paypal',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('PayPal', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Paysafecard.php
+++ b/src/PaymentMethods/Paysafecard.php
@@ -10,7 +10,7 @@ class Paysafecard extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'paysafecard',
-            'defaultTitle' => __('paysafecard', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'paysafecard',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -21,6 +21,15 @@ class Paysafecard extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/paysafecard',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('paysafecard', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Przelewy24.php
+++ b/src/PaymentMethods/Przelewy24.php
@@ -10,11 +10,8 @@ class Przelewy24 extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'przelewy24',
-            'defaultTitle' => __('Przelewy24', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Przelewy24, a customer email is required for every payment.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Przelewy24',
+            'settingsDescription' => 'To accept payments via Przelewy24, a customer email is required for every payment.',
             'defaultDescription' => '',
             'paymentFields' => false,
             'instructions' => true,
@@ -27,6 +24,19 @@ class Przelewy24 extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/przelewy24',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Przelewy24', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Przelewy24, a customer email is required for every payment.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Riverty.php
+++ b/src/PaymentMethods/Riverty.php
@@ -12,11 +12,8 @@ class Riverty extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'riverty',
-            'defaultTitle' => __('Riverty', 'mollie-payments-for-woocommerce'),
-            'settingsDescription' => __(
-                'To accept payments via Riverty, all default WooCommerce checkout fields should be enabled and required.',
-                'mollie-payments-for-woocommerce'
-            ),
+            'defaultTitle' => 'Riverty',
+            'settingsDescription' => 'To accept payments via Riverty, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => true,
             'additionalFields' => ['birthdate', 'phone'],
@@ -29,10 +26,26 @@ class Riverty extends AbstractPaymentMethod implements PaymentMethodI
             'confirmationDelayed' => false,
             'SEPA' => false,
             'orderMandatory' => true,
-            'phonePlaceholder' => __('Please enter your phone here. +316xxxxxxxx', 'mollie-payments-for-woocommerce'),
-            'birthdatePlaceholder' => __('Please enter your birthdate here.', 'mollie-payments-for-woocommerce'),
+            'phonePlaceholder' => 'Please enter your phone here. +316xxxxxxxx', 'mollie-payments-for-woocommerce',
+            'birthdatePlaceholder' => 'Please enter your birthdate here.', 'mollie-payments-for-woocommerce',
             'docs' => 'https://www.mollie.com/gb/payments/riverty',
         ];
+    }
+
+    // Replace translatable strings after the 'after_setup_theme' hook
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Riverty', 'mollie-payments-for-woocommerce');
+        $this->config['settingsDescription'] = __(
+            'To accept payments via Riverty, all default WooCommerce checkout fields should be enabled and required.',
+            'mollie-payments-for-woocommerce'
+        );
+        $this->config['phonePlaceholder'] = __('Please enter your phone here. +316xxxxxxxx', 'mollie-payments-for-woocommerce');
+        $this->config['birthdatePlaceholder'] = __('Please enter your birthdate here.', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Satispay.php
+++ b/src/PaymentMethods/Satispay.php
@@ -10,7 +10,7 @@ class Satispay extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'satispay',
-            'defaultTitle' => __('Satispay', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Satispay',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -21,6 +21,15 @@ class Satispay extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/satispay',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Satispay', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Sofort.php
+++ b/src/PaymentMethods/Sofort.php
@@ -10,7 +10,7 @@ class Sofort extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'sofort',
-            'defaultTitle' => __('SOFORT Banking', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'SOFORT Banking',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,15 @@ class Sofort extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => true,
             'docs' => 'https://help.mollie.com/hc/en-us/articles/20904206772626-SOFORT-Deprecation-30-September-2024',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('SOFORT Banking', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Swish.php
+++ b/src/PaymentMethods/Swish.php
@@ -10,7 +10,7 @@ class Swish extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'swish',
-            'defaultTitle' => __('Swish', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Swish',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -23,6 +23,15 @@ class Swish extends AbstractPaymentMethod implements PaymentMethodI
             'confirmationDelayed' => false,
             'SEPA' => false,
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Swish', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Trustly.php
+++ b/src/PaymentMethods/Trustly.php
@@ -10,7 +10,7 @@ class Trustly extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'trustly',
-            'defaultTitle' => __('Trustly', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Trustly',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,15 @@ class Trustly extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => true,
             'docs' => 'https://www.mollie.com/gb/payments/trustly',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Trustly', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Twint.php
+++ b/src/PaymentMethods/Twint.php
@@ -10,7 +10,7 @@ class Twint extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'twint',
-            'defaultTitle' => __('Twint', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Twint',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -24,6 +24,15 @@ class Twint extends AbstractPaymentMethod implements PaymentMethodI
             'SEPA' => false,
             'docs' => 'https://www.mollie.com/gb/payments/twint',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Twint', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/PaymentMethods/Voucher.php
+++ b/src/PaymentMethods/Voucher.php
@@ -31,7 +31,7 @@ class Voucher extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'voucher',
-            'defaultTitle' => __('Voucher', 'mollie-payments-for-woocommerce'),
+            'defaultTitle' => 'Voucher',
             'settingsDescription' => '',
             'defaultDescription' => '',
             'paymentFields' => false,
@@ -45,6 +45,15 @@ class Voucher extends AbstractPaymentMethod implements PaymentMethodI
             'orderMandatory' => true,
             'docs' => 'https://www.mollie.com/gb/payments/meal-eco-gift-vouchers',
         ];
+    }
+
+    public function initializeTranslations(): void
+    {
+        if ($this->translationsInitialized) {
+            return;
+        }
+        $this->config['defaultTitle'] = __('Voucher', 'mollie-payments-for-woocommerce');
+        $this->translationsInitialized = true;
     }
 
     public function getFormFields($generalFormFields): array

--- a/src/Shared/GatewaySurchargeHandler.php
+++ b/src/Shared/GatewaySurchargeHandler.php
@@ -19,8 +19,12 @@ class GatewaySurchargeHandler
     public function __construct(Surcharge $surcharge)
     {
         $this->surcharge = $surcharge;
-        $this->gatewayFeeLabel = $this->surchargeFeeOption();
+        add_action('after_setup_theme', [$this, 'initializeGatewayFeeLabel']);
         add_action('init', [$this, 'surchargeActions']);
+    }
+    public function initializeGatewayFeeLabel()
+    {
+        $this->gatewayFeeLabel = $this->surchargeFeeOption();
     }
 
     public function surchargeActions()

--- a/src/Shared/SharedModule.php
+++ b/src/Shared/SharedModule.php
@@ -37,15 +37,11 @@ class SharedModule implements ServiceModule
                 return plugin_basename(self::PLUGIN_ID . '/' . self::PLUGIN_ID . '.php');
             },
             'shared.plugin_url' => static function (ContainerInterface $container): string {
-                $pluginProperties = $container->get(Package::PROPERTIES);
-
-                return $pluginProperties->baseUrl();
+                return $container->get('properties')->baseUrl();
             },
             'shared.plugin_path' => static function (ContainerInterface $container): string {
 
-                $pluginProperties = $container->get(Package::PROPERTIES);
-
-                return $pluginProperties->basePath();
+                return $container->get('properties')->basePath();
             },
             'shared.status_helper' => static function (ContainerInterface $container): Status {
                 $pluginTitle = $container->get('shared.plugin_title');

--- a/tests/php/Functional/Shared/SurchargeHandlerTest.php
+++ b/tests/php/Functional/Shared/SurchargeHandlerTest.php
@@ -59,6 +59,7 @@ class SurchargeHandlerTest extends TestCase
             [new Surcharge()],
             ['canProcessOrder', 'canProcessGateway', 'orderRemoveFee', 'orderAddFee']
         )->getMock();
+        $testee->initializeGatewayFeeLabel();
         expect('mollieWooCommerceIsCheckoutContext')->andReturn(true);
         expect('wc_tax_enabled')->andReturn(false);
         expect('WC')->andReturn($this->wooCommerce());
@@ -106,6 +107,7 @@ class SurchargeHandlerTest extends TestCase
             [new Surcharge()],
             ['canProcessOrder', 'canProcessGateway', 'orderRemoveFee', 'orderAddFee']
         )->getMock();
+        $testee->initializeGatewayFeeLabel();
 
         $testee->expects($this->once())
             ->method('canProcessOrder')


### PR DESCRIPTION
This PR solves an issue where the Mollie methods in blocks appeared as non compatible. This was due to the change in the init hook. Now we are back to the `plugins_loaded` hook. To avoid the translations called too early issue the payment fields were moved to a later hook `after_setup_theme`