### PR TITLE
Fix value if missing option

### DIFF
--- a/src/PaymentMethods/Directdebit.php
+++ b/src/PaymentMethods/Directdebit.php
@@ -10,7 +10,7 @@ class Directdebit extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'directdebit',
-            'defaultTitle' => 'SEPA Direct Debit', 'mollie-payments-for-woocommerce',
+            'defaultTitle' => 'SEPA Direct Debit',
             'settingsDescription' => "SEPA Direct Debit is used for recurring payments with WooCommerce Subscriptions, and will not be shown in the WooCommerce checkout for regular payments! You also need to enable iDEAL and/or other 'first' payment methods if you want to use SEPA Direct Debit.",
             'defaultDescription' => '',
             'paymentFields' => false,

--- a/src/PaymentMethods/Giftcard.php
+++ b/src/PaymentMethods/Giftcard.php
@@ -59,7 +59,7 @@ class Giftcard extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'giftcard',
-            'defaultTitle' => 'Gift cards', 'mollie-payments-for-woocommerce',
+            'defaultTitle' => 'Gift cards',
             'settingsDescription' => '',
             'defaultDescription' => 'Select your gift card',
             'paymentFields' => true,

--- a/src/PaymentMethods/Klarnasliceit.php
+++ b/src/PaymentMethods/Klarnasliceit.php
@@ -10,7 +10,7 @@ class Klarnasliceit extends AbstractPaymentMethod implements PaymentMethodI
     {
         return [
             'id' => 'klarnasliceit',
-            'defaultTitle' => 'Klarna Slice it', 'mollie-payments-for-woocommerce',
+            'defaultTitle' => 'Klarna Slice it',
             'settingsDescription' => 'To accept payments via Klarna, all default WooCommerce checkout fields should be enabled and required.',
             'defaultDescription' => '',
             'paymentFields' => false,

--- a/src/Settings/SettingsModule.php
+++ b/src/Settings/SettingsModule.php
@@ -78,7 +78,7 @@ class SettingsModule implements ServiceModule, ExecutableModule
                 return $settingsHelper->isTestModeEnabled();
             },
             'settings.IsDebugEnabled' => static function (): bool {
-                $debugEnabled = get_option('mollie-payments-for-woocommerce_debug', true);
+                $debugEnabled = get_option('mollie-payments-for-woocommerce_debug', 'yes');
                 return $debugEnabled === 'yes';
             },
             'settings.advanced_default_options' => static function (ContainerInterface $container) {


### PR DESCRIPTION
If there is no value for logs yet, we default to 'yes' and so the logs will run by default