### PR TITLE
Update RefundLineItemsBuilder.php, Force refund item quantity to integer

### DIFF
--- a/src/Payment/RefundLineItemsBuilder.php
+++ b/src/Payment/RefundLineItemsBuilder.php
@@ -105,7 +105,7 @@ class RefundLineItemsBuilder
         $currency
     ) {
 
-        $toRefundItemQuantity = abs($toRefundItem->get_quantity());
+        $toRefundItemQuantity = abs((int) $toRefundItem->get_quantity());
         $toRefundItemAmount = number_format(
             abs($toRefundItem->get_total() + $toRefundItem->get_total_tax()),
             2


### PR DESCRIPTION
Force refund item quantity to integer as stated in https://github.com/mollie/WooCommerce/issues/992 