### PR TITLE
fix: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated with ApplePay on PHP8.2

### DIFF
--- a/src/PaymentMethods/Applepay.php
+++ b/src/PaymentMethods/Applepay.php
@@ -47,21 +47,26 @@ class Applepay extends AbstractPaymentMethod implements PaymentMethodI
         $checkout_page_id = wc_get_page_id('checkout');
         $edit_checkout_page_link = get_edit_post_link($checkout_page_id);
 
-        $notice = [
-            'notice' => [
-                'title' => sprintf(
-                    /* translators: Placeholder 1: link url */
-                    __(
-                        '<p>The appearance of the Apple Pay button can be controlled in the <a href="%1$s">Checkout page editor</a>.</p>',
-                        'mollie-payments-for-woocommerce'
+        if ($edit_checkout_page_link) {
+            $notice = [
+                'notice' => [
+                    'title' => sprintf(
+                        /* translators: Placeholder 1: link url */
+                        __(
+                            '<p>The appearance of the Apple Pay button can be controlled in the <a href="%1$s">Checkout page editor</a>.</p>',
+                            'mollie-payments-for-woocommerce'
+                        ),
+                        esc_url($edit_checkout_page_link)
                     ),
-                    esc_url($edit_checkout_page_link)
-                ),
-                'type' => 'title',
-                'class' => 'notice notice-warning',
-                'css' => 'padding:20px;',
-            ],
-        ];
+                    'type' => 'title',
+                    'class' => 'notice notice-warning',
+                    'css' => 'padding:20px;',
+                ],
+            ];
+        } else {
+            $notice = [];
+        }
+
         $paymentMethodFormFieds = [
             'mollie_apple_pay_button_enabled_cart' => [
                 'title' => __('Enable Apple Pay Button on Cart page', 'mollie-payments-for-woocommerce'),


### PR DESCRIPTION
This fixes an issue where php8.2 wil throw an error when ltrim function receives a null value.

This issues occurs because $edit_checkout_page_link can be null at the moment, because get_edit_post_link doesn't return anything if the user can't edit the post.

And when it gets passed to the esc_url function, it uses ltrim, which will throw an error.

I added an if statement to the notice, because it doesn't make sense to show a notice without a link.
