### PR TITLE
adjust target blank for "More Information" on inactive payment methods

### DIFF
--- a/src/Settings/Page/Section/PaymentMethods.php
+++ b/src/Settings/Page/Section/PaymentMethods.php
@@ -226,7 +226,7 @@ class PaymentMethods extends AbstractSection
             )) . '</span>';
         } else {
             if ($documentationLink) {
-                $messageOrLink = "<a class='mollie-settings-pm__info' href='" . $documentationLink . "'>" . esc_html(__(
+                $messageOrLink = "<a class='mollie-settings-pm__info' href='" . $documentationLink . "' target='_blank'>" . esc_html(__(
                     'More information',
                     'mollie-payments-for-woocommerce'
                 )) . '</a>';


### PR DESCRIPTION
Currently the inactive payment methods show a "More Information" link at the end of the payment method name for users to explore more about the payment method. This currently doesnt open in a new tab. This PR resolves this and opens the information in a new tab so users dont lose the current settings page.