### PR TITLE
Mollie Payments Failing Due to Negative unitPrice from WooCommerce Line Item Rounding

### DIFF
--- a/src/Payment/OrderLines.php
+++ b/src/Payment/OrderLines.php
@@ -78,32 +78,34 @@ class OrderLines
         $linesTotal = array_sum(array_map(static function ($line) {
             return $line['totalAmount']['value'];
         }, $this->order_lines));
-        $orderTotalDiff = $orderTotalRounded - $linesTotal;
-        if (abs($orderTotalDiff) > 0) {
-            $mismatch =  [
-                'type' => 'surcharge',
-                'name' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
-                'quantity' => 1,
-                'vatRate' => 0,
-                'unitPrice' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
-                ],
-                'totalAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
-                ],
-                'vatAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue(0, $this->currency),
-                ],
-                'metadata' =>  [
-                    'order_item_id' => 'rounding_diff',
-                ],
-            ];
-
-            $this->order_lines[] = $mismatch;
+        $linesTotalRounded = round($linesTotal, 2);
+        $orderTotalDiff = $orderTotalRounded - $linesTotalRounded;
+        if (empty($orderTotalDiff)) {
+            return;
         }
+        $mismatch =  [
+            'type' => $orderTotalDiff > 0 ? 'surcharge' : 'discount',
+            'name' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
+            'quantity' => 1,
+            'vatRate' => 0,
+            'unitPrice' =>  [
+                'currency' => $this->currency,
+                'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
+            ],
+            'totalAmount' =>  [
+                'currency' => $this->currency,
+                'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
+            ],
+            'vatAmount' =>  [
+                'currency' => $this->currency,
+                'value' => $this->dataHelper->formatCurrencyValue(0, $this->currency),
+            ],
+            'metadata' =>  [
+                'order_item_id' => 'rounding_diff',
+            ],
+        ];
+
+        $this->order_lines[] = $mismatch;
     }
 
     /**
@@ -200,30 +202,34 @@ class OrderLines
      */
     private function process_shipping()
     {
-        if ($this->order->get_shipping_methods() && WC()->session->get('chosen_shipping_methods')) {
-            $shipping =  [
-                'type' => 'shipping_fee',
-                'name' => $this->get_shipping_name(),
-                'quantity' => 1,
-                'vatRate' => $this->get_shipping_vat_rate(),
-                'unitPrice' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($this->get_shipping_amount(), $this->currency),
-                ],
-                'totalAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($this->get_shipping_amount(), $this->currency),
-                ],
-                'vatAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($this->get_shipping_tax_amount(), $this->currency),
-                ],
-                'metadata' =>  [
-                    'order_item_id' => $this->get_shipping_id(),
-                ],
-            ];
+        $shipping_methods = $this->order->get_shipping_methods();
+        if ($shipping_methods) {
+            foreach ($shipping_methods as $shipping_method) {
+                $vatRate = 0;
+                if ($shipping_method->get_total_tax() > 0 && $shipping_method->get_total() > 0) {
+                    $vatRate = round($shipping_method->get_total_tax() / $shipping_method->get_total(), 4) * 100;
+                }
+                $shipping = [
+                    'type' => 'shipping_fee',
+                    'description' => $shipping_method->get_name() ?: __('Shipping', 'mollie-payments-for-woocommerce'),
+                    'quantity' => 1,
+                    'vatRate' => $vatRate,
+                    'unitPrice' =>  [
+                        'currency' => $this->currency,
+                        'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total() + $shipping_method->get_total_tax(), $this->currency),
+                    ],
+                    'totalAmount' =>  [
+                        'currency' => $this->currency,
+                        'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total() + $shipping_method->get_total_tax(), $this->currency),
+                    ],
+                    'vatAmount' =>  [
+                        'currency' => $this->currency,
+                        'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total_tax(), $this->currency),
+                    ],
+                ];
 
-            $this->order_lines[] = $shipping;
+                $this->order_lines[] = $shipping;
+            }
         }
     }
 
@@ -256,6 +262,10 @@ class OrderLines
                     $cart_fee_vat_rate = 0;
                     $cart_fee_tax_amount = 0;
                     $cart_fee_total = $cart_fee['total'];
+                }
+
+                if (empty(round($cart_fee_total, 2))) {
+                    continue;
                 }
 
                 $fee =  [
@@ -532,101 +542,5 @@ class OrderLines
             return $localCategory;
         }
         return $category;
-    }
-
-    /**
-     * Get shipping method name.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @return string $shipping_name Name for selected shipping method.
-     */
-    private function get_shipping_name()
-    {
-        foreach ($this->order->get_items('shipping') as $i => $package) {
-            $chosen_method = isset(WC()->session->chosen_shipping_methods[ $i ]) ? WC()->session->chosen_shipping_methods[ $i ] : '';
-            if ('' !== $chosen_method) {
-                $package_rates = $package['rates'];
-                foreach ($package_rates as $rate_key => $rate_value) {
-                    if ($rate_key === $chosen_method) {
-                        $shipping_name = $rate_value->label;
-                    }
-                }
-            }
-        }
-
-        if (! isset($shipping_name)) {
-            $shipping_name = __('Shipping', 'mollie-payments-for-woocommerce');
-        }
-
-        return (string) $shipping_name;
-    }
-
-    /**
-     * Get shipping method name.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @return string $shipping_name Name for selected shipping method.
-     */
-    private function get_shipping_id()
-    {
-        $shipping_id = '';
-
-        foreach ($this->order->get_items('shipping') as $package) {
-            $shipping_id = $package->get_id();
-        }
-
-        return (string) $shipping_id;
-    }
-
-    /**
-     * Get shipping method amount.
-     *
-     * @since 1.0
-     *
-     * @access private
-     *
-     * @return string $shipping_amount Amount for selected shipping method.
-     */
-    private function get_shipping_amount(): string
-    {
-        return number_format(( WC()->cart->shipping_total + WC()->cart->shipping_tax_total ), 2, '.', '');
-    }
-
-    /**
-     * Get shipping method tax rate.
-     *
-     * @since 1.0
-     *
-     * @access private
-     *
-     * @return float|int $shipping_vat_rate Tax rate for selected shipping method.
-     *
-     * @psalm-return 0|float
-     */
-    private function get_shipping_vat_rate()
-    {
-        $shipping_vat_rate = 0;
-        if (WC()->cart->shipping_tax_total > 0) {
-            $shipping_vat_rate = round(WC()->cart->shipping_tax_total / WC()->cart->shipping_total, 4) * 100;
-        }
-
-        return $shipping_vat_rate;
-    }
-
-    /**
-     * Get shipping method tax amount.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @return integer $shipping_tax_amount Tax amount for selected shipping method.
-     */
-    private function get_shipping_tax_amount()
-    {
-        return WC()->cart->shipping_tax_total;
     }
 }

--- a/src/Payment/PaymentLines.php
+++ b/src/Payment/PaymentLines.php
@@ -79,29 +79,30 @@ class PaymentLines
         $linesTotal = array_sum(array_map(static function ($line) {
             return $line['totalAmount']['value'];
         }, $this->order_lines));
-        $orderTotalDiff = $orderTotalRounded - $linesTotal;
-        if (abs($orderTotalDiff) > 0) {
-            $mismatch =  [
-                'type' => 'surcharge',
-                'description' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
-                'quantity' => 1,
-                'vatRate' => 0,
-                'unitPrice' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
-                ],
-                'totalAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
-                ],
-                'vatAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue(0, $this->currency),
-                ],
-            ];
-
-            $this->order_lines[] = $mismatch;
+        $linesTotalRounded = round($linesTotal, 2);
+        $orderTotalDiff = $orderTotalRounded - $linesTotalRounded;
+        if (empty($orderTotalDiff)) {
+            return;
         }
+        $mismatch =  [
+            'type' => $orderTotalDiff > 0 ? 'surcharge' : 'discount',
+            'description' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
+            'quantity' => 1,
+            'vatRate' => 0,
+            'unitPrice' =>  [
+                'currency' => $this->currency,
+                'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
+            ],
+            'totalAmount' =>  [
+                'currency' => $this->currency,
+                'value' => $this->dataHelper->formatCurrencyValue($orderTotalDiff, $this->currency),
+            ],
+            'vatAmount' =>  [
+                'currency' => $this->currency,
+                'value' => $this->dataHelper->formatCurrencyValue(0, $this->currency),
+            ],
+        ];
+        $this->order_lines[] = $mismatch;
     }
 
     /**
@@ -194,27 +195,34 @@ class PaymentLines
      */
     private function process_shipping()
     {
-        if ($this->order->get_shipping_methods() && WC()->session->get('chosen_shipping_methods')) {
-            $shipping =  [
-                'type' => 'shipping_fee',
-                'description' => $this->get_shipping_name(),
-                'quantity' => 1,
-                'vatRate' => $this->get_shipping_vat_rate(),
-                'unitPrice' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($this->get_shipping_amount(), $this->currency),
-                ],
-                'totalAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($this->get_shipping_amount(), $this->currency),
-                ],
-                'vatAmount' =>  [
-                    'currency' => $this->currency,
-                    'value' => $this->dataHelper->formatCurrencyValue($this->get_shipping_tax_amount(), $this->currency),
-                ],
-            ];
+        $shipping_methods = $this->order->get_shipping_methods();
+        if ($shipping_methods) {
+            foreach ($shipping_methods as $shipping_method) {
+                $vatRate = 0;
+                if ($shipping_method->get_total_tax() > 0 && $shipping_method->get_total() > 0) {
+                    $vatRate = round($shipping_method->get_total_tax() / $shipping_method->get_total(), 4) * 100;
+                }
+                $shipping = [
+                    'type' => 'shipping_fee',
+                    'description' => $shipping_method->get_name() ?: __('Shipping', 'mollie-payments-for-woocommerce'),
+                    'quantity' => 1,
+                    'vatRate' => $vatRate,
+                    'unitPrice' =>  [
+                        'currency' => $this->currency,
+                        'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total() + $shipping_method->get_total_tax(), $this->currency),
+                    ],
+                    'totalAmount' =>  [
+                        'currency' => $this->currency,
+                        'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total() + $shipping_method->get_total_tax(), $this->currency),
+                    ],
+                    'vatAmount' =>  [
+                        'currency' => $this->currency,
+                        'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total_tax(), $this->currency),
+                    ],
+                ];
 
-            $this->order_lines[] = $shipping;
+                $this->order_lines[] = $shipping;
+            }
         }
     }
 
@@ -248,6 +256,10 @@ class PaymentLines
                     $cart_fee_vat_rate = 0;
                     $cart_fee_tax_amount = 0;
                     $cart_fee_total = $cart_fee['total'];
+                }
+
+                if (empty(round($cart_fee_total, 2))) {
+                    continue;
                 }
 
                 $fee =  [
@@ -534,101 +546,5 @@ class PaymentLines
 
         sort($categories); //sort because of removing indexes
         return $categories;
-    }
-
-    /**
-     * Get shipping method name.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @return string $shipping_name Name for selected shipping method.
-     */
-    private function get_shipping_name()
-    {
-        foreach ($this->order->get_items('shipping') as $i => $package) {
-            $chosen_method = isset(WC()->session->chosen_shipping_methods[ $i ]) ? WC()->session->chosen_shipping_methods[ $i ] : '';
-            if ('' !== $chosen_method) {
-                $package_rates = $package['rates'];
-                foreach ($package_rates as $rate_key => $rate_value) {
-                    if ($rate_key === $chosen_method) {
-                        $shipping_name = $rate_value->label;
-                    }
-                }
-            }
-        }
-
-        if (! isset($shipping_name)) {
-            $shipping_name = __('Shipping', 'mollie-payments-for-woocommerce');
-        }
-
-        return (string) $shipping_name;
-    }
-
-    /**
-     * Get shipping method name.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @return string $shipping_name Name for selected shipping method.
-     */
-    private function get_shipping_id()
-    {
-        $shipping_id = '';
-
-        foreach ($this->order->get_items('shipping') as $package) {
-            $shipping_id = $package->get_id();
-        }
-
-        return (string) $shipping_id;
-    }
-
-    /**
-     * Get shipping method amount.
-     *
-     * @since 1.0
-     *
-     * @access private
-     *
-     * @return string $shipping_amount Amount for selected shipping method.
-     */
-    private function get_shipping_amount(): string
-    {
-        return number_format(( WC()->cart->shipping_total + WC()->cart->shipping_tax_total ), 2, '.', '');
-    }
-
-    /**
-     * Get shipping method tax rate.
-     *
-     * @since 1.0
-     *
-     * @access private
-     *
-     * @return float|int $shipping_vat_rate Tax rate for selected shipping method.
-     *
-     * @psalm-return 0|float
-     */
-    private function get_shipping_vat_rate()
-    {
-        $shipping_vat_rate = 0;
-        if (WC()->cart->shipping_tax_total > 0) {
-            $shipping_vat_rate = round(WC()->cart->shipping_tax_total / WC()->cart->shipping_total, 4) * 100;
-        }
-
-        return $shipping_vat_rate;
-    }
-
-    /**
-     * Get shipping method tax amount.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @return integer $shipping_tax_amount Tax amount for selected shipping method.
-     */
-    private function get_shipping_tax_amount()
-    {
-        return WC()->cart->shipping_tax_total;
     }
 }


### PR DESCRIPTION
- allow negative rounding correction
- fix getting of shipping costs on the pay for order page