### PR TITLE
Incorrect Order Status Update After Chargeback Due to Conflicting Webhooks

### DIFF
--- a/src/Payment/MollieOrder.php
+++ b/src/Payment/MollieOrder.php
@@ -186,7 +186,7 @@ class MollieOrder extends MollieObject
             }
             if (!empty($payment->amountChargedBack)) {
                 $this->logger->debug(
-                    __METHOD__ . ' payment at Mollie has a charged back, so no processing for order ' . $orderId
+                    __METHOD__ . ' payment at Mollie has a chargeback, so no processing for order ' . $orderId
                 );
                 return;
             }

--- a/src/Payment/MollieOrder.php
+++ b/src/Payment/MollieOrder.php
@@ -184,6 +184,12 @@ class MollieOrder extends MollieObject
             if ($payment->method === 'paypal') {
                 $this->addPaypalTransactionIdToOrder($order);
             }
+            if (!empty($payment->amountChargedBack)) {
+                $this->logger->debug(
+                    __METHOD__ . ' payment at Mollie has a charged back, so no processing for order ' . $orderId
+                );
+                return;
+            }
 
             $order->payment_complete($payment->id);
 

--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -164,7 +164,7 @@ class MolliePayment extends MollieObject
             }
             if (!empty($payment->amountChargedBack)) {
                 $this->logger->debug(
-                    __METHOD__ . ' payment at Mollie has a charged back, so no processing for order ' . $orderId
+                    __METHOD__ . ' payment at Mollie has a chargeback, so no processing for order ' . $orderId
                 );
                 return;
             }

--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -162,6 +162,12 @@ class MolliePayment extends MollieObject
             if ($payment->method === 'paypal') {
                 $this->addPaypalTransactionIdToOrder($order);
             }
+            if (!empty($payment->amountChargedBack)) {
+                $this->logger->debug(
+                    __METHOD__ . ' payment at Mollie has a charged back, so no processing for order ' . $orderId
+                );
+                return;
+            }
 
             // WooCommerce 2.2.0 has the option to store the Payment transaction id.
             $order->payment_complete($payment->id);


### PR DESCRIPTION
- do not set order as paid again on webhooks paid with chargebacks