### PR TITLE
Support Multiple Categories per Product/Voucher

### DIFF
--- a/src/Gateway/Voucher/MaybeDisableGateway.php
+++ b/src/Gateway/Voucher/MaybeDisableGateway.php
@@ -39,36 +39,31 @@ class MaybeDisableGateway
      */
     public function haveCartProductsCategories(): bool
     {
+        $voucherSettings = Voucher::voucherDefaultCategories();
+        if ($voucherSettings) {
+            return true;
+        }
+
         $cart = WC()->cart;
         if (!$cart) {
             return false;
         }
         $products = $cart->get_cart_contents();
-        $mealvoucherSettings = get_option(
-            'mollie_wc_gateway_voucher_settings'
-        );
-        if (!$mealvoucherSettings) {
-            $mealvoucherSettings = get_option(
-                'mollie_wc_gateway_mealvoucher_settings'
-            );
-        }
-        //Check if mealvoucherSettings is an array as to prevent notice from being thrown for PHP 7.4 and up.
-        if (is_array($mealvoucherSettings) && !empty($mealvoucherSettings['mealvoucher_category_default']) && $mealvoucherSettings['mealvoucher_category_default'] !== Voucher::NO_CATEGORY) {
-            return true;
-        }
-
         foreach ($products as $product) {
             if (!$product['data'] instanceof \WC_Product) {
                 continue;
             }
             $wcProduct = $product['data'];
             $metaKey = $wcProduct->is_type('variation') ? 'voucher' : Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION;
-            $localCategories = $wcProduct->get_meta($metaKey, false);
-            foreach ($localCategories as $key => $localCategory) {
-                assert($localCategory instanceof \WC_Meta_Data);
-                $localCategories[$key] = $localCategory->value;
+            $localCategories = $wcProduct->get_meta($metaKey);
+            //support old setting
+            if ($localCategories && !is_array($localCategories)) {
+                if ($localCategories === Voucher::NO_CATEGORY) {
+                    $localCategories = [];
+                }
+                $localCategories = [$localCategories];
             }
-            if ($localCategories && !in_array(Voucher::NO_CATEGORY, $localCategories, true)) {
+            if ($localCategories) {
                 return true;
             }
 
@@ -80,18 +75,11 @@ class MaybeDisableGateway
                 }
             }
             if ($catTermIds) {
-                $term_id = end($catTermIds);
-                $metaVouchers = [];
-                if ($term_id) {
-                    $metaVouchers = get_term_meta($term_id, '_mollie_voucher_category', false);
-                }
-                foreach ($metaVouchers as $key => $metaVoucher) {
-                    if (!$metaVoucher || $metaVoucher === Voucher::NO_CATEGORY) {
-                        unset($metaVouchers[$key]);
+                foreach ($catTermIds as $catTermId) {
+                    $metaVoucher = get_term_meta($catTermId, '_mollie_voucher_category', true);
+                    if ($metaVoucher && $metaVoucher !== Voucher::NO_CATEGORY) {
+                        return true;
                     }
-                }
-                if (!empty($metaVouchers)) {
-                    return true;
                 }
             }
         }

--- a/src/Gateway/Voucher/VoucherModule.php
+++ b/src/Gateway/Voucher/VoucherModule.php
@@ -32,22 +32,9 @@ class VoucherModule implements ExecutableModule, ServiceModule
 {
     use ModuleClassNameIdTrait;
 
-    /**
-     * @var string
-     */
-    protected $voucherDefaultCategory;
-
     public function services(): array
     {
         return [
-                'voucher.defaultCategory' => static function (ContainerInterface $container): string {
-                    $paymentMethods = $container->get('gateway.paymentMethods');
-                    $voucher = isset($paymentMethods['voucher']) ? $paymentMethods['voucher'] : false;
-                    if ($voucher) {
-                        return $voucher->voucherDefaultCategory();
-                    }
-                    return Voucher::NO_CATEGORY;
-                },
         ];
     }
 
@@ -63,7 +50,6 @@ class VoucherModule implements ExecutableModule, ServiceModule
         $voucher = $voucherGateway && $voucherGateway->enabled === 'yes';
 
         if ($voucher) {
-            $this->voucherDefaultCategory = $container->get('voucher.defaultCategory');
             $this->voucherEnabledHooks();
         }
 
@@ -89,7 +75,6 @@ class VoucherModule implements ExecutableModule, ServiceModule
         add_action('woocommerce_process_product_meta_variable', [$this, 'saveProductVoucherOptionFields']);
         add_action('woocommerce_product_after_variable_attributes', [$this, 'voucherFieldInVariations'], 10, 3);
         add_action('woocommerce_save_product_variation', [$this, 'saveVoucherFieldVariations'], 10, 2);
-        add_filter('woocommerce_available_variation', [$this, 'addVoucherVariationData']);
         add_action('woocommerce_product_bulk_edit_start', [$this, 'voucherBulkEditInput']);
         add_action('woocommerce_product_bulk_edit_save', [$this, 'voucherBulkEditSave']);
         add_action('product_cat_add_form_fields', [$this, 'voucherTaxonomyFieldOnCreatePage'], 10, 1);
@@ -109,8 +94,7 @@ class VoucherModule implements ExecutableModule, ServiceModule
                 <span class="title"><?php esc_html_e('Mollie Voucher Category', 'mollie-payments-for-woocommerce'); ?></span>
                 <span class="input-text-wrap">
                 <select name="_mollie_voucher_category" class="select">
-                   <option value=""><?php esc_html_e('--Please choose an option--', 'mollie-payments-for-woocommerce'); ?></option>
-                   <option value="no_category"> <?php esc_html_e('No Category', 'mollie-payments-for-woocommerce'); ?></option>
+                   <option value=""><?php esc_html_e('-- No category Selected --', 'mollie-payments-for-woocommerce'); ?></option>
                    <option value="<?php echo esc_attr(Voucher::MEAL); ?>"><?php esc_html_e('Meal', 'mollie-payments-for-woocommerce'); ?></option>
                    <option value="<?php echo esc_attr(Voucher::ECO); ?>"><?php esc_html_e('Eco', 'mollie-payments-for-woocommerce'); ?></option>
                    <option value="<?php echo esc_attr(Voucher::GIFT); ?>"><?php esc_html_e('Gift', 'mollie-payments-for-woocommerce'); ?></option>
@@ -149,8 +133,7 @@ class VoucherModule implements ExecutableModule, ServiceModule
         <div class="form-field">
             <label for="_mollie_voucher_category"><?php esc_html_e('Mollie Voucher Category', 'mollie-payments-for-woocommerce'); ?></label>
             <select name="_mollie_voucher_category" id="_mollie_voucher_category" class="select">
-                <option value=""><?php esc_html_e('--Please choose an option--', 'mollie-payments-for-woocommerce'); ?></option>
-                <option value="no_category"> <?php esc_html_e('No Category', 'mollie-payments-for-woocommerce'); ?></option>
+                <option value=""><?php esc_html_e('-- No category Selected --', 'mollie-payments-for-woocommerce'); ?></option>
                 <option value="<?php echo esc_attr(Voucher::MEAL); ?>"><?php esc_html_e('Meal', 'mollie-payments-for-woocommerce'); ?></option>
                 <option value="<?php echo esc_attr(Voucher::ECO); ?>"><?php esc_html_e('Eco', 'mollie-payments-for-woocommerce'); ?></option>
                 <option value="<?php echo esc_attr(Voucher::GIFT); ?>"><?php esc_html_e('Gift', 'mollie-payments-for-woocommerce'); ?></option>
@@ -168,6 +151,9 @@ class VoucherModule implements ExecutableModule, ServiceModule
     {
         $term_id = $term->term_id;
         $savedCategory = get_term_meta($term_id, '_mollie_voucher_category', true);
+        if (!is_array($savedCategory)) {
+            $savedCategory = [$savedCategory];
+        }
 
         ?>
         <tr class="form-field">
@@ -176,22 +162,19 @@ class VoucherModule implements ExecutableModule, ServiceModule
                 <select name="_mollie_voucher_category" id="_mollie_voucher_category" class="select">
                     <option value="">
                         <?php esc_html_e(
-                            '--Please choose an option--',
+                            '-- No category Selected --',
                             'mollie-payments-for-woocommerce'
                         ); ?></option>
-                    <option value="no_category" <?php selected($savedCategory, 'no_category'); ?>>
-                        <?php esc_html_e('No Category', 'mollie-payments-for-woocommerce'); ?>
-                    </option>
-                    <option value="<?php echo esc_attr(Voucher::MEAL); ?>" <?php selected($savedCategory, Voucher::MEAL); ?>>
+                    <option value="<?php echo esc_attr(Voucher::MEAL); ?>" <?php selected(in_array(Voucher::MEAL, $savedCategory, true)); ?>>
                         <?php esc_html_e('Meal', 'mollie-payments-for-woocommerce'); ?>
                     </option>
-                    <option value="<?php echo esc_attr(Voucher::ECO); ?>" <?php selected($savedCategory, Voucher::ECO); ?>>
+                    <option value="<?php echo esc_attr(Voucher::ECO); ?>" <?php selected(in_array(Voucher::ECO, $savedCategory, true)); ?>>
                         <?php esc_html_e('Eco', 'mollie-payments-for-woocommerce'); ?>
                     </option>
-                    <option value="<?php echo esc_attr(Voucher::GIFT); ?>" <?php selected($savedCategory, Voucher::GIFT); ?>>
+                    <option value="<?php echo esc_attr(Voucher::GIFT); ?>" <?php selected(in_array(Voucher::GIFT, $savedCategory, true)); ?>>
                         <?php esc_html_e('Gift', 'mollie-payments-for-woocommerce'); ?>
                     </option>
-                    <option value="<?php echo esc_attr(Voucher::SPORT_CULTURE); ?>" <?php selected($savedCategory, Voucher::SPORT_CULTURE); ?>>
+                    <option value="<?php echo esc_attr(Voucher::SPORT_CULTURE); ?>" <?php selected(in_array(Voucher::SPORT_CULTURE, $savedCategory, true)); ?>>
                         <?php esc_html_e('Sport & Culture', 'mollie-payments-for-woocommerce'); ?>
                     </option>
                 </select>
@@ -212,7 +195,7 @@ class VoucherModule implements ExecutableModule, ServiceModule
     public function voucherTaxonomyCustomMetaSave($term_id)
     {
 
-        $metaOption = filter_input(INPUT_POST, '_mollie_voucher_category', FILTER_SANITIZE_SPECIAL_CHARS);
+        $metaOption = filter_input(INPUT_POST, '_mollie_voucher_category', FILTER_REQUIRE_ARRAY);
 
         update_term_meta($term_id, '_mollie_voucher_category', $metaOption);
     }
@@ -222,44 +205,56 @@ class VoucherModule implements ExecutableModule, ServiceModule
      */
     public function mollieOptionsProductTabContent()
     {
+        //get values manually for old settings conversion
+        $product = wc_get_product();
+        if (!$product) {
+            return;
+        }
+        $values = $product->get_meta(Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION);
+        if ($values && !is_array($values)) {
+            if ($values === Voucher::NO_CATEGORY) {
+                $values = [];
+            }
+            $values = [$values];
+        }
+        if (!$values) {
+            $values = [];
+        }
         ?>
         <div id='mollie_options' class='panel woocommerce_options_panel'>
             <div class='options_group'>
                 <?php
-                $defaultCategory = $this->voucherDefaultCategory;
                 woocommerce_wp_select(
                     [
-                                'id' => Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION,
-                                'title' => __(
-                                    'Select the default products category',
-                                    'mollie-payments-for-woocommerce'
-                                ),
-                                'label' => __(
-                                    'Products voucher category',
-                                    'mollie-payments-for-woocommerce'
-                                ),
-
-                                'type' => 'select',
-                                'options' => [
-                                        $defaultCategory => __(
-                                            'Same as default category',
-                                            'mollie-payments-for-woocommerce'
-                                        ),
-                                        Voucher::NO_CATEGORY => __('No Category', 'mollie-payments-for-woocommerce'),
-                                        Voucher::MEAL => __('Meal', 'mollie-payments-for-woocommerce'),
-                                        Voucher::ECO => __('Eco', 'mollie-payments-for-woocommerce'),
-                                        Voucher::GIFT => __('Gift', 'mollie-payments-for-woocommerce'),
-                                        Voucher::SPORT_CULTURE => __('Sport & Culture', 'mollie-payments-for-woocommerce'),
-
-                                ],
-                                'default' => $defaultCategory,
-                            /* translators: Placeholder 1: Default order status, placeholder 2: Link to 'Hold Stock' setting */
-                                'description' => __(
-                                    "In order to process it, all products in the order must have a category. To disable the product from voucher selection select 'No category' option.",
-                                    'mollie-payments-for-woocommerce'
-                                ),
-                                'desc_tip' => true,
-                        ]
+                        'id' => Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION,
+                        'name' => Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION . '[]',
+                        'title' => __(
+                            'Select the default products category',
+                            'mollie-payments-for-woocommerce'
+                        ),
+                        'label' => __(
+                            'Products voucher category',
+                            'mollie-payments-for-woocommerce'
+                        ),
+                        'class' => 'wc-enhanced-select long',
+                        'options' => [
+                                Voucher::MEAL => __('Meal', 'mollie-payments-for-woocommerce'),
+                                Voucher::ECO => __('Eco', 'mollie-payments-for-woocommerce'),
+                                Voucher::GIFT => __('Gift', 'mollie-payments-for-woocommerce'),
+                                Voucher::SPORT_CULTURE => __('Sport & Culture', 'mollie-payments-for-woocommerce'),
+                        ],
+                        'default' => [],
+                        'value' => $values,
+                        'custom_attributes' => [
+                            'multiple' => true,
+                        ],
+                        /* translators: Placeholder 1: Default order status, placeholder 2: Link to 'Hold Stock' setting */
+                        'description' => __(
+                            "In order to process it, all products in the order must have a category. To disable the product from voucher selection select no option. If orders API is active only the first option will be used",
+                            'mollie-payments-for-woocommerce'
+                        ),
+                        'desc_tip' => true,
+                    ]
                 );
                 ?>
             </div>
@@ -274,14 +269,22 @@ class VoucherModule implements ExecutableModule, ServiceModule
      */
     public function saveProductVoucherOptionFields($post_id)
     {
-        $option = filter_input(INPUT_POST, Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION, FILTER_SANITIZE_SPECIAL_CHARS);
-        $voucherCategory = $option ?? '';
+        $option = $_POST[Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION] ?? [];
+        //filter out not allowed
+        if (!is_array($option)) {
+            $option = [$option];
+        }
+        foreach ($option as $key => $value) {
+            if (!in_array($value, [Voucher::MEAL, Voucher::ECO, Voucher::GIFT, Voucher::SPORT_CULTURE, Voucher::NO_CATEGORY], true)) {
+                unset($option[$key]);
+            }
+        }
 
-        update_post_meta(
-            $post_id,
-            Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION,
-            $voucherCategory
-        );
+        $product = wc_get_product($post_id);
+        if ($product) {
+            $product->update_meta_data(Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION, $option);
+            $product->save();
+        }
     }
 
     /**
@@ -293,19 +296,37 @@ class VoucherModule implements ExecutableModule, ServiceModule
      */
     public function voucherFieldInVariations($loop, $variation_data, $variation)
     {
-        $defaultCategory = $this->voucherDefaultCategory;
+        //get values manually for old settings conversion
+        $product = wc_get_product($variation->ID);
+        if (!$product) {
+            return;
+        }
+        $values = $product->get_meta(Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION);
+        if ($values && !is_array($values)) {
+            if ($values === Voucher::NO_CATEGORY) {
+                $values = [];
+            }
+            $values = [$values];
+        }
+        if (!$values) {
+            $values = [];
+        }
         woocommerce_wp_select(
             [
                 'id' => 'voucher[' . $variation->ID . ']',
+                'name' => 'voucher[' . $variation->ID . '][]',
                 'label' => __('Mollie Voucher category', 'mollie-payments-for-woocommerce'),
-                'value' => get_post_meta($variation->ID, 'voucher', true),
+                'class' => 'wc-enhanced-select',
                 'options' => [
-                    $defaultCategory => __('Same as default category', 'mollie-payments-for-woocommerce'),
-                    Voucher::NO_CATEGORY => __('No Category', 'mollie-payments-for-woocommerce'),
                     Voucher::MEAL => __('Meal', 'mollie-payments-for-woocommerce'),
                     Voucher::ECO => __('Eco', 'mollie-payments-for-woocommerce'),
                     Voucher::GIFT => __('Gift', 'mollie-payments-for-woocommerce'),
                     Voucher::SPORT_CULTURE => __('Sport & Culture', 'mollie-payments-for-woocommerce'),
+                ],
+                'default' => [],
+                'value' => $values,
+                'custom_attributes' => [
+                    'multiple' => true,
                 ],
             ]
         );
@@ -318,22 +339,22 @@ class VoucherModule implements ExecutableModule, ServiceModule
      */
     public function saveVoucherFieldVariations($variation_id, $i)
     {
-        $optionName = 'voucher';
         //phpcs:ignore WordPress.Security.NonceVerification.Missing
-        $voucherCategory = isset($_POST[$optionName]) && isset($_POST[$optionName][$variation_id])
-        //phpcs:ignore WordPress.Security.NonceVerification.Missing
-                ? sanitize_text_field(wp_unslash($_POST[$optionName][$variation_id]))
-                : false;
-
-        if ($voucherCategory) {
-            update_post_meta($variation_id, $optionName, esc_attr($voucherCategory));
+        $voucherCategories = $_POST['voucher'][$variation_id];
+        //filter out not allowed
+        if (!is_array($voucherCategories)) {
+            $voucherCategories = [$voucherCategories];
         }
-    }
+        foreach ($voucherCategories as $key => $value) {
+            if (!in_array($value, [Voucher::MEAL, Voucher::ECO, Voucher::GIFT, Voucher::SPORT_CULTURE, Voucher::NO_CATEGORY], true)) {
+                unset($voucherCategories[$key]);
+            }
+        }
 
-    public function addVoucherVariationData($variations)
-    {
-        $optionName = 'voucher';
-        $variations[$optionName] = get_post_meta($variations[ 'variation_id' ], $optionName, true);
-        return $variations;
+        $product = wc_get_product($variation_id);
+        if ($product) {
+            $product->update_meta_data(Voucher::MOLLIE_VOUCHER_CATEGORY_OPTION, $voucherCategories);
+            $product->save();
+        }
     }
 }

--- a/src/Gateway/inc/services.php
+++ b/src/Gateway/inc/services.php
@@ -140,9 +140,8 @@ return static function (): array {
             $pluginId = $container->get('shared.plugin_id');
             $paymentCheckoutRedirectService = $container->get(PaymentCheckoutRedirectService::class);
             assert($paymentCheckoutRedirectService instanceof PaymentCheckoutRedirectService);
-            $voucherDefaultCategory = $container->get('voucher.defaultCategory');
             $deprecatedGatewayInstances = $container->get('__deprecated.gateway_helpers');
-            return new PaymentProcessor($notice, $logger, $paymentFactory, $data, $api, $settings, $pluginId, $paymentCheckoutRedirectService, $voucherDefaultCategory, $deprecatedGatewayInstances);
+            return new PaymentProcessor($notice, $logger, $paymentFactory, $data, $api, $settings, $pluginId, $paymentCheckoutRedirectService, $deprecatedGatewayInstances);
         },
         OrderInstructionsManager::class => static function (): OrderInstructionsManager {
             return new OrderInstructionsManager();

--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -151,7 +151,7 @@ class MollieObject
      * @param $customerId
      *
      */
-    protected function getPaymentRequestData($order, $customerId, $voucherDefaultCategory = Voucher::NO_CATEGORY)
+    protected function getPaymentRequestData($order, $customerId)
     {
     }
 

--- a/src/Payment/MollieOrder.php
+++ b/src/Payment/MollieOrder.php
@@ -87,7 +87,7 @@ class MollieOrder extends MollieObject
      *
      * @return array
      */
-    public function getPaymentRequestData($order, $customerId, $voucherDefaultCategory = Voucher::NO_CATEGORY)
+    public function getPaymentRequestData($order, $customerId)
     {
         return $this->requestFactory->createRequest('order', $order, $customerId);
     }

--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -69,7 +69,7 @@ class MolliePayment extends MollieObject
      *
      * @return array
      */
-    public function getPaymentRequestData($order, $customerId, $voucherDefaultCategory = Voucher::NO_CATEGORY)
+    public function getPaymentRequestData($order, $customerId)
     {
         return $this->requestFactory->createRequest('payment', $order, $customerId);
     }

--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -50,10 +50,6 @@ class PaymentProcessor implements PaymentProcessorInterface
      * @var PaymentCheckoutRedirectService
      */
     protected $paymentCheckoutRedirectService;
-    /**
-     * @var string
-     */
-    protected $voucherDefaultCategory;
     private PaymentGateway $gateway;
     private array $deprecatedGatewayInstances;
 
@@ -69,7 +65,6 @@ class PaymentProcessor implements PaymentProcessorInterface
         Settings $settingsHelper,
         string $pluginId,
         PaymentCheckoutRedirectService $paymentCheckoutRedirectService,
-        string $voucherDefaultCategory,
         array $deprecatedGatewayInstances
     ) {
 
@@ -81,7 +76,6 @@ class PaymentProcessor implements PaymentProcessorInterface
         $this->settingsHelper = $settingsHelper;
         $this->pluginId = $pluginId;
         $this->paymentCheckoutRedirectService = $paymentCheckoutRedirectService;
-        $this->voucherDefaultCategory = $voucherDefaultCategory;
         $this->deprecatedGatewayInstances = $deprecatedGatewayInstances;
     }
 
@@ -272,7 +266,6 @@ class PaymentProcessor implements PaymentProcessorInterface
         $paymentRequestData = $paymentObject->getPaymentRequestData(
             $order,
             $customer_id,
-            $this->voucherDefaultCategory,
         );
 
         $data = array_filter($paymentRequestData);

--- a/src/Payment/Request/Middleware/OrderLinesMiddleware.php
+++ b/src/Payment/Request/Middleware/OrderLinesMiddleware.php
@@ -28,21 +28,14 @@ class OrderLinesMiddleware implements RequestMiddlewareInterface
     private PaymentLines $paymentLines;
 
     /**
-     * @var string The default category for vouchers.
-     */
-    private string $voucherDefaultCategory;
-
-    /**
      * OrderLinesMiddleware constructor.
      *
      * @param OrderLines $orderLines The order lines handler.
-     * @param string $voucherDefaultCategory The default category for vouchers.
      */
-    public function __construct(OrderLines $orderLines, PaymentLines $paymentLines, string $voucherDefaultCategory)
+    public function __construct(OrderLines $orderLines, PaymentLines $paymentLines)
     {
         $this->orderLines = $orderLines;
         $this->paymentLines = $paymentLines;
-        $this->voucherDefaultCategory = $voucherDefaultCategory;
     }
 
     /**
@@ -57,9 +50,9 @@ class OrderLinesMiddleware implements RequestMiddlewareInterface
     public function __invoke(array $requestData, WC_Order $order, $context, $next): array
     {
         if ($context === 'payment') {
-            $orderLines = $this->paymentLines->order_lines($order, $this->voucherDefaultCategory);
+            $orderLines = $this->paymentLines->order_lines($order);
         } else {
-            $orderLines = $this->orderLines->order_lines($order, $this->voucherDefaultCategory);
+            $orderLines = $this->orderLines->order_lines($order);
         }
         $requestData['lines'] = $orderLines['lines'];
         return $next($requestData, $order, $context);

--- a/src/Payment/inc/services.php
+++ b/src/Payment/inc/services.php
@@ -112,8 +112,7 @@ return static function (): array {
         OrderLinesMiddleware::class => static function (ContainerInterface $container): OrderLinesMiddleware {
             $orderLines = $container->get(OrderLines::class);
             $paymentLines = $container->get(PaymentLines::class);
-            $voucherDefaultCategory = $container->get('voucher.defaultCategory');
-            return new OrderLinesMiddleware($orderLines, $paymentLines, $voucherDefaultCategory);
+            return new OrderLinesMiddleware($orderLines, $paymentLines);
         },
         AddressMiddleware::class => static function (): AddressMiddleware {
             return new AddressMiddleware();

--- a/src/PaymentMethods/Voucher.php
+++ b/src/PaymentMethods/Voucher.php
@@ -64,19 +64,18 @@ class Voucher extends AbstractPaymentMethod implements PaymentMethodI
     {
         $paymentMethodFormFieds = [
             'mealvoucher_category_default' => [
-                'title' => __('Select the default products category', 'mollie-payments-for-woocommerce'),
-                'type' => 'select',
+                'title' => __('Select the default products categories', 'mollie-payments-for-woocommerce'),
+                'type' => 'multiselect',
                 'options' => [
-                    self::NO_CATEGORY => __('No category', 'mollie-payments-for-woocommerce'),
                     self::MEAL => __('Meal', 'mollie-payments-for-woocommerce'),
                     self::ECO => __('Eco', 'mollie-payments-for-woocommerce'),
                     self::GIFT => __('Gift', 'mollie-payments-for-woocommerce'),
                     self::SPORT_CULTURE => __('Sport & Culture', 'mollie-payments-for-woocommerce'),
                 ],
-                'default' => self::NO_CATEGORY,
+                'default' => '',
+                'class' => 'wc-enhanced-select',
                 /* translators: Placeholder 1: Default order status, placeholder 2: Link to 'Hold Stock' setting */
-                'description' => __('In order to process it, all products in the order must have a category. This selector will assign the default category for the shop products', 'mollie-payments-for-woocommerce'),
-                'desc_tip' => true,
+                'description' => __('In order to process it, all products in the order must have a category. This selector will assign the default categories for the shop products. If orders API is active only the first category will be used!', 'mollie-payments-for-woocommerce'),
             ],
         ];
         return array_merge($generalFormFields, $paymentMethodFormFieds);
@@ -99,5 +98,39 @@ class Voucher extends AbstractPaymentMethod implements PaymentMethodI
         }
 
         return $mealvoucherSettings ? $mealvoucherSettings['mealvoucher_category_default'] : Voucher::NO_CATEGORY;
+    }
+
+    /**
+     * Retrieve the default categories saved in the db option
+     *
+     * @return array
+     */
+    public static function voucherDefaultCategories(): array
+    {
+
+        $voucherSettings = get_option(
+            'mollie_wc_gateway_voucher_settings'
+        );
+        //get very old setting
+        if (! $voucherSettings) {
+            $voucherSettings = get_option(
+                'mollie_wc_gateway_mealvoucher_settings'
+            );
+        }
+
+        //convert an old single value option
+        if (isset($voucherSettings['mealvoucher_category_default']) && !is_array($voucherSettings['mealvoucher_category_default'])) {
+            if ($voucherSettings['mealvoucher_category_default'] !== self::NO_CATEGORY) {
+                $voucherSettings['mealvoucher_category_default'] = [ $voucherSettings['mealvoucher_category_default'] ];
+            } else {
+                $voucherSettings['mealvoucher_category_default'] = [];
+            }
+        }
+
+        if (!isset($voucherSettings['mealvoucher_category_default']) || !is_array($voucherSettings['mealvoucher_category_default'])) {
+            return [];
+        }
+
+        return $voucherSettings['mealvoucher_category_default'];
     }
 }


### PR DESCRIPTION
 - Add support for multiple voucher categories on payments API
 - removed get_meta functions form voucher and used them from product object