### PR TITLE
Default to payments api for new users (717)

### DIFF
--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -196,7 +196,7 @@ class PaymentProcessor implements PaymentProcessorInterface
     {
         $optionName = $this->pluginId . '_' . 'api_switch';
         $apiSwitchOption = get_option($optionName);
-        $paymentType = $apiSwitchOption ?: self::PAYMENT_METHOD_TYPE_ORDER;
+        $paymentType = $apiSwitchOption ?: self::PAYMENT_METHOD_TYPE_PAYMENT;
         $isBankTransferGateway = $paymentMethod->getProperty('id') === Constants::BANKTRANSFER;
         if ($isBankTransferGateway && $paymentMethod->isExpiredDateSettingActivated()) {
             $paymentType = self::PAYMENT_METHOD_TYPE_PAYMENT;

--- a/src/Settings/Page/Section/Advanced.php
+++ b/src/Settings/Page/Section/Advanced.php
@@ -115,7 +115,7 @@ class Advanced extends AbstractSection
                     ),
                     PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT => ucfirst(
                         PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT
-                    ). ' (' . __('default', 'mollie-payments-for-woocommerce')
+                    ) . ' (' . __('default', 'mollie-payments-for-woocommerce')
                         . ')',
                 ],
                 'default' => PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT,

--- a/src/Settings/Page/Section/Advanced.php
+++ b/src/Settings/Page/Section/Advanced.php
@@ -125,7 +125,7 @@ class Advanced extends AbstractSection
                         'Payments API is the recommended option since Orders API will be deprecated. Click %1$shere%2$s to read more about the differences between the Payments and Orders API',
                         'mollie-payments-for-woocommerce'
                     ),
-                    '<a href="https://docs.mollie.com/orders/why-use-orders" target="_blank">',
+                    '<a href="https://docs.mollie.com/reference/payments-api" target="_blank">',
                     '</a>'
                 ),
             ],

--- a/src/Settings/Page/Section/Advanced.php
+++ b/src/Settings/Page/Section/Advanced.php
@@ -112,17 +112,17 @@ class Advanced extends AbstractSection
                 'options' => [
                     PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER => ucfirst(
                         PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER
-                    ) . ' (' . __('default', 'mollie-payments-for-woocommerce')
-                        . ')',
+                    ),
                     PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT => ucfirst(
                         PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT
-                    ),
+                    ). ' (' . __('default', 'mollie-payments-for-woocommerce')
+                        . ')',
                 ],
-                'default' => PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER,
+                'default' => PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT,
                 'desc' => sprintf(
                 /* translators: Placeholder 1: opening link tag, placeholder 2: closing link tag */
                     __(
-                        'Click %1$shere%2$s to read more about the differences between the Payments and Orders API',
+                        'Payments API is the recommended option since Orders API will be deprecated. Click %1$shere%2$s to read more about the differences between the Payments and Orders API',
                         'mollie-payments-for-woocommerce'
                     ),
                     '<a href="https://docs.mollie.com/orders/why-use-orders" target="_blank">',

--- a/src/Settings/Page/Section/Header.php
+++ b/src/Settings/Page/Section/Header.php
@@ -68,7 +68,7 @@ class Header extends AbstractSection
                     </strong>
                 </p>
                 <div class="mollie-settings-header__buttons">
-                    <a href="https://help.mollie.com/hc/en-us/sections/12858723658130-Mollie-for-WooCommerce"
+                    <a href="https://docs.mollie.com/docs/woo-get-started"
                        target="_blank" class="button-secondary">
                         <?= esc_html(__('Mollie Plugin Documentation', 'mollie-payments-for-woocommerce')); ?>
                     </a>

--- a/tests/php/Functional/Payment/PaymentServiceTest.php
+++ b/tests/php/Functional/Payment/PaymentServiceTest.php
@@ -108,7 +108,8 @@ class PaymentServiceTest extends TestCase
                 'WC' => $this->wooCommerce(),
                 'wc_clean' => null,
                 'wp_parse_url' => null,
-                'wp_strip_all_tags' => null
+                'wp_strip_all_tags' => null,
+                'get_option' => PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER
             ]
         );
 


### PR DESCRIPTION
When a new user opens the plugin configuration for the first time:

- The Payments API is selected by default.

- The documentation link in the plugin points to the Payments API documentation, not the Orders API.

- Existing users with the Orders API already configured should not be affected by this change.

- A visual indicator or note (optional) could be added to suggest the Payments API is the recommended option.