### PR TITLE
Improve Handling of Retryable Failed Payments

### DIFF
--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -733,14 +733,12 @@ class MollieObject
             function_exists('wcs_order_contains_renewal')
             && wcs_order_contains_renewal($orderId)
         ) {
-            if (mollieWooCommerceIsMollieGateway($gateway->id)) {
-                $this->updateOrderStatus(
-                    $order,
-                    $newOrderStatus,
-                    sprintf(__('Renewal: %s', 'mollie-payments-for-woocommerce'), $orderNote),
-                    false
-                );
-            }
+            $this->updateOrderStatus(
+                $order,
+                $newOrderStatus,
+                sprintf(__('Renewal: %s', 'mollie-payments-for-woocommerce'), $orderNote),
+                false
+            );
             $this->logger->debug(
                 __METHOD__ . ' called for order ' . $orderId . ' and payment '
                 . $payment->id . ', renewal order payment failed, order set to '

--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -733,6 +733,7 @@ class MollieObject
             function_exists('wcs_order_contains_renewal')
             && wcs_order_contains_renewal($orderId)
         ) {
+            add_filter('wcs_is_scheduled_payment_attempt', '__return_true');
             $this->updateOrderStatus(
                 $order,
                 $newOrderStatus,

--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -719,7 +719,7 @@ class MollieObject
             $orderNote = sprintf(
             /* translators: Placeholder 1: payment method title, placeholder 2: payment ID, placeholder 3: failure reason, placeholder 4: failure message */
                 __(
-                    '%1$s payment failed via Mollie (%2$s). Because of: (%3$s) %4$s',
+                    '%1$s payment failed via Mollie (%2$s). Because of: (%3$s) %4$s.',
                     'mollie-payments-for-woocommerce'
                 ),
                 $paymentMethodTitle,

--- a/src/Payment/MollieOrder.php
+++ b/src/Payment/MollieOrder.php
@@ -415,15 +415,6 @@ class MollieOrder extends MollieObject
         // Get current gateway
         $gateway = wc_get_payment_gateway_by_order($order);
 
-        //check if there is a reason for faild payment and print it to order note
-        if (isset($payment->details->failureReason)) {
-            $message = $payment->details->failureReason;
-            if (isset($payment->details->failureMessage)) {
-                $message = '(' . $payment->details->failureReason . ') "' . $payment->details->failureMessage . '"';
-            }
-            $order->add_order_note(sprintf(__('%1$s payment failed with: %2$s', 'mollie-payments-for-woocommerce'), $paymentMethodTitle, esc_attr($message)));
-        }
-
         // New order status
         $newOrderStatus = SharedDataDictionary::STATUS_FAILED;
 

--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -337,6 +337,15 @@ class MolliePayment extends MollieObject
         // Get current gateway
         $gateway = wc_get_payment_gateway_by_order($order);
 
+        //check if there is a reason for faild payment and print it to order note
+        if (isset($payment->details->failureReason)) {
+            $message = $payment->details->failureReason;
+            if (isset($payment->details->failureMessage)) {
+                $message = '(' . $payment->details->failureReason . ') "' . $payment->details->failureMessage . '"';
+            }
+            $order->add_order_note(sprintf(__('%1$s payment failed with: %2$s', 'mollie-payments-for-woocommerce'), $paymentMethodTitle, esc_attr($message)));
+        }
+
         // New order status
         $newOrderStatus = SharedDataDictionary::STATUS_FAILED;
 
@@ -357,7 +366,11 @@ class MolliePayment extends MollieObject
             $payment
         );
 
-        $this->logger->debug(__METHOD__ . ' called for order ' . $orderId . ' and payment ' . $payment->id . ', regular payment failed.');
+        if (isset($payment->details->failureReason)) {
+            $this->logger->debug(__METHOD__ . ' called for order ' . $orderId . ' and payment ' . $payment->id . ', regular payment failed because of ' . esc_attr($payment->details->failureReason) . '.');
+        } else {
+            $this->logger->debug(__METHOD__ . ' called for order ' . $orderId . ' and payment ' . $payment->id . ', regular payment failed.');
+        }
     }
 
     /**

--- a/src/Payment/MolliePayment.php
+++ b/src/Payment/MolliePayment.php
@@ -337,15 +337,6 @@ class MolliePayment extends MollieObject
         // Get current gateway
         $gateway = wc_get_payment_gateway_by_order($order);
 
-        //check if there is a reason for faild payment and print it to order note
-        if (isset($payment->details->failureReason)) {
-            $message = $payment->details->failureReason;
-            if (isset($payment->details->failureMessage)) {
-                $message = '(' . $payment->details->failureReason . ') "' . $payment->details->failureMessage . '"';
-            }
-            $order->add_order_note(sprintf(__('%1$s payment failed with: %2$s', 'mollie-payments-for-woocommerce'), $paymentMethodTitle, esc_attr($message)));
-        }
-
         // New order status
         $newOrderStatus = SharedDataDictionary::STATUS_FAILED;
 

--- a/src/Subscription/MollieSubscriptionGatewayHandler.php
+++ b/src/Subscription/MollieSubscriptionGatewayHandler.php
@@ -23,6 +23,7 @@ use Mollie\WooCommerce\SDK\HttpResponse;
 use Mollie\WooCommerce\SDK\InvalidApiKey;
 use Mollie\WooCommerce\Settings\Settings;
 use Mollie\WooCommerce\Shared\Data;
+use Mollie\WooCommerce\Shared\SharedDataDictionary;
 use Psr\Log\LoggerInterface as Logger;
 use Mollie\WooCommerce\PaymentMethods\Constants;
 use WC_Order;
@@ -369,7 +370,7 @@ class MollieSubscriptionGatewayHandler extends MolliePaymentGatewayHandler
             /* translators: Placeholder 1: Payment method title */
             $message = sprintf(__('Could not create %s renewal payment.', 'mollie-payments-for-woocommerce'), $gateway->title);
             $message .= ' ' . $e->getMessage();
-            $renewal_order->update_status('failed', $message);
+            $renewal_order->update_status(SharedDataDictionary::STATUS_FAILED, $message);
         }
 
         return ['result' => 'failure'];


### PR DESCRIPTION
- fixed the WCS retry logic not works in webhook context
- Add messages that shows failure reasons in the order note on Credit Card Payments.