### PR TITLE
Fix duplicate recurring payments from webhook race condition (718)

### DIFF
--- a/.env.integration.example
+++ b/.env.integration.example
@@ -1,0 +1,4 @@
+MOLLIE_INTEGRATION_WP_DIR=${ROOT_DIR}/.ddev/wordpress
+
+BASEURL="https://mollie-payments-for-woocommerce.ddev.site"
+AUTHORIZATION="Bearer ABC123"

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,16 +12,18 @@ use Throwable;
 /**
  * Bootstrap function to initialize the plugin.
  *
- * @param string $plugin_file The main plugin file path
+ * @param string $root_dir The main plugin file path
  * @param array $additional_modules Additional modules to load
  * @return callable A function that returns the container
  */
 return function (
-    string $plugin_file,
+    string $root_dir,
     array $additional_modules = []
 ): ContainerInterface {
     try {
-        require_once __DIR__ . '/inc/functions.php';
+        if(!function_exists('mollieWooCommerceIsCheckoutContext')){
+            require_once __DIR__ . '/inc/functions.php';
+        }
 
         if (!function_exists('Mollie\WooCommerce\mollie_wc_plugin_autoload') || !mollie_wc_plugin_autoload()) {
             throw new \RuntimeException('Autoloader could not be initialized.');
@@ -38,9 +40,9 @@ return function (
         }
 
         // Initialize plugin.
-        $properties = PluginProperties::new($plugin_file);
+        $properties = PluginProperties::new(M4W_FILE);
         $package = Package::new($properties);
-        $modules = (require __DIR__ . '/inc/modules.php')($plugin_file);
+        $modules = (require $root_dir . '/inc/modules.php')();
         $modules = array_merge($modules, $additional_modules);
         $modules = apply_filters('mollie_wc_plugin_modules', $modules);
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce;
+
+use Inpsyde\Modularity\Package;
+use Inpsyde\Modularity\Properties\PluginProperties;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+/**
+ * Bootstrap function to initialize the plugin.
+ *
+ * @param string $plugin_file The main plugin file path
+ * @param array $additional_modules Additional modules to load
+ * @return callable A function that returns the container
+ */
+return function (
+    string $plugin_file,
+    array $additional_modules = []
+): ContainerInterface {
+    try {
+        require_once __DIR__ . '/inc/functions.php';
+
+        if (!function_exists('Mollie\WooCommerce\mollie_wc_plugin_autoload') || !mollie_wc_plugin_autoload()) {
+            throw new \RuntimeException('Autoloader could not be initialized.');
+        }
+
+        $checker = new Activation\ConstraintsChecker();
+        $meetRequirements = $checker->handleActivation();
+        if (!$meetRequirements) {
+            $nextScheduledTime = wp_next_scheduled('pending_payment_confirmation_check');
+            if ($nextScheduledTime) {
+                wp_unschedule_event($nextScheduledTime, 'pending_payment_confirmation_check');
+            }
+            throw new \RuntimeException('Plugin requirements not met.');
+        }
+
+        // Initialize plugin.
+        $properties = PluginProperties::new($plugin_file);
+        $package = Package::new($properties);
+        $modules = (require __DIR__ . '/inc/modules.php')($plugin_file);
+        $modules = array_merge($modules, $additional_modules);
+        $modules = apply_filters('mollie_wc_plugin_modules', $modules);
+
+        foreach ($modules as $module) {
+            $package->addModule($module);
+        }
+
+        $package->boot();
+
+        return $package->container();
+    } catch (Throwable $throwable) {
+        if (function_exists('Mollie\WooCommerce\handleException')) {
+            handleException($throwable);
+        }
+        throw $throwable;
+    }
+};

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "psr/container": "1.1.0",
     "psr/log":"^1.1.4",
     "sniccowp/php-scoper-wordpress-excludes": "^6.6",
-    "dhii/services": "^0.1.0"
+    "dhii/services": "^0.1.0",
+    "vlucas/phpdotenv": "^5.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
@@ -49,7 +50,8 @@
     "psr-4": {
       "Mollie\\WooCommerceTests\\": "tests/php",
       "Mollie\\WooCommerceTests\\Unit\\": "tests/php/Unit",
-      "Mollie\\WooCommerceTests\\Functional\\": "tests/php/Functional"
+      "Mollie\\WooCommerceTests\\Functional\\": "tests/php/Functional",
+      "Mollie\\WooCommerceTests\\Integration\\": "tests/Integration"
     }
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1e8936703aa6cff296fa891dd9ccf25",
+    "content-hash": "b694b3e22d710d19298ce4c42cfd0c20",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -128,6 +128,68 @@
                 "source": "https://github.com/Dhii/services/tree/v0.1.0"
             },
             "time": "2022-01-06T14:57:20+00:00"
+        },
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
+                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-20T21:45:45+00:00"
         },
         {
             "name": "inpsyde/modularity",
@@ -280,6 +342,81 @@
             "time": "2025-01-24T14:59:44+00:00"
         },
         {
+            "name": "phpoption/phpoption",
+            "version": "1.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-20T21:41:07+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.1.0",
             "source": {
@@ -428,6 +565,329 @@
                 "source": "https://github.com/snicco/php-scoper-wordpress-excludes/tree/6.7.1"
             },
             "time": "2024-11-25T00:31:50+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.1.3",
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.3",
+                "symfony/polyfill-ctype": "^1.24",
+                "symfony/polyfill-mbstring": "^1.24",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-master": "5.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-30T23:37:27+00:00"
         }
     ],
     "packages-dev": [
@@ -3971,85 +4431,6 @@
             "time": "2024-09-25T14:11:13+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
             "name": "symfony/polyfill-intl-grapheme",
             "version": "v1.31.0",
             "source": {
@@ -4209,86 +4590,6 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
             "name": "symfony/polyfill-php73",
             "version": "v1.31.0",
             "source": {
@@ -4347,86 +4648,6 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {

--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -101,11 +101,11 @@ function handleException(Throwable $throwable)
 function initialize(): ?ContainerInterface
 {
     static $container = null;
-
+    $root_dir = M4W_PLUGIN_DIR;
     if ($container === null) {
         try {
             $bootstrap = require __DIR__ . '/bootstrap.php';
-            $container = $bootstrap(M4W_FILE);
+            $container = $bootstrap($root_dir);
         } catch (Throwable $throwable) {
             handleException($throwable);
             return null;

--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -20,21 +20,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce;
 
-use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
-use Inpsyde\Modularity\Package;
-use Inpsyde\Modularity\Properties\PluginProperties;
-use Mollie\WooCommerce\Activation\ActivationModule;
-use Mollie\WooCommerce\Activation\ConstraintsChecker;
-use Mollie\WooCommerce\Assets\AssetsModule;
-use Mollie\WooCommerce\Shared\SharedModule;
-use Mollie\WooCommerce\Gateway\GatewayModule;
-use Mollie\WooCommerce\Gateway\Voucher\VoucherModule;
-use Mollie\WooCommerce\Log\LogModule;
-use Mollie\WooCommerce\Notice\NoticeModule;
-use Mollie\WooCommerce\Payment\PaymentModule;
-use Mollie\WooCommerce\SDK\SDKModule;
-use Mollie\WooCommerce\Settings\SettingsModule;
-use Mollie\WooCommerce\Uninstall\UninstallModule;
+use Psr\Container\ContainerInterface;
 use Throwable;
 
 require_once(ABSPATH . 'wp-admin/includes/plugin.php');
@@ -48,21 +34,16 @@ if (!defined('M4W_PLUGIN_URL')) {
 }
 
 
-function mollie_wc_plugin_autoload()
+function mollie_wc_plugin_autoload(): bool
 {
     $autoloader = __DIR__ . '/vendor/autoload.php';
     $mollieSdkAutoload = __DIR__ . '/vendor/mollie/mollie-api-php/vendor/autoload.php';
-    if (file_exists($autoloader)) {
-        /**
-         * @noinspection PhpIncludeInspection
-         *
-         */
+    if (file_exists($autoloader) && ! class_exists('Mollie\WooCommerce\Activation\ActivationModule')) {
         require $autoloader;
     }
 
     if (file_exists($mollieSdkAutoload)) {
         /**
-         * @noinspection PhpIncludeInspection
          * @psalm-suppress MissingFile
          */
         require $mollieSdkAutoload;
@@ -115,45 +96,23 @@ function handleException(Throwable $throwable)
 /**
  * Initialize all the plugin things.
  *
- * @throws Throwable
+ * @return ContainerInterface|null
  */
-function initialize()
+function initialize(): ?ContainerInterface
 {
-    static $package;
-    if (!$package) {
+    static $container = null;
+
+    if ($container === null) {
         try {
-            require_once __DIR__ . '/inc/functions.php';
-
-            if (!mollie_wc_plugin_autoload()) {
-                return;
-            }
-
-            $checker = new ConstraintsChecker();
-            $meetRequirements = $checker->handleActivation();
-            if (!$meetRequirements) {
-                $nextScheduledTime = wp_next_scheduled('pending_payment_confirmation_check');
-                if ($nextScheduledTime) {
-                    wp_unschedule_event($nextScheduledTime, 'pending_payment_confirmation_check');
-                }
-                return;
-            }
-
-            // Initialize plugin.
-            $properties = PluginProperties::new(__FILE__);
-            $package = Package::new($properties);
-            $modules = (require __DIR__ . '/inc/modules.php')();
-            $modules = apply_filters('mollie_wc_plugin_modules', $modules);
-            foreach ($modules as $module) {
-                $package->addModule($module);
-            }
-            $package->boot();
+            $bootstrap = require __DIR__ . '/bootstrap.php';
+            $container = $bootstrap(M4W_FILE);
         } catch (Throwable $throwable) {
             handleException($throwable);
+            return null;
         }
     }
 
-    /** @var Package $package */
-    return $package;
+    return $container;
 }
 
 add_action(

--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -281,24 +281,6 @@ class MollieOrderService
     }
 
     /**
-     * Check if a payment has already been processed for this order
-     *
-     * @param WC_Order $order
-     * @param string $paymentId
-     * @return bool
-     */
-    private function isPaymentAlreadyProcessed(\WC_Order $order, string $paymentId): bool
-    {
-        // Check if this specific payment ID has been processed
-        $processedPayments = $order->get_meta('_mollie_processed_payments', true);
-        if (!is_array($processedPayments)) {
-            $processedPayments = [];
-        }
-
-        return in_array($paymentId, $processedPayments, true);
-    }
-
-    /**
      * @param \WC_Order $order
      * @param $payment
      */

--- a/tests/Integration/API/Mocks/MockedApi.php
+++ b/tests/Integration/API/Mocks/MockedApi.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\API\Mocks;
+
+use Mollie\WooCommerce\SDK\Api;
+use Mollie\Api\MollieApiClient;
+use Mockery;
+
+class MockedApi extends Api
+{
+    /**
+     * @var \Mockery\MockInterface|\Mollie\Api\MollieApiClient
+     */
+    protected $mockedApiClient;
+
+    /**
+     * @var array
+     */
+    protected $mockedResponses = [];
+
+    public function __construct(string $pluginVersion = '1.0.0', string $pluginId = 'mollie-test')
+    {
+        parent::__construct($pluginVersion, $pluginId);
+        $this->setupMockedApiClient();
+    }
+
+    /**
+     * Override the parent method to return our mocked client
+     *
+     * @param string $apiKey
+     * @param bool $needToUpdateApiKey
+     * @return \Mockery\MockInterface|\Mollie\Api\MollieApiClient
+     */
+    public function getApiClient($apiKey, $needToUpdateApiKey = false)
+    {
+        if (empty($apiKey)) {
+            throw new \Mollie\Api\Exceptions\ApiException('No API key provided. Please set your Mollie API keys below.');
+        } elseif (!preg_match('#^(live|test)_\w{30,}$#', $apiKey)) {
+            throw new \Mollie\Api\Exceptions\ApiException('Invalid API key format.');
+        }
+
+        return $this->mockedApiClient;
+    }
+
+    /**
+     * Setup the mocked API client with all necessary endpoints
+     */
+    protected function setupMockedApiClient(): void
+    {
+        $this->mockedApiClient = Mockery::mock(MollieApiClient::class);
+
+        $this->mockedApiClient->payments = Mockery::mock('PaymentEndpoint');
+        $this->mockedApiClient->methods = Mockery::mock('MethodEndpoint');
+        $this->mockedApiClient->customers = Mockery::mock('CustomerEndpoint');
+        $this->mockedApiClient->orders = Mockery::mock('OrderEndpoint');
+        $this->mockedApiClient->refunds = Mockery::mock('RefundEndpoint');
+        $this->mockedApiClient->subscriptions = Mockery::mock('SubscriptionEndpoint');
+        $this->mockedApiClient->mandates = Mockery::mock('MandateEndpoint');
+        $this->mockedApiClient->profiles = Mockery::mock('ProfileEndpoint');
+        $this->mockedApiClient->organizations = Mockery::mock('OrganizationEndpoint');
+        $this->mockedApiClient->permissions = Mockery::mock('PermissionEndpoint');
+        $this->mockedApiClient->invoices = Mockery::mock('InvoiceEndpoint');
+        $this->mockedApiClient->settlements = Mockery::mock('SettlementsEndpoint');
+        $this->mockedApiClient->chargebacks = Mockery::mock('ChargebackEndpoint');
+    }
+
+    /**
+     * Configure mock responses for payments endpoint
+     *
+     * @param string $paymentId
+     * @param array $paymentData
+     * @return self
+     */
+    public function mockPaymentGet(string $paymentId, array $paymentData): self
+    {
+        $paymentObject = $this->createMockPaymentObject($paymentData);
+
+        $this->mockedApiClient->payments
+            ->shouldReceive('get')
+            ->with($paymentId)
+            ->andReturn($paymentObject);
+
+        return $this;
+    }
+
+    /**
+     * Create a mock payment object that mimics Mollie Payment resource behavior
+     *
+     * @param array $paymentData
+     * @return \Mockery\MockInterface
+     */
+    protected function createMockPaymentObject(array $paymentData)
+    {
+        $paymentObject = Mockery::mock('Payment');
+
+        foreach ($paymentData as $key => $value) {
+            $paymentObject->$key = $value;
+        }
+
+        $status = $paymentData['status'] ?? 'pending';
+        $paymentObject->shouldReceive('isPaid')->andReturn($status === 'paid');
+        $paymentObject->shouldReceive('isAuthorized')->andReturn($status === 'authorized');
+        $paymentObject->shouldReceive('isFailed')->andReturn($status === 'failed');
+        $paymentObject->shouldReceive('isCanceled')->andReturn($status === 'canceled');
+        $paymentObject->shouldReceive('isExpired')->andReturn($status === 'expired');
+        $paymentObject->shouldReceive('isPending')->andReturn($status === 'pending');
+        $paymentObject->shouldReceive('isCompleted')->andReturn($status === 'completed');
+
+        $paymentObject->shouldReceive('refunds')->andReturn([]);
+        $paymentObject->shouldReceive('chargebacks')->andReturn([]);
+
+        return $paymentObject;
+    }
+
+    /**
+     * Configure mock responses for payment creation
+     *
+     * @param array $paymentParams
+     * @param array $paymentResponse
+     * @return self
+     */
+    public function mockPaymentCreate(array $paymentParams, array $paymentResponse): self
+    {
+        $this->mockedApiClient->payments
+            ->shouldReceive('create')
+            ->with($paymentParams)
+            ->andReturn((object)$paymentResponse);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock responses for payment updates
+     *
+     * @param string $paymentId
+     * @param array $updateData
+     * @param array $updatedPaymentResponse
+     * @return self
+     */
+    public function mockPaymentUpdate(string $paymentId, array $updateData, array $updatedPaymentResponse): self
+    {
+        $this->mockedApiClient->payments
+            ->shouldReceive('update')
+            ->with($paymentId, $updateData)
+            ->andReturn((object)$updatedPaymentResponse);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock responses for customer creation
+     *
+     * @param array $customerData
+     * @param array $customerResponse
+     * @return self
+     */
+    public function mockCustomerCreate(array $customerData, array $customerResponse): self
+    {
+        $this->mockedApiClient->customers
+            ->shouldReceive('create')
+            ->with($customerData)
+            ->andReturn((object)$customerResponse);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock responses for customer get
+     *
+     * @param string $customerId
+     * @param array $customerData
+     * @return self
+     */
+    public function mockCustomerGet(string $customerId, array $customerData): self
+    {
+        $this->mockedApiClient->customers
+            ->shouldReceive('get')
+            ->with($customerId)
+            ->andReturn((object)$customerData);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock responses for order creation
+     *
+     * @param array $orderData
+     * @param array $orderResponse
+     * @return self
+     */
+    public function mockOrderCreate(array $orderData, array $orderResponse): self
+    {
+        $this->mockedApiClient->orders
+            ->shouldReceive('create')
+            ->with($orderData)
+            ->andReturn((object)$orderResponse);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock responses for order get
+     *
+     * @param string $orderId
+     * @param array $orderData
+     * @return self
+     */
+    public function mockOrderGet(string $orderId, array $orderData): self
+    {
+        $this->mockedApiClient->orders
+            ->shouldReceive('get')
+            ->with($orderId)
+            ->andReturn((object)$orderData);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock responses for refund creation
+     *
+     * @param array $refundData
+     * @param array $refundResponse
+     * @return self
+     */
+    public function mockRefundCreate(array $refundData, array $refundResponse): self
+    {
+        $this->mockedApiClient->refunds
+            ->shouldReceive('create')
+            ->with($refundData)
+            ->andReturn((object)$refundResponse);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock for any method call with flexible parameters
+     *
+     * @param string $endpoint (e.g., 'payments', 'customers', 'orders')
+     * @param string $method (e.g., 'get', 'create', 'update', 'delete')
+     * @param array $expectedParams
+     * @param mixed $response
+     * @return self
+     */
+    public function mockEndpointCall(string $endpoint, string $method, array $expectedParams, $response): self
+    {
+        $mockCall = $this->mockedApiClient->$endpoint->shouldReceive($method);
+
+        if (!empty($expectedParams)) {
+            $mockCall->with(...$expectedParams);
+        }
+
+        $mockCall->andReturn(is_array($response) ? (object)$response : $response);
+
+        return $this;
+    }
+
+    /**
+     * Configure mock to throw an exception
+     *
+     * @param string $endpoint
+     * @param string $method
+     * @param array $expectedParams
+     * @param \Exception $exception
+     * @return self
+     */
+    public function mockEndpointException(string $endpoint, string $method, array $expectedParams, \Exception $exception): self
+    {
+        $mockCall = $this->mockedApiClient->$endpoint->shouldReceive($method);
+
+        if (!empty($expectedParams)) {
+            $mockCall->with(...$expectedParams);
+        }
+
+        $mockCall->andThrow($exception);
+
+        return $this;
+    }
+
+    /**
+     * Get the mocked API client for direct manipulation in tests
+     *
+     * @return \Mockery\MockInterface|\Mollie\Api\MollieApiClient
+     */
+    public function getMockedApiClient()
+    {
+        return $this->mockedApiClient;
+    }
+
+    /**
+     * Reset all mock expectations (useful between tests)
+     */
+    public function resetMocks(): void
+    {
+        Mockery::close();
+        $this->setupMockedApiClient();
+    }
+}

--- a/tests/Integration/API/Traits/APIMockTrait.php
+++ b/tests/Integration/API/Traits/APIMockTrait.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\API\Traits;
+
+use Mollie\WooCommerce\Payment\MollieOrderService;
+use Mollie\WooCommerceTests\Integration\API\Mocks\MockedApi;
+use Mollie\Api\Exceptions\ApiException;
+
+trait APIMockTrait
+{
+    /**
+     * @var MockedApi
+     */
+    protected $apiMock;
+
+    /**
+     * Initialize the API mock
+     */
+    protected function initializeApiMock(): void
+    {
+        $this->apiMock = new MockedApi();
+    }
+
+    /**
+     * Get the API mock instance
+     */
+    protected function apiMock(): MockedApi
+    {
+        if (!$this->apiMock) {
+            $this->initializeApiMock();
+        }
+
+        return $this->apiMock;
+    }
+
+    /**
+     * Create a basic payment response structure for webhook testing
+     *
+     * @param string $paymentId
+     * @param string $status
+     * @param string $amount
+     * @param string $currency
+     * @param array $additionalData
+     * @return array
+     */
+    protected function createPaymentResponse(
+        string $paymentId,
+        string $status = 'paid',
+        string $amount = '10.00',
+        string $currency = 'EUR',
+        array $additionalData = []
+    ): array {
+        $response = array_merge([
+                               'id' => $paymentId,
+                               'status' => $status,
+                               'amount' => [
+                                   'value' => $amount,
+                                   'currency' => $currency
+                               ],
+                               'description' => 'Test payment',
+                               'redirectUrl' => 'https://example.com/return',
+                               'webhookUrl' => 'https://example.com/webhook',
+                               'metadata' => (object)['order_id' => '1'],
+                               'createdAt' => '2023-01-01T12:00:00+00:00',
+                               'method' => 'ideal',
+                               'mode' => 'test',
+                               'resource' => 'payment',
+                               // Add methods that the webhook logic expects
+                               'isPaid' => function() use ($status) { return $status === 'paid'; },
+                               'isAuthorized' => function() use ($status) { return $status === 'authorized'; },
+                               'isFailed' => function() use ($status) { return $status === 'failed'; },
+                               'isCanceled' => function() use ($status) { return $status === 'canceled'; },
+                               'isExpired' => function() use ($status) { return $status === 'expired'; },
+                               'isPending' => function() use ($status) { return $status === 'pending'; },
+                               // Add links for refunds and chargebacks
+                               '_links' => [
+                                   'refunds' => null,
+                                   'chargebacks' => null
+                               ],
+                               '_embedded' => [
+                                   'refunds' => []
+                               ],
+                               'amountRefunded' => null,
+                               'amountChargedBack' => null
+                           ], $additionalData);
+        if (isset($additionalData['metadata']) && is_array($additionalData['metadata'])) {
+            $response['metadata'] = (object)$additionalData['metadata'];
+        }
+        return $response;
+    }
+
+    /**
+     * Create a basic customer response structure
+     *
+     * @param string $customerId
+     * @param string $email
+     * @param array $additionalData
+     * @return array
+     */
+    protected function createCustomerResponse(
+        string $customerId,
+        string $email = 'test@example.com',
+        array $additionalData = []
+    ): array {
+        return array_merge([
+                               'id' => $customerId,
+                               'email' => $email,
+                               'name' => 'Test Customer',
+                               'createdAt' => '2023-01-01T12:00:00+00:00'
+                           ], $additionalData);
+    }
+
+    /**
+     * Create a basic order response structure
+     *
+     * @param string $orderId
+     * @param string $status
+     * @param array $additionalData
+     * @return array
+     */
+    protected function createOrderResponse(
+        string $orderId,
+        string $status = 'created',
+        array $additionalData = []
+    ): array {
+        return array_merge([
+                               'id' => $orderId,
+                               'status' => $status,
+                               'amount' => [
+                                   'value' => '10.00',
+                                   'currency' => 'EUR'
+                               ],
+                               'lines' => [],
+                               'createdAt' => '2023-01-01T12:00:00+00:00'
+                           ], $additionalData);
+    }
+
+    /**
+     * Mock a successful payment retrieval
+     *
+     * @param string $paymentId
+     * @param string $status
+     * @param array $additionalData
+     */
+    protected function mockSuccessfulPaymentGet(
+        string $paymentId,
+        string $status = 'paid',
+        array $additionalData = []
+    ): void {
+        $payment = $this->createPaymentResponse($paymentId, $status, '10.00', 'EUR', $additionalData);
+        $this->apiMock()->mockPaymentGet($paymentId, $payment);
+    }
+
+    /**
+     * Mock a failed payment retrieval
+     *
+     * @param string $paymentId
+     * @param int $errorCode
+     * @param string $errorMessage
+     * @throws ApiException
+     */
+    protected function mockFailedPaymentGet(
+        string $paymentId,
+        int $errorCode = 404,
+        string $errorMessage = 'Payment not found'
+    ): void {
+        $this->apiMock()->mockEndpointException(
+            'payments',
+            'get',
+            [$paymentId],
+            new ApiException($errorMessage, $errorCode)
+        );
+    }
+
+    /**
+     * Mock a successful payment creation
+     *
+     * @param array $paymentParams
+     * @param string $paymentId
+     * @param string $status
+     */
+    protected function mockSuccessfulPaymentCreate(
+        array $paymentParams,
+        string $paymentId = 'tr_test_payment_id',
+        string $status = 'open'
+    ): void {
+        $response = $this->createPaymentResponse($paymentId, $status);
+        $response['_links'] = [
+            'checkout' => [
+                'href' => 'https://mollie.com/checkout/' . $paymentId,
+                'type' => 'text/html'
+            ]
+        ];
+
+        $this->apiMock()->mockPaymentCreate($paymentParams, $response);
+    }
+
+    /**
+     * Reset all API mocks
+     */
+    protected function resetApiMocks(): void
+    {
+        if ($this->apiMock) {
+            $this->apiMock->resetMocks();
+        }
+    }
+
+    /**
+     * Get mocked services array for bootstrapping
+     *
+     * @return array
+     */
+    protected function getMockedApiServices(): array
+    {
+        return [
+            'SDK.api_helper' => function () {
+                return $this->apiMock();
+            }
+        ];
+    }
+}

--- a/tests/Integration/Common/Factories/CouponFactory.php
+++ b/tests/Integration/Common/Factories/CouponFactory.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Factories;
+
+use WC_Coupon;
+use Mollie\WooCommerceTests\Integration\Common\Fixtures\DiscountPresets;
+
+class CouponFactory
+{
+    private array $created_coupon_ids = [];
+
+    /**
+     * @param string $preset_name
+     * @return WC_Coupon
+     * @throws \WC_Data_Exception
+     */
+    public function createFromPreset(string $preset_name): WC_Coupon
+    {
+        $presets = DiscountPresets::get();
+
+        if (!isset($presets[$preset_name])) {
+            throw new \WC_Data_Exception('invalid_preset', "Coupon preset '{$preset_name}' not found");
+        }
+
+        $preset = $presets[$preset_name];
+
+        if (!isset($preset['coupon_code'])) {
+            throw new \WC_Data_Exception('invalid_preset', "Preset '{$preset_name}' is not a coupon");
+        }
+
+        return $this->createCoupon($preset);
+    }
+
+    /**
+     * @param array $preset
+     * @return WC_Coupon
+     */
+    private function createCoupon(array $preset): WC_Coupon
+    {
+        $coupon = new WC_Coupon();
+        $coupon->set_code($preset['coupon_code']);
+        $coupon->set_discount_type($preset['type']);
+        $coupon->set_amount($preset['amount']);
+        $coupon->set_status('publish');
+        $coupon->save();
+
+        $this->created_coupon_ids[] = $coupon->get_id();
+
+        return $coupon;
+    }
+
+    /**
+     * @param string $coupon_code
+     * @return bool
+     */
+    public function exists(string $coupon_code): bool
+    {
+        return (bool)wc_get_coupon_id_by_code($coupon_code);
+    }
+
+    /**
+     * @param string $coupon_code
+     * @return WC_Coupon|null
+     */
+    public function getByCode(string $coupon_code): ?WC_Coupon
+    {
+        $coupon_id = wc_get_coupon_id_by_code($coupon_code);
+
+        return $coupon_id ? new WC_Coupon($coupon_id) : null;
+    }
+
+    /**
+     * Delete all created coupons
+     */
+    public function cleanup(): void
+    {
+        foreach ($this->created_coupon_ids as $coupon_id) {
+            wp_delete_post($coupon_id, true);
+        }
+
+        $this->created_coupon_ids = [];
+    }
+
+    /**
+     * @return array
+     */
+    public function getCreatedIds(): array
+    {
+        return $this->created_coupon_ids;
+    }
+}

--- a/tests/Integration/Common/Factories/OrderFactory.php
+++ b/tests/Integration/Common/Factories/OrderFactory.php
@@ -1,0 +1,242 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Factories;
+
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Order_Item_Fee;
+use Mollie\WooCommerceTests\Integration\Common\Fixtures\ProductPresets;
+use Mollie\WooCommerceTests\Integration\Common\Fixtures\DiscountPresets;
+
+class OrderFactory
+{
+    private array $created_order_ids = [];
+    private ProductFactory $product_factory;
+    private CouponFactory $coupon_factory;
+
+    public function __construct(
+        ProductFactory $product_factory = null,
+        CouponFactory  $coupon_factory = null
+    )
+    {
+        $this->product_factory = $product_factory ?? new ProductFactory();
+        $this->coupon_factory = $coupon_factory ?? new CouponFactory();
+    }
+
+    /**
+     * @param int $customer_id
+     * @param string $payment_method
+     * @param array $product_presets
+     * @param array $discount_presets
+     * @param bool $set_paid
+     * @return WC_Order
+     * @throws \WC_Data_Exception
+     */
+    public function create(
+        int    $customer_id,
+        string $payment_method,
+        array  $product_presets,
+        array  $discount_presets = [],
+        bool   $set_paid = true
+    ): WC_Order
+    {
+        $products = $this->resolveProductPresets($product_presets);
+        $discounts = $this->resolveDiscountPresets($discount_presets);
+
+        $order = wc_create_order([
+            'customer_id' => $customer_id,
+            'set_paid' => $set_paid,
+        ]);
+
+        if (is_wp_error($order)) {
+            throw new \WC_Data_Exception('order_creation_failed', 'Failed to create order');
+        }
+
+        $this->setBillingAddress($order);
+        $this->addProductsToOrder($order, $products);
+        $this->applyDiscountsToOrder($order, $discounts);
+
+        $order->set_payment_method($payment_method);
+        $order->calculate_totals();
+        $order->save();
+
+        return $order;
+    }
+
+    /**
+     * @param WC_Order $order
+     */
+    private function setBillingAddress(WC_Order $order): void
+    {
+        $order->set_billing_first_name('John');
+        $order->set_billing_last_name('Doe');
+        $order->set_billing_address_1('969 Market');
+        $order->set_billing_city('San Francisco');
+        $order->set_billing_state('CA');
+        $order->set_billing_postcode('94103');
+        $order->set_billing_country('US');
+        $order->set_billing_email('john.doe@example.com');
+        $order->set_billing_phone('(555) 555-5555');
+    }
+
+    /**
+     * @param WC_Order $order
+     * @param array $products
+     * @throws \WC_Data_Exception
+     */
+    private function addProductsToOrder(WC_Order $order, array $products): void
+    {
+        foreach ($products as $product_data) {
+            $product_id = null;
+
+            if (!empty($product_data['sku'])) {
+                $product_sku = $product_data['sku'];
+                $product_id = wc_get_product_id_by_sku($product_sku);
+            }
+
+            if (!$product_id && isset($product_data['id'])) {
+                $product_id = $product_data['id'];
+            }
+
+            if (!$product_id) {
+                throw new \WC_Data_Exception('invalid_product', "Product not found - no valid SKU or ID provided");
+            }
+
+            $variation_id = $product_data['variation_id'] ?? 0;
+            $product_type = $product_data['type'] ?? 'simple';
+
+            $product = wc_get_product($variation_id ?: $product_id);
+
+            if (!$product) {
+                throw new \WC_Data_Exception('invalid_product', "Product {$product_id} not found");
+            }
+
+            // Use appropriate item class based on product type
+            $item = $this->createOrderItem($product_type, $product_data, $product);
+
+            if ($variation_id && $product->is_type('variation')) {
+                $item->set_variation_data($product->get_variation_attributes());
+            }
+
+            $order->add_item($item);
+        }
+    }
+
+    /**
+     * @param WC_Order $order
+     * @param array $discounts
+     */
+    private function applyDiscountsToOrder(WC_Order $order, array $discounts): void
+    {
+        foreach ($discounts as $discount) {
+            if (isset($discount['coupon_code'])) {
+                $order->apply_coupon($discount['coupon_code']);
+            }
+
+            if (isset($discount['fee'])) {
+                $fee = new WC_Order_Item_Fee();
+                $fee->set_props([
+                    'name' => $discount['fee']['name'],
+                    'amount' => -abs($discount['fee']['amount']),
+                    'total' => -abs($discount['fee']['amount']),
+                ]);
+                $order->add_item($fee);
+            }
+        }
+    }
+
+    /**
+     * @param array $product_presets
+     * @return array
+     * @throws \WC_Data_Exception
+     */
+    private function resolveProductPresets(array $product_presets): array
+    {
+        $available_presets = ProductPresets::get();
+        $products = [];
+
+        foreach ($product_presets as $preset) {
+            if (is_string($preset)) {
+                if (!isset($available_presets[$preset])) {
+                    throw new \WC_Data_Exception('invalid_preset', "Product preset '{$preset}' not found");
+                }
+                $products[] = $available_presets[$preset];
+            } elseif (is_array($preset)) {
+                $preset_name = $preset['preset'];
+                $quantity = $preset['quantity'] ?? 1;
+
+                if (!isset($available_presets[$preset_name])) {
+                    throw new \WC_Data_Exception('invalid_preset', "Product preset '{$preset_name}' not found");
+                }
+
+                $product_data = $available_presets[$preset_name];
+                $product_data['quantity'] = $quantity;
+                $products[] = $product_data;
+            }
+        }
+
+        return $products;
+    }
+
+    /**
+     * @param array $discount_presets
+     * @return array
+     * @throws \WC_Data_Exception
+     */
+    private function resolveDiscountPresets(array $discount_presets): array
+    {
+        $available_presets = DiscountPresets::get();
+        $discounts = [];
+
+        foreach ($discount_presets as $preset) {
+            if (!isset($available_presets[$preset])) {
+                throw new \WC_Data_Exception('invalid_preset', "Discount preset '{$preset}' not found");
+            }
+            $discounts[] = $available_presets[$preset];
+        }
+
+        return $discounts;
+    }
+
+    /**
+     * Delete all created orders
+     */
+    public function cleanup(): void
+    {
+        foreach ($this->created_order_ids as $order_id) {
+            wp_delete_post($order_id, true);
+        }
+
+        $this->created_order_ids = [];
+    }
+
+    /**
+     * @return array
+     */
+    public function getCreatedIds(): array
+    {
+        return $this->created_order_ids;
+    }
+
+    /**
+     * @param string $product_type
+     * @param array $product_data
+     * @param \WC_Product $product
+     * @return \WC_Order_Item_Product
+     */
+    private function createOrderItem(string $product_type, array $product_data, \WC_Product $product): \WC_Order_Item_Product
+    {
+        $item = new \WC_Order_Item_Product();
+
+        $item->set_props([
+            'product_id' => $product->get_id(),
+            'variation_id' => $product_data['variation_id'] ?? 0,
+            'quantity' => $product_data['quantity'],
+            'subtotal' => $product->get_price() * $product_data['quantity'],
+            'total' => $product->get_price() * $product_data['quantity'],
+        ]);
+
+        return $item;
+    }
+}

--- a/tests/Integration/Common/Factories/ProductFactory.php
+++ b/tests/Integration/Common/Factories/ProductFactory.php
@@ -1,0 +1,166 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Factories;
+
+use WC_Product_Simple;
+use WC_Product_Variable;
+use WC_Product_Variation;
+use Mollie\WooCommerceTests\Integration\Common\Fixtures\ProductPresets;
+
+class ProductFactory
+{
+    private array $created_product_ids = [];
+
+    /**
+     * @param string $preset_name
+     * @return \WC_Product
+     * @throws \WC_Data_Exception
+     */
+    public function createFromPreset(string $preset_name): \WC_Product
+    {
+        $presets = ProductPresets::get();
+
+        if (!isset($presets[$preset_name])) {
+            throw new \WC_Data_Exception('invalid_preset', "Product preset '{$preset_name}' not found");
+        }
+
+        $preset = $presets[$preset_name];
+
+        if (isset($preset['sku'])) {
+            $existing_product_id = wc_get_product_id_by_sku($preset['sku']);
+            if ($existing_product_id) {
+                $existing_product = wc_get_product($existing_product_id);
+                if ($existing_product) {
+                    return $existing_product;
+                }
+            }
+        }
+
+        if (isset($preset['product_id'])) {
+            $existing_product = wc_get_product($preset['product_id']);
+            if ($existing_product) {
+                return $existing_product;
+            }
+        }
+
+        if ($preset['type'] === 'subscription' && !class_exists('\WC_Product_Subscription')) {
+            return $this->createSimpleProduct($preset);
+        }
+        switch ($preset['type']) {
+            case 'variable':
+                return $this->createVariableProduct($preset);
+            case 'subscription':
+                return $this->createSubscriptionProduct($preset);
+            case 'simple':
+            default:
+                return $this->createSimpleProduct($preset);
+        }
+    }
+
+    /**
+     * @param array $preset
+     * @return WC_Product_Simple
+     */
+    private function createSimpleProduct(array $preset): WC_Product_Simple
+    {
+        $product = new WC_Product_Simple();
+        $product_id = wc_get_product_id_by_sku($preset['sku']);
+        $product->set_sku($preset['sku']);
+        $product->set_id($product_id);
+        $product->set_name($preset['name']);
+        $product->set_regular_price($preset['price']);
+        $product->set_status('publish');
+        $product->save();
+
+        $this->created_product_ids[] = $product_id;
+
+        return $product;
+    }
+
+    /**
+     * @param array $preset
+     * @return WC_Product_Variation
+     */
+    private function createVariableProduct(array $preset): WC_Product_Variation
+    {
+        // Create parent variable product
+        $parent = new WC_Product_Variable();
+        $product_id = wc_get_product_id_by_sku($preset['sku']);
+        $parent->set_sku($preset['sku']);
+        $parent->set_id($product_id);
+        $parent->set_name($preset['name']);
+        $parent->set_status('publish');
+        $parent->save();
+
+        // Create variation
+        $variation = new WC_Product_Variation();
+        $variation->set_id($preset['variation_id']);
+        $variation->set_parent_id($preset['product_id']);
+        $variation->set_regular_price($preset['price']);
+        $variation->set_attributes(['color' => 'red']);
+        $variation->set_status('publish');
+        $variation->save();
+
+        $this->created_product_ids[] = $product_id;
+        $this->created_product_ids[] = $preset['variation_id'];
+
+        return $variation;
+    }
+
+    /**
+     * @param array $preset
+     * @return \WC_Product_Subscription
+     */
+    private function createSubscriptionProduct(array $preset): \WC_Product_Subscription
+    {
+        $product = new \WC_Product_Subscription();
+        $product->set_props([
+            'name' => $preset['name'],
+            'regular_price' => $preset['price'],
+            'price' => $preset['price'],
+            'sku' => $preset['sku'],
+            'manage_stock' => false,
+            'tax_status' => 'taxable',
+            'downloadable' => false,
+            'virtual' => false,
+            'stock_status' => 'instock',
+            'weight' => '1.1',
+            'subscription_period' => $preset['subscription_period'],
+            'subscription_period_interval' => $preset['subscription_period_interval'],
+            'subscription_length' => $preset['subscription_length'],
+            'subscription_trial_period' => $preset['subscription_trial_period'],
+            'subscription_trial_length' => $preset['subscription_trial_length'],
+            'subscription_price' => $preset['subscription_price'],
+            'subscription_sign_up_fee' => $preset['subscription_sign_up_fee'],
+        ]);
+
+        $product->set_status('publish');
+        $product->save();
+
+        $this->created_product_ids[] = $product->get_id();
+        return $product;
+    }
+
+    /**
+     * @param string $sku
+     * @return bool
+     */
+    public function exists(string $sku): bool
+    {
+        $existing_product_id = wc_get_product_id_by_sku($sku);
+        return (bool)$existing_product_id;
+    }
+
+    /**
+     * Delete all created products
+     */
+    public function cleanup(): void
+    {
+        foreach ($this->created_product_ids as $product_id) {
+            wp_delete_post($product_id, true);
+        }
+
+        $this->created_product_ids = [];
+    }
+}

--- a/tests/Integration/Common/Fixtures/DiscountPresets.php
+++ b/tests/Integration/Common/Fixtures/DiscountPresets.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Fixtures;
+
+class DiscountPresets
+{
+    public static function get(): array
+    {
+        return [
+            'percentage_10' => [
+                'coupon_code' => 'TEST10PERCENT',
+                'type' => 'percent',
+                'amount' => '10'
+            ],
+            'fixed_5' => [
+                'coupon_code' => 'TEST5FIXED',
+                'type' => 'fixed_cart',
+                'amount' => '5.00'
+            ],
+            'manual_discount' => [
+                'fee' => ['name' => 'Test Discount', 'amount' => 3.50]
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Common/Fixtures/ProductPresets.php
+++ b/tests/Integration/Common/Fixtures/ProductPresets.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Fixtures;
+
+class ProductPresets
+{
+    public static function get(): array
+    {
+        return [
+            'simple' => [
+                'sku' => 'DUMMY_SIMPLE_SKU_01',
+                'name' => 'Test Simple Product',
+                'price' => '10.00',
+                'quantity' => 1,
+                'type' => 'simple'
+            ],
+            'simple_expensive' => [
+                'sku' => 'DUMMY_SIMPLE_SKU_02',
+                'name' => 'Test Expensive Product',
+                'price' => '199.99',
+                'quantity' => 1,
+                'type' => 'simple'
+            ],
+            /*'variable' => [
+                'sku' => 'DUMMY_VARIABLE_SKU_01',
+                'variation_id' => 20002,
+                'name' => 'Test Variable Product',
+                'price' => '25.00',
+                'quantity' => 1,
+                'type' => 'variable'
+            ],*/
+            'subscription' => [
+                'name' => 'Dummy Subscription Product',
+                'price' => '10.00',
+                'quantity' => 1,
+                'type' => 'subscription',
+                'sku' => 'DUMMY SUB SKU',
+                'subscription_period' => 'day',
+                'subscription_period_interval' => 1,
+                'subscription_length' => 0,
+                'subscription_trial_period' => '',
+                'subscription_trial_length' => 0,
+                'subscription_price' => 10,
+                'subscription_sign_up_fee' => 0,
+            ]
+        ];
+    }
+}

--- a/tests/Integration/Common/Traits/CleansTestData.php
+++ b/tests/Integration/Common/Traits/CleansTestData.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Traits;
+
+trait CleansTestData
+{
+    /**
+     * Clean all test data created by factories
+     */
+    protected function cleanupTestData(): void
+    {
+        if (isset($this->order_factory)) {
+            $this->order_factory->cleanup();
+        }
+
+        if (isset($this->product_factory)) {
+            $this->product_factory->cleanup();
+        }
+
+        if (isset($this->coupon_factory)) {
+            $this->coupon_factory->cleanup();
+        }
+    }
+}

--- a/tests/Integration/Common/Traits/CreateTestOrders.php
+++ b/tests/Integration/Common/Traits/CreateTestOrders.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Traits;
+
+use WC_Order;
+use Mollie\WooCommerceTests\Integration\Common\Factories\OrderFactory;
+
+trait CreateTestOrders
+{
+    use CreateTestProducts;
+
+    private OrderFactory $order_factory;
+
+    /**
+     * Initialize order factory
+     */
+    protected function initializeOrderFactory(): void
+    {
+        if (!isset($this->product_factory)) {
+            $this->initializeFactories();
+        }
+
+        $this->order_factory = new OrderFactory($this->product_factory, $this->coupon_factory);
+    }
+
+    /**
+     * Create a configured order using presets
+     */
+    protected function getConfiguredOrder(
+        int    $customer_id,
+        string $payment_method,
+        array  $product_presets,
+        array  $discount_presets = [],
+        bool   $set_paid = true
+    ): WC_Order
+    {
+        if (!isset($this->order_factory)) {
+            $this->initializeOrderFactory();
+        }
+
+        return $this->order_factory->create(
+            $customer_id,
+            $payment_method,
+            $product_presets,
+            $discount_presets,
+            $set_paid
+        );
+    }
+}

--- a/tests/Integration/Common/Traits/CreateTestProducts.php
+++ b/tests/Integration/Common/Traits/CreateTestProducts.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\Common\Traits;
+
+use Mollie\WooCommerceTests\Integration\Common\Factories\ProductFactory;
+use Mollie\WooCommerceTests\Integration\Common\Factories\CouponFactory;
+use Mollie\WooCommerceTests\Integration\Common\Fixtures\ProductPresets;
+use Mollie\WooCommerceTests\Integration\Common\Fixtures\DiscountPresets;
+
+trait CreateTestProducts
+{
+    private ProductFactory $product_factory;
+    private CouponFactory $coupon_factory;
+
+    /**
+     * Initialize factories
+     */
+    protected function initializeFactories(): void
+    {
+        $this->product_factory = new ProductFactory();
+        $this->coupon_factory = new CouponFactory();
+    }
+
+    /**
+     * Create all test products from presets
+     * @throws \WC_Data_Exception
+     */
+    protected function createTestProducts(): void
+    {
+        if (!isset($this->product_factory)) {
+            $this->initializeFactories();
+        }
+
+        foreach (array_keys(ProductPresets::get()) as $preset_name) {
+            $preset = ProductPresets::get()[$preset_name];
+            // Only create if doesn't exist
+            if (!$this->product_factory->exists($preset['sku'])) {
+                $this->product_factory->createFromPreset($preset_name);
+            }
+        }
+    }
+
+    /**
+     * Create all test coupons from presets
+     */
+    protected function createTestCoupons(): void
+    {
+        if (!isset($this->coupon_factory)) {
+            $this->initializeFactories();
+        }
+
+        foreach (DiscountPresets::get() as $preset_name => $preset) {
+            // Only create coupons (skip manual fees)
+            if (isset($preset['coupon_code']) && !$this->coupon_factory->exists($preset['coupon_code'])) {
+                $this->coupon_factory->createFromPreset($preset_name);
+            }
+        }
+    }
+}

--- a/tests/Integration/IntegrationMockedTestCase.php
+++ b/tests/Integration/IntegrationMockedTestCase.php
@@ -1,0 +1,187 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration;
+
+use Inpsyde\Modularity\Module\ExecutableModule;
+use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
+use Inpsyde\Modularity\Module\ServiceModule;
+use Mollie\WooCommerceTests\Integration\Common\Traits\CreateTestOrders;
+use Mollie\WooCommerceTests\Integration\Common\Traits\CreateTestProducts;
+use Psr\Container\ContainerInterface;
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Payment_Token_CC;
+use WC_Subscription;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+
+class IntegrationMockedTestCase extends \PHPUnit\Framework\TestCase
+{
+    use MockeryPHPUnitIntegration, CreateTestOrders, CreateTestProducts;
+
+    /**
+     * @throws \WC_Data_Exception
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->customer_id = $this->createCustomerIfNotExists();
+        $this->createTestProducts();
+        //$this->createTestCoupons();
+    }
+
+    public function tearDown(): void
+    {
+        // This cleans up everything created during tests
+        //$this->cleanupTestData();
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, callable> $overriddenServices
+     * @return ContainerInterface
+     */
+    protected function bootstrapModule(array $overriddenServices = []): ContainerInterface
+    {
+        $module = new class ($overriddenServices) implements ServiceModule, ExecutableModule {
+            use ModuleClassNameIdTrait;
+
+            public function __construct(array $services)
+            {
+                $this->services = $services;
+            }
+
+            public function services(): array
+            {
+                return $this->services;
+            }
+
+            public function run(ContainerInterface $c): bool
+            {
+                return true;
+            }
+        };
+
+        $rootDir = ROOT_DIR;
+        $bootstrap = require("$rootDir/bootstrap.php");
+        return $bootstrap($rootDir, [$module]);
+    }
+
+    public function createCustomerIfNotExists(int $customer_id = 1): int
+    {
+        $customer = new \WC_Customer($customer_id);
+        if (empty($customer->get_email())) {
+            $customer->set_email('customer' . $customer_id . '@example.com');
+            $customer->set_first_name('John');
+            $customer->set_last_name('Doe');
+            $customer->save();
+        }
+        return $customer->get_id();
+    }
+
+    /**
+     * Creates a payment token for a customer.
+     *
+     * @param int $customer_id The customer ID.
+     * @return WC_Payment_Token_CC The created payment token.
+     * @throws \Exception
+     */
+    public function createAPaymentTokenForTheCustomer(int $customer_id = 1, $gateway_id = 'ppcp-gateway'): WC_Payment_Token_CC
+    {
+        $this->createCustomerIfNotExists($customer_id);
+
+        $token = new WC_Payment_Token_CC();
+        $token->set_token('test_token_' . uniqid()); // Unique token ID
+        $token->set_gateway_id($gateway_id);
+        $token->set_user_id($customer_id);
+
+        // These fields are required for WC_Payment_Token_CC
+        $token->set_card_type('visa'); // lowercase is often expected
+        $token->set_last4('1234');
+        $token->set_expiry_month('12');
+        $token->set_expiry_year('2030'); // Missing expiry year in your original code
+
+        $result = $token->save();
+
+        if (!$result || is_wp_error($result)) {
+            throw new \Exception('Failed to save payment token: ' .
+                (is_wp_error($result) ? $result->get_error_message() : 'Unknown error'));
+        }
+
+        $saved_token = \WC_Payment_Tokens::get($token->get_id());
+        if (!$saved_token || $saved_token->get_id() !== $token->get_id()) {
+            throw new \Exception('Token was not saved correctly');
+        }
+
+        return $token;
+    }
+
+    /**
+     * Helper method to create a subscription for testing.
+     *
+     * @param int $customer_id The customer ID
+     * @param string $payment_method The payment method
+     * @param string $sku
+     * @return WC_Subscription
+     * @throws \WC_Data_Exception
+     */
+    public function createSubscription(int $customer_id = 1, string $payment_method = 'ppcp-gateway', $sku = 'DUMMY SUB SKU'): WC_Subscription
+    {
+        $product_id = wc_get_product_id_by_sku($sku);
+
+        $order = $this->getConfiguredOrder(
+            $this->customer_id,
+            $payment_method,
+            ['subscription']
+        );
+        $subscription = new WC_Subscription();
+        $subscription->set_customer_id($customer_id);
+        $subscription->set_payment_method($payment_method);
+        $subscription->set_status('active');
+        $subscription->set_parent_id($order->get_id());
+        $subscription->set_billing_period('month');
+        $subscription->set_billing_interval(1);
+
+        // Add a product to the subscription
+        $subscription_item = new WC_Order_Item_Product();
+        $subscription_item->set_props([
+            'product_id' => $product_id,
+            'quantity' => 1,
+            'subtotal' => 10,
+            'total' => 10,
+        ]);
+        $subscription->add_item($subscription_item);
+        $subscription->set_date_created(current_time('mysql'));
+        $subscription->set_start_date(current_time('mysql'));
+        $subscription->set_next_payment_date(date('Y-m-d H:i:s', strtotime('+1 month', current_time('timestamp'))));
+        $subscription->save();
+
+        return $subscription;
+    }
+
+    /**
+     * Creates a renewal order for testing
+     *
+     * @param int $customer_id
+     * @param string $gateway_id
+     * @param int $subscription_id
+     * @return WC_Order
+     */
+    protected function createRenewalOrder(int $customer_id, string $gateway_id, int $subscription_id): WC_Order
+    {
+        $renewal_order = $this->getConfiguredOrder(
+            $customer_id,
+            $gateway_id,
+            ['subscription'],
+            [],
+            false
+        );
+        $renewal_order->update_meta_data('_subscription_renewal', $subscription_id);
+        $renewal_order->update_meta_data('_subscription_renewal', $subscription_id);
+        $renewal_order->save();
+
+        return $renewal_order;
+    }
+}

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -1,0 +1,38 @@
+# Integration Tests
+PHPUnit tests that runs against a working WP site. Useful to test modules (ex. classes) together without having the use test doubles but the real infrastructure.
+
+### How to run tests
+- Copy and rename `.env.integration.example` to  `.env.integration` from the root of the plugin, set configurations if needed.
+- Run configuration: `ddev php tests/integration/PHPUnit/setup.php`
+- Run tests: `ddev exec phpunit -c tests/Integration/phpunit.xml.dist --testdox`
+- Run a single test: `ddev exec phpunit --filter testSomeTestName -c tests/Integration/phpunit.xml.dist --testdox`
+
+### Guidelines
+
+- Use descriptive class names that reflect what system/component you're testing
+- Group related tests using @group annotations
+- Keep one test class per main class you're testing
+- Use consistent prefixes like it_, should_, or test_ for methods
+- Include setup/teardown methods for database state management
+
+#### Method Naming
+
+Pattern: it_[action]_[expected_outcome]_[given_condition]()
+
+#### DocBlock
+
+``` php
+/**
+* Brief description of what the test verifies.
+*
+* Longer description if needed, explaining the business scenario
+* or complex integration flow being tested.
+*
+* @test
+* @group integration
+* @group [feature-name]
+* @covers ClassName::methodName
+* @dataProvider dataProviderName (if applicable)
+ */
+  
+```

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+define('INTEGRATION_TESTS_ROOT_DIR', dirname(__DIR__));
+define('ROOT_DIR', dirname(INTEGRATION_TESTS_ROOT_DIR, 1));
+
+if (file_exists(ROOT_DIR . '/.env.integration')) {
+    $dotenv = Dotenv\Dotenv::createImmutable(ROOT_DIR, '.env.integration');
+    $dotenv->load();
+}
+
+if (!isset($_ENV['MOLLIE_INTEGRATION_WP_DIR'])) {
+    exit('Copy .env.integration.example to .env.integration or define the environment variables.' . PHP_EOL);
+}
+$wpRootDir = str_replace('${ROOT_DIR}', ROOT_DIR, $_ENV['MOLLIE_INTEGRATION_WP_DIR']);
+
+define('WP_ROOT_DIR', $wpRootDir);
+
+$_SERVER['HTTP_HOST'] = ''; // just to avoid a warning
+
+// Set a constant that your plugin can check to prevent double initialization
+define('MOLLIE_INTEGRATION_TESTS', true);
+require_once WP_ROOT_DIR . '/wp-load.php';
+require_once WP_ROOT_DIR . '/wp-includes/functions.php';
+
+// Ensure the TestCase class is loaded
+require_once __DIR__ . '/IntegrationMockedTestCase.php';

--- a/tests/Integration/spec/webhooks/WebhooksIntegrationTest.php
+++ b/tests/Integration/spec/webhooks/WebhooksIntegrationTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Mollie\WooCommerceTests\Integration\spec\webhooks;
+
+use Mockery;
+use Mollie\WooCommerceTests\Integration\IntegrationMockedTestCase;
+use Mollie\WooCommerceTests\Integration\API\Traits\APIMockTrait;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\WooCommerce\Payment\MollieOrderService;
+use Psr\Log\LoggerInterface as Logger;
+use Mollie\WooCommerce\Payment\PaymentFactory;
+
+use function Brain\Monkey\Functions\when;
+
+class WebhooksIntegrationTest extends IntegrationMockedTestCase
+{
+    use APIMockTrait;
+
+    /**
+     * @var MollieOrderService
+     */
+    private $webhookService;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->initializeApiMock();
+
+        // Clear any existing globals
+        unset($_GET['order_id'], $_GET['key'], $_POST['id']);
+    }
+
+    /**
+     * Helper method to set up webhook request environment
+     */
+    protected function setupWebhookRequest(int $orderId, string $orderKey, string $paymentId): void
+    {
+        $_GET['order_id'] = (string)$orderId;
+        $_GET['key'] = $orderKey;
+        $_POST['id'] = $paymentId; // This won't be used by filter_input, but keep for consistency
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+    }
+
+    /**
+     * Test that webhook processes only one order when race conditions occur.
+     *
+     * This test verifies that when multiple webhook calls arrive simultaneously
+     * for the same order, only one payment is processed and subsequent calls
+     * are properly handled to prevent duplicate processing.
+     *
+     * @test
+     * @group integration
+     * @group Webhooks
+     */
+    public function it_processes_only_one_order_when_race_conditions()
+    {
+        $order = $this->getConfiguredOrder(
+            1,
+            'mollie_wc_gateway_ideal',
+            ['simple'],
+            [],
+            false
+        );
+
+        $orderId = $order->get_id();
+        $orderKey = $order->get_order_key();
+
+        $paymentData = [
+            'id' => 'tr_first_payment_id',
+        ];
+
+        $this->mockSuccessfulPaymentGet('tr_first_payment_id', 'paid', [
+            'metadata' => ['order_id' => $orderId],
+            'method' => 'ideal',
+            'mode' => 'test'
+        ]);
+
+        $mockedServices = $this->getMockedApiServices();
+        $container = $this->bootstrapModule($mockedServices);
+        $this->setupWebhookRequest($orderId, $orderKey, $paymentData['id']);
+
+        $this->webhookService = Mockery::mock(MollieOrderService::class, [
+            $container->get('SDK.HttpResponse'),
+            $container->get(Logger::class),
+            $container->get(PaymentFactory::class),
+            $container->get('settings.data_helper'),
+            $container->get('shared.plugin_id'),
+            $container
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $this->webhookService->shouldReceive('getPaymentIdFromRequest')
+            ->andReturn($paymentData['id']);
+        $this->webhookService->onWebhookAction();
+
+        $order = wc_get_order($orderId);
+        $this->assertEquals('processing', $order->get_status());
+
+        // Verify that subsequent webhook calls with the same payment ID are handled gracefully
+        // (This simulates the race condition scenario)
+        $this->webhookService->onWebhookAction();
+
+        // Order status should remain the same, not be processed again
+        $order = wc_get_order($orderId);
+        $this->assertEquals('processing', $order->get_status());
+    }
+
+    /**
+     * Test concurrent webhook calls for the same payment (race condition simulation)
+     *
+     * @test
+     * @group integration
+     * @group Webhooks
+     */
+    public function it_handles_concurrent_webhook_calls_gracefully()
+    {
+        $order = $this->getConfiguredOrder(
+            1,
+            'mollie_wc_gateway_ideal',
+            ['simple'],
+            [],
+            false
+        );
+
+        $orderId = $order->get_id();
+        $orderKey = $order->get_order_key();
+
+        $this->mockSuccessfulPaymentGet('tr_concurrent_payment_id', 'paid', [
+            'metadata' => ['order_id' => $orderId],
+            'method' => 'ideal',
+            'mode' => 'test'
+        ]);
+
+        $mockedServices = $this->getMockedApiServices();
+        $container = $this->bootstrapModule($mockedServices);
+
+        // Set up the webhook request parameters
+        $this->setupWebhookRequest($orderId, $orderKey, 'tr_concurrent_payment_id');
+
+        // Get two instances of the webhook service to simulate concurrent requests
+        $webhookService1 = Mockery::mock(MollieOrderService::class, [
+            $container->get('SDK.HttpResponse'),
+            $container->get(Logger::class),
+            $container->get(PaymentFactory::class),
+            $container->get('settings.data_helper'),
+            $container->get('shared.plugin_id'),
+            $container
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $webhookService1->shouldReceive('getPaymentIdFromRequest')
+            ->andReturn('tr_concurrent_payment_id');
+
+        $webhookService2 = Mockery::mock(MollieOrderService::class, [
+            $container->get('SDK.HttpResponse'),
+            $container->get(Logger::class),
+            $container->get(PaymentFactory::class),
+            $container->get('settings.data_helper'),
+            $container->get('shared.plugin_id'),
+            $container
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $webhookService2->shouldReceive('getPaymentIdFromRequest')
+            ->andReturn('tr_concurrent_payment_id');
+
+        // First webhook call should process successfully
+        $webhookService1->onWebhookAction();
+
+        $order = wc_get_order($orderId);
+        $this->assertEquals('processing', $order->get_status());
+
+        // Second webhook call should be handled gracefully (idempotency)
+        // This simulates a race condition where the same webhook arrives multiple times
+        $webhookService2->onWebhookAction();
+
+        // Order status should remain the same
+        $order = wc_get_order($orderId);
+        $this->assertEquals('processing', $order->get_status());
+
+        // Verify no duplicate processing occurred by checking order notes
+        $notes = wc_get_order_notes(['order_id' => $orderId]);
+        $paymentNotes = array_filter($notes, function ($note) {
+            return strpos($note->content, 'completed using  payment (tr_concurrent_payment_id') != false;
+        });
+
+        // Should only have one payment started note
+        $this->assertCount(1, $paymentNotes, 'Should only process payment once, even with concurrent webhooks');
+    }
+}


### PR DESCRIPTION
## Prevent Race Conditions in Webhook Processing with Order Locking

### Problem
Multiple webhook calls arriving simultaneously for the same order could cause race conditions, leading to:
- Duplicate payment processing
- Inconsistent order states
- Double order status updates
- Potential financial discrepancies

### Solution
Implemented a locking mechanism to ensure only one webhook processes an order at a time:

#### Core Changes
- **Order-level locking**: Added `acquireOrderLock()` and `releaseOrderLock()` using WordPress transients
- **Idempotency checks**: Prevent duplicate processing of the same payment ID
- **Conflict handling**: Return HTTP 409 when another webhook is already processing
- **Always release locks**: Use try/finally blocks to prevent deadlocks

#### Testing Infrastructure
- Added comprehensive integration test framework
- Created webhook race condition simulation tests
- Added factories for consistent test data creation
- Included API mocking capabilities for reliable testing

### Technical Details
The lock uses a 30-second timeout with unique identifiers to prevent indefinite locks. The implementation ensures:
- Only one webhook processes per order
- Graceful handling of duplicate webhook calls
- Proper cleanup even on exceptions
- Maintained backward compatibility

### Testing
- Integration tests verify race condition handling
- Concurrent webhook simulation tests
- Lock acquisition/release verification
- Idempotency validation