### PR TITLE
Add metadata in shipping lines

### DIFF
--- a/src/Payment/OrderLines.php
+++ b/src/Payment/OrderLines.php
@@ -231,6 +231,9 @@ class OrderLines
                         'currency' => $this->currency,
                         'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total_tax(), $this->currency),
                     ],
+                    'metadata' => [
+                        'order_item_id' => $shipping_method->get_id(),
+                    ],
                 ];
 
                 $this->order_lines[] = $shipping;


### PR DESCRIPTION
This PR fixes the error thrown when missing metadata in the shipping lines on refund processing