### PR TITLE
Riverty inconsistency with birth date and phone inputs (684)

### DIFF
--- a/resources/js/blocks/molliePaymentMethod.js
+++ b/resources/js/blocks/molliePaymentMethod.js
@@ -188,7 +188,7 @@ const MollieComponent = (props) => {
 
     function fieldMarkup(id, fieldType, label, action, value, placeholder = null) {
         const className = "wc-block-components-text-input wc-block-components-address-form__" + id;
-        return <div class="custom-input">
+        return <div className="custom-input">
             <label htmlFor={id} dangerouslySetInnerHTML={{__html: label}}></label>
             <input type={fieldType} name={id} id={id} value={value} onChange={action} placeholder={placeholder}></input>
         </div>

--- a/resources/js/blocks/molliePaymentMethod.js
+++ b/resources/js/blocks/molliePaymentMethod.js
@@ -59,7 +59,7 @@ let onSubmitLocal
 let activePaymentMethodLocal
 let creditCardSelected = new Event("mollie_creditcard_component_selected", {bubbles: true});
 const MollieComponent = (props) => {
-    let {onSubmit, activePaymentMethod, billing, item, useEffect, ajaxUrl, jQuery, emitResponse, eventRegistration, requiredFields, shippingData, isPhoneFieldVisible} = props
+    let {onSubmit, activePaymentMethod, billing, item, useEffect, ajaxUrl, jQuery, emitResponse, eventRegistration, requiredFields, shippingData, showPhoneField} = props
     const {  responseTypes } = emitResponse;
     const {onPaymentSetup, onCheckoutValidation} = eventRegistration;
     if (!item || !item.name) {
@@ -240,7 +240,7 @@ const MollieComponent = (props) => {
             <>
                 <div>{itemContentP}</div>
                 {fieldMarkup("billing-birthdate", "date", birthdateField, updateBirthdate, inputBirthdate)}
-                {!isPhoneFieldVisible && fieldMarkup("billing-phone-in3", "tel", phoneLabel, updatePhone, inputPhone, phoneField)}
+                {showPhoneField && fieldMarkup("billing-phone-in3", "tel", phoneLabel, updatePhone, inputPhone, phoneField)}
             </>
         );
     }
@@ -253,7 +253,7 @@ const MollieComponent = (props) => {
             <>
                 <div>{itemContentP}</div>
                 {fieldMarkup("billing-birthdate", "date", birthdateField, updateBirthdate, inputBirthdate)}
-                {!isPhoneFieldVisible && fieldMarkup("billing-phone-riverty", "tel", phoneLabel, updatePhone, inputPhone, phoneField)}
+                {showPhoneField && fieldMarkup("billing-phone-riverty", "tel", phoneLabel, updatePhone, inputPhone, phoneField)}
             </>
         );
     }
@@ -282,7 +282,7 @@ const Label = ({ item, filters, ajaxUrl }) => {
     );
 };
 
-const molliePaymentMethod = (useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, isPhoneFieldVisible) =>{
+const molliePaymentMethod = (useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, showPhoneField) =>{
 
     if (item.name === "mollie_wc_gateway_creditcard") {
         document.addEventListener('mollie_components_ready_to_submit', function () {
@@ -308,7 +308,7 @@ const molliePaymentMethod = (useEffect, ajaxUrl, filters, gatewayData, available
             ajaxUrl={ajaxUrl}
             jQuery={jQuery}
             requiredFields={requiredFields}
-            isPhoneFieldVisible={isPhoneFieldVisible}/>,
+            showPhoneField={showPhoneField}/>,
         edit: <div>{item.edit}</div>,
         paymentMethodId: item.paymentMethodId,
         canMakePayment: ({cartTotals, billingData}) => {

--- a/resources/js/blocks/molliePaymentMethod.js
+++ b/resources/js/blocks/molliePaymentMethod.js
@@ -282,7 +282,7 @@ const Label = ({ item, filters, ajaxUrl }) => {
     );
 };
 
-const molliePaymentMethod = (useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, isCompanyFieldVisible, isPhoneFieldVisible) =>{
+const molliePaymentMethod = (useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, isPhoneFieldVisible) =>{
 
     if (item.name === "mollie_wc_gateway_creditcard") {
         document.addEventListener('mollie_components_ready_to_submit', function () {

--- a/resources/js/blocks/molliePaymentMethod.js
+++ b/resources/js/blocks/molliePaymentMethod.js
@@ -190,7 +190,7 @@ const MollieComponent = (props) => {
         const className = "wc-block-components-text-input wc-block-components-address-form__" + id;
         return <div className="custom-input">
             <label htmlFor={id} dangerouslySetInnerHTML={{__html: label}}></label>
-            <input type={fieldType} name={id} id={id} value={value} onChange={action} placeholder={placeholder}></input>
+            <input type={fieldType} name={id} id={id} value={value} onChange={action} placeholder={placeholder} data-testid={id}></input>
         </div>
     }
 

--- a/resources/js/blocks/molliePaymentMethod.js
+++ b/resources/js/blocks/molliePaymentMethod.js
@@ -188,7 +188,7 @@ const MollieComponent = (props) => {
 
     function fieldMarkup(id, fieldType, label, action, value, placeholder = null) {
         const className = "wc-block-components-text-input wc-block-components-address-form__" + id;
-        return <div className="custom-input">
+        return <div className="custom-input wc-block-components-text-input wc-block-components-address-form__phone is-active">
             <label htmlFor={id} dangerouslySetInnerHTML={{__html: label}}></label>
             <input type={fieldType} name={id} id={id} value={value} onChange={action} placeholder={placeholder} data-testid={id}></input>
         </div>

--- a/resources/js/mollieBlockIndex.js
+++ b/resources/js/mollieBlockIndex.js
@@ -15,11 +15,11 @@ import ApplePayButtonEditorComponent from './blocks/ApplePayButtonEditorComponen
         const isAppleSession = typeof window.ApplePaySession === "function"
 
         function getPhoneField() {
-            const phoneFieldDataset = document.querySelector('[data-show-phone-field]');
-            if (!phoneFieldDataset) {
+            const wooRequiresPhoneField = document.querySelector('[data-require-phone-field]');
+            if (!wooRequiresPhoneField) {
                 return true;
             }
-            return phoneFieldDataset.dataset.showPhoneField !== "false"
+            return wooRequiresPhoneField.dataset.requirePhoneField !== "false"
         }
 
         const companyNameString = defaultFields.company.label

--- a/resources/js/mollieBlockIndex.js
+++ b/resources/js/mollieBlockIndex.js
@@ -14,23 +14,23 @@ import ApplePayButtonEditorComponent from './blocks/ApplePayButtonEditorComponen
         const {useEffect} = wp.element;
         const isAppleSession = typeof window.ApplePaySession === "function"
 
-        function getPhoneField() {
+        function mustShowPhoneField() {
             const wooRequiresPhoneField = document.querySelector('[data-require-phone-field]');
             if (!wooRequiresPhoneField) {
                 return true;
             }
-            return wooRequiresPhoneField.dataset.requirePhoneField !== "false"
+            return !wooRequiresPhoneField.dataset.requirePhoneField === true;
         }
 
         const companyNameString = defaultFields.company.label
-        const isPhoneFieldVisible = getPhoneField();
+        const showPhoneField = mustShowPhoneField();
         const phoneString = defaultFields.phone.label
         let requiredFields = {
             'companyNameString': companyNameString,
             'phoneString': phoneString,
         }
         gatewayData.forEach(item => {
-            let register = () => registerPaymentMethod(molliePaymentMethod(useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, isPhoneFieldVisible));
+            let register = () => registerPaymentMethod(molliePaymentMethod(useEffect, ajaxUrl, filters, gatewayData, availableGateways, item, jQuery, requiredFields, showPhoneField));
             if (item.name === 'mollie_wc_gateway_applepay') {
                 const {isExpressEnabled} = item;
                 if ((isAppleSession && window.ApplePaySession.canMakePayments())) {

--- a/src/PaymentMethods/PaymentFieldsStrategies/BancomatpayFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/BancomatpayFieldsStrategy.php
@@ -43,7 +43,7 @@ class BancomatpayFieldsStrategy extends AbstractPaymentFieldsRenderer implements
     {
         $phoneValue = $phoneValue ?: '';
         return '
-            <p class="form-row form-row-wide" id="billing_phone_field">
+            <p class="form-row form-row-wide" id="billing_phone_field" data-testid="billing-phone-bancomatpay">
                 <label for="' . esc_attr(self::FIELD_PHONE) . '" class="">' . esc_html__(
             'Phone',
             'mollie-payments-for-woocommerce'

--- a/src/PaymentMethods/PaymentFieldsStrategies/BillieFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/BillieFieldsStrategy.php
@@ -43,7 +43,7 @@ class BillieFieldsStrategy extends AbstractPaymentFieldsRenderer implements Paym
     protected function company()
     {
         return '
-    <p class="form-row form-row-wide" id="billing_company_field">
+    <p class="form-row form-row-wide" id="billing_company_field" data-testid="billing-company-billie">
         <label for="' . esc_attr(self::FIELD_COMPANY) . '" class="">' . esc_html__(
             'Company',
             'mollie-payments-for-woocommerce'

--- a/src/PaymentMethods/PaymentFieldsStrategies/In3FieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/In3FieldsStrategy.php
@@ -49,7 +49,7 @@ class In3FieldsStrategy extends AbstractPaymentFieldsRenderer implements Payment
     protected function phoneNumber($phoneValue)
     {
         $phoneValue = $phoneValue ?: '';
-        $html = '<p class="form-row form-row-wide" id="billing_phone_field">';
+        $html = '<p class="form-row form-row-wide" id="billing_phone_field" data-testid="billing-phone-in3">';
         $html .= '<label for="' . esc_attr(self::FIELD_PHONE) . '" class="">' . esc_html__(
             'Phone',
             'mollie-payments-for-woocommerce'

--- a/src/PaymentMethods/PaymentFieldsStrategies/RivertyFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/RivertyFieldsStrategy.php
@@ -59,7 +59,7 @@ class RivertyFieldsStrategy extends AbstractPaymentFieldsRenderer implements Pay
         ];
         $placeholder = in_array($country, array_keys($countryCodes)) ? $countryCodes[$country] : $countryCodes['NL'];
 
-        $html = '<p class="form-row form-row-wide" id="billing_phone_field">';
+        $html = '<p class="form-row form-row-wide" id="billing_phone_field" data-testid="billing-phone-riverty">';
         $html .= '<label for="' . esc_attr(self::FIELD_PHONE) . '" class="">' . esc_html__('Phone', 'mollie-payments-for-woocommerce') . '</label>';
         $html .= '<span class="woocommerce-input-wrapper">';
         $html .= '<input type="tel" class="input-text " name="' . esc_attr(self::FIELD_PHONE) . '" id="' . esc_attr(self::FIELD_PHONE) . '" placeholder="' . esc_attr($placeholder) . '" value="' . esc_attr($phoneValue) . '" autocomplete="phone">';


### PR DESCRIPTION
This PR
- Fixes the logic to render the phone button. It only hides if the phone is required in Woo.
- Adds data-testid to locate the items more reliably
- Adds css classes to unify the look of the custom phone field