### PR TITLE
Change validation logic for in3 phone field (PIWOO-478)

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -521,7 +521,7 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         }
         $fieldPosted = filter_input(INPUT_POST, $field, FILTER_SANITIZE_SPECIAL_CHARS) ?? false;
 
-        if ($fieldPosted && !$this->isPhoneValid($fieldPosted)) {
+        if ($fieldPosted && $this->isPhoneValid($fieldPosted)) {
             $fields['billing_phone'] = $fieldPosted;
             return $fields;
         }


### PR DESCRIPTION
If woo phone is empty or invalid, and our phone field is not empty and the phone is valid we save it, it does not make sense that we only save invalid phones