### PR TITLE
Modernize webhooks with rest endpoint

### DIFF
--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -91,7 +91,6 @@ class MollieOrderService
         }
         $payment_object_id = sanitize_text_field(wp_unslash($paymentId));
 
-        $data_helper = $this->data;
         $order = wc_get_order($order_id);
 
         if (!$order instanceof WC_Order) {
@@ -110,7 +109,30 @@ class MollieOrderService
         if (!mollieWooCommerceIsMollieGateway($gateway->id)) {
             return;
         }
-        $this->setGateway($gateway);
+
+        // Prevent double payment webhooks for klarna on orders api
+        // TODO improve testing to check if we can remove this check
+        if (
+            $this->container->get('settings.settings_helper')->isOrderApiSetting()
+            && in_array(
+                str_replace('mollie_wc_gateway_', '', $gateway->id),
+                [
+                    Constants::KLARNA,
+                    Constants::KLARNAPAYLATER,
+                    Constants::KLARNASLICEIT,
+                    Constants::KLARNAPAYNOW,
+                ],
+                true
+            )
+            && strpos($payment_object_id, 'tr_') === 0
+        ) {
+            $this->httpResponse->setHttpResponseCode(200);
+            $this->logger->debug(
+                $this->gateway->id . ": not respond on transaction webhooks for this payment method when order API is active. Payment ID {$payment->id}, order ID $order_id"
+            );
+            return;
+        }
+
         // Acquire exclusive lock for this order to prevent race conditions
         $lockKey = 'mollie_webhook_lock_' . $order_id;
         $lockAcquired = $this->acquireOrderLock($lockKey, 30);
@@ -125,116 +147,9 @@ class MollieOrderService
         }
 
         try {
-            $test_mode = $data_helper->getActiveMolliePaymentMode($order_id) === 'test';
-            // Load the payment from Mollie, do not use cache
-            try {
-                $payment_object = $this->paymentFactory->getPaymentObject(
-                    $payment_object_id
-                );
-            } catch (ApiException $exception) {
+            if (!$this->doPaymentForOrder($order)) {
                 $this->httpResponse->setHttpResponseCode(400);
-                $this->logger->debug($exception->getMessage());
-                return;
-            }
-
-            $payment = $payment_object->getPaymentObject($payment_object->data(), $test_mode, false);
-
-            // Payment not found
-            if (!$payment) {
-                $this->httpResponse->setHttpResponseCode(404);
-                $this->logger->debug(__METHOD__ . ": payment object $payment_object_id not found.", [true]);
-                return;
-            }
-
-            // Prevent double payment webhooks for klarna on orders api
-            // TODO improve testing to check if we can remove this check
-            if (
-                $this->container->get('settings.settings_helper')->isOrderApiSetting()
-                && in_array(
-                    $payment->method,
-                    [
-                        Constants::KLARNA,
-                        Constants::KLARNAPAYLATER,
-                        Constants::KLARNASLICEIT,
-                        Constants::KLARNAPAYNOW,
-                    ],
-                    true
-                )
-                && strpos($payment_object_id, 'tr_') === 0
-            ) {
-                $this->httpResponse->setHttpResponseCode(200);
-                $this->logger->debug(
-                    $this->gateway->id . ": not respond on transaction webhooks for this payment method when order API is active. Payment ID {$payment->id}, order ID $order_id"
-                );
-                return;
-            }
-
-            if ($order_id != $payment->metadata->order_id) {
-                $this->httpResponse->setHttpResponseCode(400);
-                $this->logger->debug(
-                    __METHOD__ . ": Order ID does not match order_id in payment metadata. Payment ID {$payment->id}, order ID $order_id"
-                );
-                return;
-            }
-
-            $this->logger->debug(
-                $this->gateway->id . ": Mollie payment object {$payment->id} (" . $payment->mode . ") webhook call for order {$order->get_id()}.",
-                [true]
-            );
-            $payment_method_title = $this->getPaymentMethodTitle($payment);
-
-            $method_name = 'onWebhook' . ucfirst($payment->status);
-
-            // Re-check if order needs payment after acquiring lock
-            if (!$this->orderNeedsPayment($order)) {
-                // TODO David: move to payment object?
-                // Add a debug message that order was already paid for
-                $this->handlePaidOrderWebhook($order, $payment);
-
-                $this->processRefunds($order, $payment);
-                $this->processChargebacks($order, $payment);
-
-                // If the order gets updated to completed at mollie, we need to update the order status
-                if (
-                    $order->get_status() === 'processing'
-                    && method_exists($payment, 'isCompleted')
-                    && $payment->isCompleted()
-                    && method_exists($payment_object, 'onWebhookCompleted')
-                ) {
-                    $payment_object->onWebhookCompleted($order, $payment, $payment_method_title);
-                }
-                return;
-            }
-
-            if (
-                $payment->method === 'paypal' && isset($payment->billingAddress) && $this->isOrderButtonPayment(
-                    $order
-                )
-            ) {
-                $this->logger->debug($this->gateway->id . ": updating address from express button", [true]);
-                $this->setBillingAddressAfterPayment($payment, $order);
-            }
-
-            if (method_exists($payment_object, $method_name)) {
-                do_action($this->pluginId . '_before_webhook_payment_action', $payment, $order);
-                $payment_object->{$method_name}($order, $payment, $payment_method_title);
-            } else {
-                $order->add_order_note(
-                    sprintf(
-                    /* translators: Placeholder 1: payment method title, placeholder 2: payment status, placeholder 3: payment ID */
-                        __('%1$s payment %2$s (%3$s), not processed.', 'mollie-payments-for-woocommerce'),
-                        $this->gateway->method_title,
-                        $payment->status,
-                        $payment->id . ($payment->mode === 'test' ? (' - ' . __(
-                            'test mode',
-                            'mollie-payments-for-woocommerce'
-                        )) : ''
-                        )
-                    )
-                );
-            }
-
-            do_action($this->pluginId . '_after_webhook_action', $payment, $order);
+            };
             // Status 200
         } finally {
             // Always release the lock
@@ -297,6 +212,17 @@ class MollieOrderService
             return true;
         }
 
+        return $this->doPaymentForOrder($order);
+    }
+
+    /**
+     * Processes the payment for a given WooCommerce order.
+     *
+     * @param \WC_Order $order The order object for which the payment is being processed.
+     * @return bool Returns true if the payment was successfully processed, false otherwise.
+     */
+    public function doPaymentForOrder(\WC_Order $order): bool
+    {
         $gateway = wc_get_payment_gateway_by_order($order);
         if (!$gateway || !mollieWooCommerceIsMollieGateway($gateway->id)) {
             return false;
@@ -308,6 +234,7 @@ class MollieOrderService
         if (!$payment_object_id) {
             $payment_object_id = $order->get_meta('_mollie_payment_id');
         }
+
         try {
             $payment_object = $this->paymentFactory->getPaymentObject(
                 $payment_object_id
@@ -326,37 +253,54 @@ class MollieOrderService
             return false;
         }
 
+        if ($order->get_id() != $payment->metadata->order_id) {
+            $this->httpResponse->setHttpResponseCode(400);
+            $this->logger->debug(
+                __METHOD__ . ": Order ID does not match order_id in payment metadata. Payment ID {$payment->id}, order ID {$order->get_id()}"
+            );
+            return false;
+        }
+
         $this->logger->debug($this->gateway->id . ": Mollie payment object {$payment->id} (" . $payment->mode . ") action call for order {$order->get_id()}.");
+
+        $method_name = 'onWebhook' . ucfirst($payment->status);
+        $payment_method_title = $this->getPaymentMethodTitle($payment);
+
+        if (!$this->orderNeedsPayment($order)) {
+            $this->handlePaidOrderWebhook($order, $payment);
+            $this->processRefunds($order, $payment);
+            $this->processChargebacks($order, $payment);
+            if (
+                $order->get_status() === 'processing'
+                && method_exists($payment, 'isCompleted')
+                && $payment->isCompleted()
+                && method_exists($payment_object, 'onWebhookCompleted')
+            ) {
+                $payment_object->onWebhookCompleted($order, $payment, $payment_method_title);
+            }
+            return true;
+        }
 
         if ($payment->method === 'paypal' && isset($payment->billingAddress) && $this->isOrderButtonPayment($order)) {
             $this->logger->debug($this->gateway->id . ": updating address from express button");
             $this->setBillingAddressAfterPayment($payment, $order);
         }
 
-        $method_name = 'onWebhook' . ucfirst($payment->status);
-        $payment_method_title = $this->getPaymentMethodTitle($payment);
         if (method_exists($payment_object, $method_name)) {
             do_action($this->pluginId . '_before_webhook_payment_action', $payment, $order);
             $payment_object->{$method_name}($order, $payment, $payment_method_title);
         } else {
             $order->add_order_note(sprintf(
-            /* translators: Placeholder 1: payment method title, placeholder 2: payment status, placeholder 3: payment ID */
-                __('%1$s payment %2$s (%3$s), not processed.', 'mollie-payments-for-woocommerce'),
-                $this->gateway->method_title,
-                $payment->status,
-                $payment->id . ($payment->mode === 'test' ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce')) : '')
-            ));
+               /* translators: Placeholder 1: payment method title, placeholder 2: payment status, placeholder 3: payment ID */
+                   __('%1$s payment %2$s (%3$s), not processed.', 'mollie-payments-for-woocommerce'),
+                   $this->gateway->method_title,
+                   $payment->status,
+                   $payment->id . ($payment->mode === 'test' ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce')) : '')
+               ));
             return false;
         }
 
         do_action($this->pluginId . '_after_webhook_action', $payment, $order);
-
-        if ($payment->status === 'canceled') {
-            $this->updateOrderStatus($order, SharedDataDictionary::STATUS_CANCELLED, __('Mollie Payment was canceled.', 'mollie-payments-for-woocommerce'));
-        }
-
-        $this->processRefunds($order, $payment);
-        $this->processChargebacks($order, $payment);
 
         return true;
     }

--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -292,11 +292,11 @@ class MollieOrderService
         } else {
             $order->add_order_note(sprintf(
                /* translators: Placeholder 1: payment method title, placeholder 2: payment status, placeholder 3: payment ID */
-                   __('%1$s payment %2$s (%3$s), not processed.', 'mollie-payments-for-woocommerce'),
-                   $this->gateway->method_title,
-                   $payment->status,
-                   $payment->id . ($payment->mode === 'test' ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce')) : '')
-               ));
+                __('%1$s payment %2$s (%3$s), not processed.', 'mollie-payments-for-woocommerce'),
+                $this->gateway->method_title,
+                $payment->status,
+                $payment->id . ($payment->mode === 'test' ? (' - ' . __('test mode', 'mollie-payments-for-woocommerce')) : '')
+            ));
             return false;
         }
 

--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -128,7 +128,7 @@ class MollieOrderService
         ) {
             $this->httpResponse->setHttpResponseCode(200);
             $this->logger->debug(
-                $this->gateway->id . ": not respond on transaction webhooks for this payment method when order API is active. Payment ID {$payment->id}, order ID $order_id"
+                $this->gateway->id . ": not respond on transaction webhooks for this payment method when order API is active. Payment ID {$payment_object_id}, order ID {$order->get_id()}"
             );
             return;
         }

--- a/src/Payment/PaymentModule.php
+++ b/src/Payment/PaymentModule.php
@@ -14,6 +14,7 @@ use Mollie\Api\Resources\Refund;
 use Mollie\WooCommerce\Gateway\MolliePaymentGatewayHandler;
 use Mollie\WooCommerce\Gateway\Refund\OrderItemsRefunder;
 use Mollie\WooCommerce\MerchantCapture\Capture\Action\CapturePayment;
+use Mollie\WooCommerce\Payment\Webhooks\RestApi;
 use Mollie\WooCommerce\PaymentMethods\InstructionStrategies\OrderInstructionsManager;
 use Mollie\WooCommerce\SDK\Api;
 use Mollie\WooCommerce\SDK\HttpResponse;
@@ -75,6 +76,11 @@ class PaymentModule implements ServiceModule, ExecutableModule
         $this->pluginId = $container->get('shared.plugin_id');
         $this->gatewayClassnames = $container->get('gateway.classnames');
         $this->container = $container;
+
+        //add webhook rest API endpoint
+        add_action('rest_api_init', function () use ($container) {
+            $container->get(RestApi::class)->registerRoutes();
+        });
 
         // Listen to return URL call
         add_action('woocommerce_api_mollie_return', function () use ($container) {

--- a/src/Payment/Request/Middleware/UrlMiddleware.php
+++ b/src/Payment/Request/Middleware/UrlMiddleware.php
@@ -101,7 +101,7 @@ class UrlMiddleware implements RequestMiddlewareInterface
     public function getWebhookUrl(WC_Order $order, string $gatewayId): string
     {
         $webhookUrl = get_rest_url(null, RestApi::ROUTE_NAMESPACE . '/' . RestApi::WEBHOOK_ROUTE);
-        if (! $webhookUrl ||  ! wc_is_valid_url($webhookUrl) || apply_filters('mollie_wc_gateway_disable_rest_webhook', true)) {
+        if (! $webhookUrl ||  ! wc_is_valid_url($webhookUrl) || apply_filters('mollie_wc_gateway_disable_rest_webhook', false)) {
             $webhookUrl = WC()->api_request_url($gatewayId);
             $webhookUrl = untrailingslashit($webhookUrl);
             $webhookUrl = $this->asciiDomainName($webhookUrl);

--- a/src/Payment/Request/Middleware/UrlMiddleware.php
+++ b/src/Payment/Request/Middleware/UrlMiddleware.php
@@ -100,8 +100,8 @@ class UrlMiddleware implements RequestMiddlewareInterface
      */
     public function getWebhookUrl(WC_Order $order, string $gatewayId): string
     {
-        $webhookUrl = get_rest_url(null, RestApi::ROUTE_NAMESPACE . '/' .RestApi::WEBHOOK_ROUTE);
-        if ( apply_filters( 'mollie_wc_gateway_disable_rest_webhook', false ) ) {
+        $webhookUrl = get_rest_url(null, RestApi::ROUTE_NAMESPACE . '/' . RestApi::WEBHOOK_ROUTE);
+        if (apply_filters('mollie_wc_gateway_disable_rest_webhook', false)) {
             $webhookUrl = WC()->api_request_url($gatewayId);
             $webhookUrl = untrailingslashit($webhookUrl);
             $webhookUrl = $this->asciiDomainName($webhookUrl);

--- a/src/Payment/Request/Middleware/UrlMiddleware.php
+++ b/src/Payment/Request/Middleware/UrlMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\Payment\Request\Middleware;
 
+use Mollie\WooCommerce\Payment\Webhooks\RestApi;
 use WC_Order;
 
 /**
@@ -99,17 +100,20 @@ class UrlMiddleware implements RequestMiddlewareInterface
      */
     public function getWebhookUrl(WC_Order $order, string $gatewayId): string
     {
-        $webhookUrl = WC()->api_request_url($gatewayId);
-        $webhookUrl = untrailingslashit($webhookUrl);
-        $webhookUrl = $this->asciiDomainName($webhookUrl);
-        $orderId = $order->get_id();
-        $orderKey = $order->get_order_key();
-        $webhookUrl = $this->appendOrderArgumentsToUrl(
-            $orderId,
-            $orderKey,
-            $webhookUrl
-        );
-        $webhookUrl = untrailingslashit($webhookUrl);
+        $webhookUrl = get_rest_url(null, RestApi::ROUTE_NAMESPACE . '/' .RestApi::WEBHOOK_ROUTE);
+        if ( apply_filters( 'mollie_wc_gateway_disable_rest_webhook', false ) ) {
+            $webhookUrl = WC()->api_request_url($gatewayId);
+            $webhookUrl = untrailingslashit($webhookUrl);
+            $webhookUrl = $this->asciiDomainName($webhookUrl);
+            $orderId = $order->get_id();
+            $orderKey = $order->get_order_key();
+            $webhookUrl = $this->appendOrderArgumentsToUrl(
+                $orderId,
+                $orderKey,
+                $webhookUrl
+            );
+            $webhookUrl = untrailingslashit($webhookUrl);
+        }
 
         $this->logger->debug(" Order {$orderId} webhookUrl: {$webhookUrl}", [true]);
 

--- a/src/Payment/Request/Middleware/UrlMiddleware.php
+++ b/src/Payment/Request/Middleware/UrlMiddleware.php
@@ -101,7 +101,7 @@ class UrlMiddleware implements RequestMiddlewareInterface
     public function getWebhookUrl(WC_Order $order, string $gatewayId): string
     {
         $webhookUrl = get_rest_url(null, RestApi::ROUTE_NAMESPACE . '/' . RestApi::WEBHOOK_ROUTE);
-        if (apply_filters('mollie_wc_gateway_disable_rest_webhook', false)) {
+        if (! $webhookUrl ||  ! wc_is_valid_url($webhookUrl) || apply_filters('mollie_wc_gateway_disable_rest_webhook', true)) {
             $webhookUrl = WC()->api_request_url($gatewayId);
             $webhookUrl = untrailingslashit($webhookUrl);
             $webhookUrl = $this->asciiDomainName($webhookUrl);

--- a/src/Payment/Webhooks/RestApi.php
+++ b/src/Payment/Webhooks/RestApi.php
@@ -76,8 +76,18 @@ class RestApi
         ]);
 
         if (! $orders) {
-            $this->logger->debug(__METHOD__ . ': No orders found for transaction ID: ' . $transactionID);
-            return new \WP_REST_Response(null, 200);
+            $this->logger->debug(__METHOD__ . ': No orders found for transaction ID: ' . $transactionID . ' fall back to search in meta data');
+            //Fallback search order in order mollie oder meta
+            $orders = wc_get_orders([
+                'limit' => 2,
+                'meta_key' => '_mollie_order_id',
+                'meta_compare' => '=',
+                'meta_value' => $transactionID,
+            ]);
+            if (! $orders) {
+                $this->logger->debug(__METHOD__ . ': No orders found in mollie meta for transaction ID: ' . $transactionID);
+                return new \WP_REST_Response(null, 200);
+            }
         }
 
         if (count($orders) > 1) {

--- a/src/Payment/Webhooks/RestApi.php
+++ b/src/Payment/Webhooks/RestApi.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Mollie\WooCommerce\Payment\Webhooks;
+
+use Mollie\WooCommerce\Payment\MollieOrderService;
+use Psr\Log\LoggerInterface;
+use WP_REST_Request;
+
+class RestApi
+{
+    public const ROUTE_NAMESPACE = 'mollie/v1';
+    public const WEBHOOK_ROUTE = 'webhook';
+    private MollieOrderService $mollieOrderService;
+    private LoggerInterface $logger;
+
+    /**
+     * Constructor method for initializing the class with necessary dependencies.
+     *
+     * @param MollieOrderService $mollieOrderService Service to handle orders through Mollie.
+     * @param LoggerInterface $logger Logger interface for logging purposes.
+     *
+     * @return void
+     */
+    public function __construct(MollieOrderService $mollieOrderService, LoggerInterface $logger)
+    {
+        $this->mollieOrderService = $mollieOrderService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Registers REST API routes for the application.
+     *
+     * This method defines and registers a specific REST route under the given namespace,
+     * along with its callback and permission settings.
+     *
+     * @return void
+     */
+    public function registerRoutes()
+    {
+        register_rest_route(self::ROUTE_NAMESPACE, self::WEBHOOK_ROUTE, [
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'callback'],
+                'permission_callback' => '__return_true',
+            ],
+        ]);
+    }
+
+    /**
+     * Handles the callback request from Mollie and processes the payment.
+     *
+     * @param WP_REST_Request $request The REST request object containing callback parameters.
+     *
+     * @return \WP_REST_Response A response object with the corresponding status code.
+     * - 200: When the request is successfully handled, whether for testing, no results, or successful processing.
+     * - 404: When the "id" parameter is not provided in the request.
+     */
+    public function callback(WP_REST_Request $request)
+    {
+        //Answer Mollie Test request.
+        if ($request->get_param('testByMollie') === '') {
+            $this->logger->debug(__METHOD__ . ': REST Webhook tested by Mollie.');
+            return new \WP_REST_Response(null, 200);
+        }
+
+        //check that id in post is set with transaction_id
+        $transactionID = $request->get_param('id');
+        if (! $transactionID) {
+            $this->logger->debug(__METHOD__ . ': No transaction ID provided.');
+            return new \WP_REST_Response(null, 404);
+        }
+
+        $orders = wc_get_orders([
+            'transaction_id' => $transactionID,
+            'limit' => 2,
+        ]);
+
+        if (! $orders) {
+            $this->logger->debug(__METHOD__ . ': No orders found for transaction ID: ' . $transactionID);
+            return new \WP_REST_Response(null, 200);
+        }
+
+        if (count($orders) > 1) {
+            $this->logger->debug(__METHOD__ . ': More than one order found for transaction ID: ' . $transactionID);
+            return new \WP_REST_Response(null, 200);
+        }
+
+        $this->mollieOrderService->doPaymentForOrder($orders[0]);
+
+        return new \WP_REST_Response(null, 200);
+    }
+}

--- a/src/Payment/inc/services.php
+++ b/src/Payment/inc/services.php
@@ -191,5 +191,11 @@ return static function (): array {
                 $middlewareHandler
             );
         },
+        \Mollie\WooCommerce\Payment\Webhooks\RestApi::class => static function (ContainerInterface $container): \Mollie\WooCommerce\Payment\Webhooks\RestApi {
+            return new \Mollie\WooCommerce\Payment\Webhooks\RestApi(
+                $container->get(\Mollie\WooCommerce\Payment\MollieOrderService::class),
+                $container->get(Logger::class)
+            );
+        },
     ];
 };

--- a/tests/Integration/Common/Factories/OrderFactory.php
+++ b/tests/Integration/Common/Factories/OrderFactory.php
@@ -30,6 +30,7 @@ class OrderFactory
      * @param array $product_presets
      * @param array $discount_presets
      * @param bool $set_paid
+     * @param string $transaction_id
      * @return WC_Order
      * @throws \WC_Data_Exception
      */
@@ -38,7 +39,8 @@ class OrderFactory
         string $payment_method,
         array  $product_presets,
         array  $discount_presets = [],
-        bool   $set_paid = true
+        bool   $set_paid = true,
+        string $transaction_id = ''
     ): WC_Order
     {
         $products = $this->resolveProductPresets($product_presets);
@@ -58,6 +60,11 @@ class OrderFactory
         $this->applyDiscountsToOrder($order, $discounts);
 
         $order->set_payment_method($payment_method);
+        if (!$transaction_id) {
+            $order->set_transaction_id(uniqid('tr_'));
+        } else {
+            $order->set_transaction_id($transaction_id);
+        }
         $order->calculate_totals();
         $order->save();
 

--- a/tests/Integration/Common/Traits/CreateTestOrders.php
+++ b/tests/Integration/Common/Traits/CreateTestOrders.php
@@ -32,7 +32,8 @@ trait CreateTestOrders
         string $payment_method,
         array  $product_presets,
         array  $discount_presets = [],
-        bool   $set_paid = true
+        bool   $set_paid = true,
+        string $transaction_id = ''
     ): WC_Order
     {
         if (!isset($this->order_factory)) {
@@ -44,7 +45,8 @@ trait CreateTestOrders
             $payment_method,
             $product_presets,
             $discount_presets,
-            $set_paid
+            $set_paid,
+            $transaction_id
         );
     }
 }

--- a/tests/Integration/phpunit.xml.dist
+++ b/tests/Integration/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="bootstrap.php"
+         colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="integration">
+            <directory>spec</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
- Added rest endpoint for getting webhooks
- keep old endpoint for fallback and existing payments
- Rest endpoint will search for order by transaction id and handle it
- add filter for switch back to old behavior

That should fix:
- problems with webhooks from payments and orders at same time, because only that wit the right transaction ID will be handled
- Rest should be faster
- easier url 

In future can the Woo API endpoint also search directly by transaction ID and not using the order Key.
Maybe remove check of payment meta that order ID is the same