### PR TITLE
For manually captured orders status dispalyed as ON HOLD

### DIFF
--- a/src/MerchantCapture/Capture/Type/ManualCapture.php
+++ b/src/MerchantCapture/Capture/Type/ManualCapture.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mollie\WooCommerce\MerchantCapture\Capture\Type;
 
 use Mollie\WooCommerce\MerchantCapture\Capture\Action\CapturePayment;
+use Mollie\WooCommerce\Payment\MollieOrderService;
 use Psr\Container\ContainerInterface;
 
 class ManualCapture
@@ -50,5 +51,7 @@ class ManualCapture
     {
 
         ($this->container->get(CapturePayment::class))($order->get_id());
+        //give paid webhook time to arrive so that updated correctly bevor showing the order in the backend
+        sleep(3);
     }
 }


### PR DESCRIPTION
Add delay in Manual Capture to ensure paid webhook updates before backend display