### PR TITLE
6 - Refactor payment field components configuration and remove jQuery dependency (PIWOO-764)

### DIFF
--- a/resources/js/src/checkout/blocks/components/PaymentComponentFactory.js
+++ b/resources/js/src/checkout/blocks/components/PaymentComponentFactory.js
@@ -27,7 +27,7 @@ export const createPaymentComponent = ( item, commonProps ) => {
 				<BillieFieldsWithStore
 					{ ...commonProps }
 					fieldConfig={ {
-						showCompany: true,
+						hasCustomCompanyField: true,
 						companyRequired: true,
 						companyLabel: item.companyPlaceholder || 'Company name',
 					} }
@@ -42,10 +42,8 @@ export const createPaymentComponent = ( item, commonProps ) => {
 				<In3FieldsWithStore
 					{ ...commonProps }
 					fieldConfig={ {
-						showPhone: true,
-						showBirthdate: true,
-						phoneRequired: true,
-						birthdateRequired: true,
+						hasCustomPhoneField: true,
+						hasCustomBirthdateField: true,
 						phoneLabel: item.phoneLabel || 'Phone',
 						birthdateLabel:
 							item.birthdatePlaceholder || 'Birthdate',
@@ -61,10 +59,8 @@ export const createPaymentComponent = ( item, commonProps ) => {
 				<RivertyFieldsWithStore
 					{ ...commonProps }
 					fieldConfig={ {
-						showPhone: true,
-						showBirthdate: true,
-						phoneRequired: true,
-						birthdateRequired: true,
+						hasCustomPhoneField: true,
+						hasCustomBirthdateField: true,
 						phoneLabel: item.phoneLabel || 'Phone',
 						birthdateLabel:
 							item.birthdatePlaceholder || 'Birthdate',

--- a/resources/js/src/checkout/blocks/components/PaymentMethodContentRenderer.js
+++ b/resources/js/src/checkout/blocks/components/PaymentMethodContentRenderer.js
@@ -11,7 +11,6 @@ export const PaymentMethodContentRenderer = ( props ) => {
 		activePaymentMethod,
 		billing,
 		item,
-		jQuery,
 		emitResponse,
 		eventRegistration,
 		requiredFields,
@@ -161,7 +160,6 @@ export const PaymentMethodContentRenderer = ( props ) => {
 
 	const commonProps = {
 		item,
-		jQuery,
 		useEffect,
 		billing,
 		shippingData,

--- a/resources/js/src/checkout/blocks/components/PaymentMethodContentRenderer.js
+++ b/resources/js/src/checkout/blocks/components/PaymentMethodContentRenderer.js
@@ -16,7 +16,7 @@ export const PaymentMethodContentRenderer = ( props ) => {
 		eventRegistration,
 		requiredFields,
 		shippingData,
-		isPhoneFieldVisible,
+		shouldHidePhoneField,
 	} = props;
 
 	const { responseTypes } = emitResponse;
@@ -167,7 +167,7 @@ export const PaymentMethodContentRenderer = ( props ) => {
 		shippingData,
 		eventRegistration,
 		requiredFields,
-		isPhoneFieldVisible,
+		shouldHidePhoneField,
 		activePaymentMethod,
 		containerRef,
 		mollieComponentsManager,

--- a/resources/js/src/checkout/blocks/components/molliePaymentMethod.js
+++ b/resources/js/src/checkout/blocks/components/molliePaymentMethod.js
@@ -5,7 +5,7 @@ const molliePaymentMethod = (
 	item,
 	jQuery,
 	requiredFields,
-	isPhoneFieldVisible
+	shouldHidePhoneField
 ) => {
 	return {
 		name: item.name,
@@ -15,7 +15,7 @@ const molliePaymentMethod = (
 				item={ item }
 				jQuery={ jQuery }
 				requiredFields={ requiredFields }
-				isPhoneFieldVisible={ isPhoneFieldVisible }
+				shouldHidePhoneField={ shouldHidePhoneField }
 			/>
 		),
 		edit: <div>{ item.edit }</div>,

--- a/resources/js/src/checkout/blocks/components/molliePaymentMethod.js
+++ b/resources/js/src/checkout/blocks/components/molliePaymentMethod.js
@@ -3,7 +3,6 @@ import { Label } from './Label';
 
 const molliePaymentMethod = (
 	item,
-	jQuery,
 	requiredFields,
 	shouldHidePhoneField
 ) => {
@@ -13,7 +12,6 @@ const molliePaymentMethod = (
 		content: (
 			<PaymentMethodContentRenderer
 				item={ item }
-				jQuery={ jQuery }
 				requiredFields={ requiredFields }
 				shouldHidePhoneField={ shouldHidePhoneField }
 			/>

--- a/resources/js/src/checkout/blocks/components/paymentFields/PhoneField.js
+++ b/resources/js/src/checkout/blocks/components/paymentFields/PhoneField.js
@@ -1,9 +1,9 @@
 export const PhoneField = ( { id, label, value, onChange, placeholder } ) => {
 	const handleChange = ( e ) => onChange( e.target.value );
-	const className = `wc-block-components-text-input wc-block-components-address-form__${ id }`;
+	const className = `wc-block-components-address-form__${ id }`;
 
 	return (
-		<div className="custom-input">
+		<div className="custom-input wc-block-components-text-input wc-block-components-address-form__phone is-active">
 			<label htmlFor={ id }>{ label }</label>
 			<input
 				type="tel"

--- a/resources/js/src/checkout/blocks/components/paymentMethods/PaymentFieldsComponent.js
+++ b/resources/js/src/checkout/blocks/components/paymentMethods/PaymentFieldsComponent.js
@@ -13,7 +13,7 @@ import { CompanyField } from '../paymentFields/CompanyField';
  * @param {Object}   props.shippingData                    - Shipping data object
  * @param {Object}   props.eventRegistration               - Event registration object
  * @param {Object}   props.requiredFields                  - Required field labels/strings
- * @param {boolean}  props.isPhoneFieldVisible             - Whether phone field is visible elsewhere
+ * @param {boolean}  props.shouldHidePhoneField             - Whether phone field is visible elsewhere
  * @param {string}   props.inputPhone                      - Current phone input value
  * @param {string}   props.inputBirthdate                  - Current birthdate input value
  * @param {string}   props.inputCompany                    - Current company input value
@@ -32,7 +32,7 @@ const PaymentFieldsComponent = ( {
 	shippingData,
 	eventRegistration,
 	requiredFields,
-	isPhoneFieldVisible,
+	shouldHidePhoneField,
 	inputPhone,
 	inputBirthdate,
 	inputCompany,
@@ -46,13 +46,12 @@ const PaymentFieldsComponent = ( {
 	const { onCheckoutValidation } = eventRegistration;
 	const { companyNameString, phoneString } = requiredFields;
 
+    console.log(fieldConfig);
 	const {
-		showCompany = false,
-		showPhone = false,
-		showBirthdate = false,
+		hasCustomCompanyField = false,
+		hasCustomPhoneField = false,
+		hasCustomBirthdateField = false,
 		companyRequired = false,
-		phoneRequired = false,
-		birthdateRequired = false,
 		companyLabel = 'Company name',
 		phoneLabel = 'Phone',
 		birthdateLabel = 'Birthdate',
@@ -66,7 +65,7 @@ const PaymentFieldsComponent = ( {
 
 	// Company field label update
 	useEffect( () => {
-		if ( ! showCompany ) {
+		if ( ! hasCustomCompanyField ) {
 			return;
 		}
 
@@ -86,7 +85,7 @@ const PaymentFieldsComponent = ( {
 			`<label htmlFor="shipping-company">${ labelText }</label>`
 		);
 	}, [
-		showCompany,
+		hasCustomCompanyField,
 		item.companyPlaceholder,
 		item.hideCompanyField,
 		companyNameString,
@@ -95,7 +94,7 @@ const PaymentFieldsComponent = ( {
 
 	// Phone field label update
 	useEffect( () => {
-		if ( ! showPhone ) {
+		if ( ! hasCustomPhoneField ) {
 			return;
 		}
 
@@ -106,12 +105,11 @@ const PaymentFieldsComponent = ( {
 
 		const labelText = item.phonePlaceholder || phoneString || 'Phone';
 		phoneLabelElement.innerText = labelText;
-	}, [ showPhone, item.phonePlaceholder, phoneString ] );
+	}, [ hasCustomPhoneField, item.phonePlaceholder, phoneString ] );
 
 	// Validation effect
 	useEffect( () => {
 		const unsubscribeProcessing = onCheckoutValidation( () => {
-			// Company validation
 			if ( companyRequired ) {
 				const isCompanyEmpty =
 					billing.billingData.company === '' &&
@@ -125,39 +123,6 @@ const PaymentFieldsComponent = ( {
 					};
 				}
 			}
-
-			// Phone validation
-			if ( phoneRequired ) {
-				const isPhoneEmpty =
-					billing.billingData.phone === '' &&
-					shippingData.shippingAddress.phone === '' &&
-					inputPhone === '';
-
-				if ( isPhoneEmpty ) {
-					return {
-						errorMessage:
-							item.errorMessage || 'Phone field is required',
-					};
-				}
-			}
-
-			// Birthdate validation
-			if ( birthdateRequired ) {
-				if ( inputBirthdate === '' ) {
-					return {
-						errorMessage:
-							item.errorMessage || 'Birthdate field is required',
-					};
-				}
-
-				const today = new Date();
-				const birthdate = new Date( inputBirthdate );
-				if ( birthdate > today ) {
-					return {
-						errorMessage: item.errorMessage || 'Invalid birthdate',
-					};
-				}
-			}
 		} );
 
 		return () => {
@@ -166,19 +131,15 @@ const PaymentFieldsComponent = ( {
 	}, [
 		onCheckoutValidation,
 		companyRequired,
-		phoneRequired,
-		birthdateRequired,
 		billing.billingData,
 		shippingData.shippingAddress,
-		inputPhone,
 		inputCompany,
-		inputBirthdate,
 		item.errorMessage,
 	] );
 
 	// Country-based phone placeholder update
 	useEffect( () => {
-		if ( ! showPhone ) {
+		if ( ! hasCustomPhoneField ) {
 			return;
 		}
 
@@ -189,14 +150,17 @@ const PaymentFieldsComponent = ( {
 	}, [
 		billing.billingData.country,
 		updatePhonePlaceholderByCountry,
-		showPhone,
+		hasCustomPhoneField,
 	] );
+
+    console.log( 'show phone 2', hasCustomPhoneField );
+    console.log(shouldHidePhoneField)
 
 	return (
 		<>
 			<div>{ item.content && <p>{ item.content }</p> }</div>
 
-			{ showCompany && (
+			{ hasCustomCompanyField && (
 				<CompanyField
 					label={ item.companyPlaceholder || companyLabel }
 					value={ inputCompany }
@@ -204,7 +168,7 @@ const PaymentFieldsComponent = ( {
 				/>
 			) }
 
-			{ showBirthdate && (
+			{ hasCustomBirthdateField && (
 				<BirthdateField
 					label={ item.birthdatePlaceholder || birthdateLabel }
 					value={ inputBirthdate }
@@ -212,7 +176,7 @@ const PaymentFieldsComponent = ( {
 				/>
 			) }
 
-			{ showPhone && ! isPhoneFieldVisible && (
+			{ hasCustomPhoneField && ! shouldHidePhoneField && (
 				<PhoneField
 					id={ `billing-phone-${ item.name }` }
 					label={ item.phoneLabel || phoneLabel }

--- a/resources/js/src/checkout/blocks/components/paymentMethods/PaymentFieldsComponent.js
+++ b/resources/js/src/checkout/blocks/components/paymentMethods/PaymentFieldsComponent.js
@@ -7,13 +7,11 @@ import { CompanyField } from '../paymentFields/CompanyField';
  * Handles field rendering and validation for different payment methods
  * @param {Object}   props                                 - The component props
  * @param {Object}   props.item                            - Payment method item configuration
- * @param {Function} props.jQuery                          - jQuery library function
  * @param {Function} props.useEffect                       - React useEffect hook
  * @param {Object}   props.billing                         - Billing data object
  * @param {Object}   props.shippingData                    - Shipping data object
  * @param {Object}   props.eventRegistration               - Event registration object
  * @param {Object}   props.requiredFields                  - Required field labels/strings
- * @param {boolean}  props.shouldHidePhoneField             - Whether phone field is visible elsewhere
  * @param {string}   props.inputPhone                      - Current phone input value
  * @param {string}   props.inputBirthdate                  - Current birthdate input value
  * @param {string}   props.inputCompany                    - Current company input value
@@ -26,13 +24,11 @@ import { CompanyField } from '../paymentFields/CompanyField';
  */
 const PaymentFieldsComponent = ( {
 	item,
-	jQuery,
 	useEffect,
 	billing,
 	shippingData,
 	eventRegistration,
 	requiredFields,
-	shouldHidePhoneField,
 	inputPhone,
 	inputBirthdate,
 	inputCompany,
@@ -62,6 +58,12 @@ const PaymentFieldsComponent = ( {
 		const billingPhone = document.getElementById( 'billing-phone' );
 		return billingPhone || shippingPhone;
 	}
+    const getShouldHidePhoneField = () => {
+        const phone = getPhoneField();
+        // hide phone field if it is required
+        return phone? (phone.hasAttribute('required') || phone.getAttribute('aria-required') === 'true') : false;
+    };
+    const shouldHidePhoneField = getShouldHidePhoneField();
 
 	// Company field label update
 	useEffect( () => {
@@ -69,11 +71,11 @@ const PaymentFieldsComponent = ( {
 			return;
 		}
 
-		const companyLabelElement = jQuery(
-			'div.wc-block-components-text-input.wc-block-components-address-form__company > label'
-		);
+		const companyLabelElement = document.querySelector(
+            'div.wc-block-components-text-input.wc-block-components-address-form__company > label'
+        );
 		if (
-			companyLabelElement.length === 0 ||
+			!companyLabelElement ||
 			item.hideCompanyField === true
 		) {
 			return;
@@ -81,15 +83,12 @@ const PaymentFieldsComponent = ( {
 
 		const labelText =
 			item.companyPlaceholder || companyNameString || 'Company name';
-		companyLabelElement.replaceWith(
-			`<label htmlFor="shipping-company">${ labelText }</label>`
-		);
+		companyLabelElement.innerText = labelText;
 	}, [
 		hasCustomCompanyField,
 		item.companyPlaceholder,
 		item.hideCompanyField,
-		companyNameString,
-		jQuery,
+		companyNameString
 	] );
 
 	// Phone field label update
@@ -152,9 +151,6 @@ const PaymentFieldsComponent = ( {
 		updatePhonePlaceholderByCountry,
 		hasCustomPhoneField,
 	] );
-
-    console.log( 'show phone 2', hasCustomPhoneField );
-    console.log(shouldHidePhoneField)
 
 	return (
 		<>

--- a/resources/js/src/checkout/blocks/components/paymentMethods/PaymentFieldsComponent.js
+++ b/resources/js/src/checkout/blocks/components/paymentMethods/PaymentFieldsComponent.js
@@ -42,7 +42,6 @@ const PaymentFieldsComponent = ( {
 	const { onCheckoutValidation } = eventRegistration;
 	const { companyNameString, phoneString } = requiredFields;
 
-    console.log(fieldConfig);
 	const {
 		hasCustomCompanyField = false,
 		hasCustomPhoneField = false,
@@ -58,12 +57,15 @@ const PaymentFieldsComponent = ( {
 		const billingPhone = document.getElementById( 'billing-phone' );
 		return billingPhone || shippingPhone;
 	}
-    const getShouldHidePhoneField = () => {
-        const phone = getPhoneField();
-        // hide phone field if it is required
-        return phone? (phone.hasAttribute('required') || phone.getAttribute('aria-required') === 'true') : false;
-    };
-    const shouldHidePhoneField = getShouldHidePhoneField();
+	const getShouldHidePhoneField = () => {
+		const phone = getPhoneField();
+		// hide phone field if it is required
+		return phone
+			? phone.hasAttribute( 'required' ) ||
+					phone.getAttribute( 'aria-required' ) === 'true'
+			: false;
+	};
+	const shouldHidePhoneField = getShouldHidePhoneField();
 
 	// Company field label update
 	useEffect( () => {
@@ -72,12 +74,9 @@ const PaymentFieldsComponent = ( {
 		}
 
 		const companyLabelElement = document.querySelector(
-            'div.wc-block-components-text-input.wc-block-components-address-form__company > label'
-        );
-		if (
-			!companyLabelElement ||
-			item.hideCompanyField === true
-		) {
+			'div.wc-block-components-text-input.wc-block-components-address-form__company > label'
+		);
+		if ( ! companyLabelElement || item.hideCompanyField === true ) {
 			return;
 		}
 
@@ -88,7 +87,7 @@ const PaymentFieldsComponent = ( {
 		hasCustomCompanyField,
 		item.companyPlaceholder,
 		item.hideCompanyField,
-		companyNameString
+		companyNameString,
 	] );
 
 	// Phone field label update

--- a/resources/js/src/checkout/blocks/registration/contextBuilder.js
+++ b/resources/js/src/checkout/blocks/registration/contextBuilder.js
@@ -1,4 +1,3 @@
-import { shouldHidePhoneField } from '../../../shared/utils/paymentUtils';
 
 /**
  * Build context for payment method registration
@@ -10,11 +9,9 @@ export const buildRegistrationContext = ( wc, jQuery ) => {
 
 	return {
 		wc,
-		jQuery,
 		requiredFields: {
 			companyNameString: defaultFields.company.label,
 			phoneString: defaultFields.phone.label,
 		},
-		shouldHidePhoneField: shouldHidePhoneField(),
 	};
 };

--- a/resources/js/src/checkout/blocks/registration/contextBuilder.js
+++ b/resources/js/src/checkout/blocks/registration/contextBuilder.js
@@ -1,4 +1,4 @@
-import { getPhoneFieldVisibility } from '../../../shared/utils/paymentUtils';
+import { shouldHidePhoneField } from '../../../shared/utils/paymentUtils';
 
 /**
  * Build context for payment method registration
@@ -15,6 +15,6 @@ export const buildRegistrationContext = ( wc, jQuery ) => {
 			companyNameString: defaultFields.company.label,
 			phoneString: defaultFields.phone.label,
 		},
-		isPhoneFieldVisible: getPhoneFieldVisibility(),
+		shouldHidePhoneField: shouldHidePhoneField(),
 	};
 };

--- a/resources/js/src/checkout/blocks/registration/paymentRegistrar.js
+++ b/resources/js/src/checkout/blocks/registration/paymentRegistrar.js
@@ -23,7 +23,7 @@ import { paymentStrategies } from './paymentStrategies';
  * @property {Function}      wc.wcBlocksRegistry.registerExpressPaymentMethod - Function to register express payment methods
  * @property {Object}        jQuery                                           - jQuery object
  * @property {Array<string>} requiredFields                                   - Array of required field names
- * @property {boolean}       isPhoneFieldVisible                              - Whether the phone field should be visible
+ * @property {boolean}       shouldHidePhoneField                              - Whether the phone field should be visible
  */
 
 /**

--- a/resources/js/src/checkout/blocks/registration/paymentStrategies.js
+++ b/resources/js/src/checkout/blocks/registration/paymentStrategies.js
@@ -23,7 +23,7 @@ import { ApplePayUtils } from '../../../shared/utils/applePayUtils';
  * @property {Function}      wc.wcBlocksRegistry.registerExpressPaymentMethod - Function to register express payment methods
  * @property {Object}        jQuery                                           - jQuery object
  * @property {Array<string>} requiredFields                                   - Array of required field names
- * @property {boolean}       isPhoneFieldVisible                              - Whether the phone field should be visible
+ * @property {boolean}       shouldHidePhoneField                              - Whether the phone field should be visible
  */
 
 /**
@@ -68,7 +68,7 @@ export const paymentStrategies = {
 	 *     wc: { wcBlocksRegistry: { registerPaymentMethod } },
 	 *     jQuery: $,
 	 *     requiredFields: ['email'],
-	 *     isPhoneFieldVisible: true
+	 *     shouldHidePhoneField: true
 	 * };
 	 * paymentStrategies.regular(item, context);
 	 */
@@ -79,7 +79,7 @@ export const paymentStrategies = {
 				item,
 				context.jQuery,
 				context.requiredFields,
-				context.isPhoneFieldVisible
+				context.shouldHidePhoneField
 			)
 		);
 	},
@@ -101,7 +101,7 @@ export const paymentStrategies = {
 	 *     wc: { wcBlocksRegistry: { registerExpressPaymentMethod } },
 	 *     jQuery: $,
 	 *     requiredFields: ['email'],
-	 *     isPhoneFieldVisible: true
+	 *     shouldHidePhoneField: true
 	 * };
 	 * paymentStrategies.express(applePayItem, context);
 	 */

--- a/resources/js/src/checkout/blocks/registration/paymentStrategies.js
+++ b/resources/js/src/checkout/blocks/registration/paymentStrategies.js
@@ -66,7 +66,6 @@ export const paymentStrategies = {
 	 * };
 	 * const context = {
 	 *     wc: { wcBlocksRegistry: { registerPaymentMethod } },
-	 *     jQuery: $,
 	 *     requiredFields: ['email'],
 	 *     shouldHidePhoneField: true
 	 * };
@@ -77,7 +76,6 @@ export const paymentStrategies = {
 		return registerPaymentMethod(
 			molliePaymentMethod(
 				item,
-				context.jQuery,
 				context.requiredFields,
 				context.shouldHidePhoneField
 			)
@@ -99,7 +97,6 @@ export const paymentStrategies = {
 	 * };
 	 * const context = {
 	 *     wc: { wcBlocksRegistry: { registerExpressPaymentMethod } },
-	 *     jQuery: $,
 	 *     requiredFields: ['email'],
 	 *     shouldHidePhoneField: true
 	 * };

--- a/resources/js/src/checkout/blocks/store/reducer.js
+++ b/resources/js/src/checkout/blocks/store/reducer.js
@@ -16,7 +16,7 @@ const initialState = {
 		companyNameString: '',
 		phoneString: '',
 	},
-	isPhoneFieldVisible: true,
+	shouldHidePhoneField: true,
 	billingData: {},
 	shippingData: {},
 
@@ -74,7 +74,7 @@ const reducer = ( state = initialState, action ) => {
 			};
 
 		case ACTIONS.SET_PHONE_FIELD_VISIBLE:
-			return { ...state, isPhoneFieldVisible: action.payload };
+			return { ...state, shouldHidePhoneField: action.payload };
 
 		case ACTIONS.SET_BILLING_DATA:
 			return { ...state, billingData: action.payload };

--- a/resources/js/src/checkout/blocks/store/selectors.js
+++ b/resources/js/src/checkout/blocks/store/selectors.js
@@ -11,7 +11,7 @@ const selectors = {
 
 	// Configuration selectors
 	getRequiredFields: ( state ) => state.requiredFields,
-	getIsPhoneFieldVisible: ( state ) => state.isPhoneFieldVisible,
+	getshouldHidePhoneField: ( state ) => state.shouldHidePhoneField,
 	getBillingData: ( state ) => state.billingData,
 	getShippingData: ( state ) => state.shippingData,
 

--- a/resources/js/src/shared/utils/paymentUtils.js
+++ b/resources/js/src/shared/utils/paymentUtils.js
@@ -63,16 +63,3 @@ export const validatePaymentItem = ( item ) => {
 	}
 	return true;
 };
-
-/**
- * Determines the visibility of the phone field based on DOM data attributes
- * Checks for a data attribute that controls phone field display
- * @return {boolean} True if phone field should be hidden, false if it should be shown
- */
-export const shouldHidePhoneField = () => {
-	const shippingPhone = document.getElementById('shipping-phone');
-	const billingPhone = document.getElementById('billing-phone');
-	const phone = shippingPhone || billingPhone;
-	// hide phone field if it is required
-	return phone? (phone.hasAttribute('required') || phone.getAttribute('aria-required') === 'true') : false;
-};

--- a/resources/js/src/shared/utils/paymentUtils.js
+++ b/resources/js/src/shared/utils/paymentUtils.js
@@ -67,19 +67,12 @@ export const validatePaymentItem = ( item ) => {
 /**
  * Determines the visibility of the phone field based on DOM data attributes
  * Checks for a data attribute that controls phone field display
- * @return {boolean} True if phone field should be visible, false if it should be hidden
- * @example
- * const shouldShowPhone = getPhoneFieldVisibility();
- * if (shouldShowPhone) {
- *     // Display phone field in checkout form
- * }
+ * @return {boolean} True if phone field should be hidden, false if it should be shown
  */
-export const getPhoneFieldVisibility = () => {
-	const phoneFieldDataset = document.querySelector(
-		'[data-show-phone-field]'
-	);
-	return (
-		! phoneFieldDataset ||
-		phoneFieldDataset.dataset.showPhoneField !== 'false'
-	);
+export const shouldHidePhoneField = () => {
+	const shippingPhone = document.getElementById('shipping-phone');
+	const billingPhone = document.getElementById('billing-phone');
+	const phone = shippingPhone || billingPhone;
+	// hide phone field if it is required
+	return phone? (phone.hasAttribute('required') || phone.getAttribute('aria-required') === 'true') : false;
 };


### PR DESCRIPTION
• **Field configuration property rename:**
  - `showCompany` → `hasCustomCompanyField`
  - `showPhone` → `hasCustomPhoneField`
  - `showBirthdate` → `hasCustomBirthdateField`
  - `isPhoneFieldVisible` → `shouldHidePhoneField`

• **jQuery dependency removal:**
  - Remove jQuery parameter from component signatures
  - Replace jQuery DOM manipulation with vanilla JavaScript
  - Update `companyLabelElement` selection to use `document.querySelector`

• **Validation logic simplification:**
  - Remove phone field validation from `PaymentFieldsComponent`
  - Remove birthdate validation logic
  - Retain only company field validation

• **Phone field visibility logic update:**
  - Invert logic from `isPhoneFieldVisible` to `shouldHidePhoneField`
  - Implement `getShouldHidePhoneField()` method checking `required` attribute or `aria-required="true"`
  - Remove `getPhoneFieldVisibility` utility function

• **CSS class updates:**
  - Add `wc-block-components-text-input wc-block-components-address-form__phone is-active` classes to PhoneField
  - Update className assignment in PhoneField component

• **State management updates:**
  - Update reducer to handle `shouldHidePhoneField` instead of `isPhoneFieldVisible`
  - Update selectors: `getIsPhoneFieldVisible` → `getshouldHidePhoneField`
  - Remove `requiredFields` validation dependencies for phone and birthdate

• **Component parameter cleanup:**
  - Remove unused parameters from function signatures across components
  - Update JSDoc comments to reflect parameter changes
  
  This PR is based on [PIWOO-764-refactor-logic-in-classic](https://github.com/mollie/WooCommerce/pull/1088)
  There might be some logs that will be removed in the last round