### PR TITLE
Return empty if posted phone is invalid also in shipping address

### DIFF
--- a/src/Payment/Request/Middleware/AddressMiddleware.php
+++ b/src/Payment/Request/Middleware/AddressMiddleware.php
@@ -202,7 +202,7 @@ class AddressMiddleware implements RequestMiddlewareInterface
                 $order->get_shipping_country(),
                 self::MAXIMAL_LENGTH_REGION
             );
-        $shippingPhone = $this->isPhoneValid($order->get_shipping_phone())? $order->get_shipping_phone() : '';
+        $shippingPhone = $this->isPhoneValid($order->get_shipping_phone()) ? $order->get_shipping_phone() : '';
         $shippingAddress->phone = (ctype_space($order->get_shipping_phone()))
             ? null
             : $this->getFormatedPhoneNumber($shippingPhone, $shippingAddress->country);
@@ -220,7 +220,7 @@ class AddressMiddleware implements RequestMiddlewareInterface
         $phoneSources = [
             $order->get_billing_phone(),
             $order->get_shipping_phone(),
-            $this->getPostedPhoneNumber($order)
+            $this->getPostedPhoneNumber($order),
         ];
 
         foreach ($phoneSources as $phone) {

--- a/src/Payment/Request/Middleware/AddressMiddleware.php
+++ b/src/Payment/Request/Middleware/AddressMiddleware.php
@@ -202,9 +202,10 @@ class AddressMiddleware implements RequestMiddlewareInterface
                 $order->get_shipping_country(),
                 self::MAXIMAL_LENGTH_REGION
             );
+        $shippingPhone = $this->isPhoneValid($order->get_shipping_phone())? $order->get_shipping_phone() : '';
         $shippingAddress->phone = (ctype_space($order->get_shipping_phone()))
             ? null
-            : $this->getFormatedPhoneNumber($order->get_shipping_phone(), $shippingAddress->country);
+            : $this->getFormatedPhoneNumber($shippingPhone, $shippingAddress->country);
         return $shippingAddress;
     }
 
@@ -214,15 +215,34 @@ class AddressMiddleware implements RequestMiddlewareInterface
      * @param WC_Order $order The WooCommerce order object.
      * @return string|null The phone number.
      */
-    protected function getPhoneNumber($order): ?string
+    protected function getPhoneNumber($order): string
+    {
+        $phoneSources = [
+            $order->get_billing_phone(),
+            $order->get_shipping_phone(),
+            $this->getPostedPhoneNumber($order)
+        ];
+
+        foreach ($phoneSources as $phone) {
+            if (!empty($phone) && $this->isPhoneValid($phone)) {
+                return $phone;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the phone number from POST data.
+     *
+     * @param WC_Order $order The WooCommerce order object.
+     * @return string The posted phone number.
+     */
+    private function getPostedPhoneNumber(WC_Order $order): string
     {
         $postedField = $this->getPhonePostedFieldName($order);
-        $phone = !empty($order->get_billing_phone()) ? $order->get_billing_phone() : $order->get_shipping_phone();
-        if (empty($phone) || !$this->isPhoneValid($phone)) {
-            //phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-            $phone = wc_clean(wp_unslash($_POST[$postedField] ?? ''));
-        }
-        return $phone;
+        //phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        return wc_clean(wp_unslash($_POST[$postedField] ?? ''));
     }
 
     /**

--- a/src/Payment/Request/Middleware/AddressMiddleware.php
+++ b/src/Payment/Request/Middleware/AddressMiddleware.php
@@ -213,7 +213,7 @@ class AddressMiddleware implements RequestMiddlewareInterface
      * Get the phone number from the order or the posted field.
      *
      * @param WC_Order $order The WooCommerce order object.
-     * @return string|null The phone number.
+     * @return string The phone number.
      */
     protected function getPhoneNumber($order): string
     {


### PR DESCRIPTION
Whenever the phone is optional but we pass something in post or shipping address we have to check again, the API will fail if any number is not valid so we must send empty.