### PR TITLE
Fix pay order page payment with components

### DIFF
--- a/resources/js/src/checkout/blocks/mollieBlockIndex.js
+++ b/resources/js/src/checkout/blocks/mollieBlockIndex.js
@@ -22,7 +22,11 @@ import {initializeMollieComponentsWithStoreSubscription} from "./services/Mollie
         console.warn( 'Mollie: No block data available' );
         return;
     }
-
+    //if we are in order pay page there are no blocks, so we bail
+    const isOrderPayPage = mollieBlockData.gatewayData.isOrderPayPage;
+    if ( isOrderPayPage ) {
+        return;
+    }
     try {
         const { gatewayData } = mollieBlockData.gatewayData;
         const context = buildRegistrationContext( wc );

--- a/src/Assets/MollieCheckoutBlocksSupport.php
+++ b/src/Assets/MollieCheckoutBlocksSupport.php
@@ -51,6 +51,7 @@ final class MollieCheckoutBlocksSupport
         /** @var ComponentDataService */
         $componentDataService = $container->get('components.data_service');
         $componentData = $componentDataService->getComponentData();
+        $isOrderPayPage = is_checkout_pay_page();
         /** @var PaymentGateway $gateway */
         foreach ($paymentGateways as $gatewayKey => $gateway) {
             if (substr($gateway->id, 0, 18) !== 'mollie_wc_gateway_') {
@@ -151,7 +152,7 @@ final class MollieCheckoutBlocksSupport
             'ajaxUrl' => admin_url('admin-ajax.php')
         ];
         $dataToScript['appleButtonData'] = $appleButtonData;
-
+        $dataToScript['isOrderPayPage'] = $isOrderPayPage;
         if ($componentData !== null) {
             $dataToScript['componentData'] = $componentData;
         }


### PR DESCRIPTION
This fix was missed somewhere in the merging process. It bails if we are in pay for order page, so we dont have both component scripts running.