### PR TITLE
Klarna payment order that uses payment api cannot be cancelled as order (794)

### DIFF
--- a/src/Payment/PaymentModule.php
+++ b/src/Payment/PaymentModule.php
@@ -490,7 +490,7 @@ class PaymentModule implements ServiceModule, ExecutableModule
 
                 return;
             }
-            if ($mollie_order->isAuthorized() || $mollie_order->isOpen() || $mollie_order->isPending()) {
+            if ($mollie_order->isAuthorized()) {
                 $apiClient->payments->cancel($mollie_order_id);
                 $message = _x('Order also cancelled at Mollie.', 'Order note info', 'mollie-payments-for-woocommerce');
                 $order->add_order_note($message);


### PR DESCRIPTION
To keep using the v2 of Mollie SDK and cancel payments we need to use the payment endpoint. Before we were only cancelling orders. 