### PR TITLE
Refresh page if checkout is stuck in complete state

### DIFF
--- a/resources/js/src/checkout/blocks/mollieBlockIndex.js
+++ b/resources/js/src/checkout/blocks/mollieBlockIndex.js
@@ -70,6 +70,26 @@ import {initializeMollieComponentsWithStoreSubscription} from "./services/Mollie
             }
             // Add custom classes to payment method icons
             addCustomClassesToPaymentIcons();
+
+            const setupBackNavigationHandler = () => {
+                window.addEventListener('pageshow', (event) => {
+                    // Check if page was loaded from cache (back/forward navigation)
+                    if (event.persisted || performance.getEntriesByType('navigation')[0]?.type === 'back_forward') {
+                        try {
+                            const currentStatus = wp.data.select('wc/store/checkout').getCheckoutStatus();
+
+                            // Only reset if checkout is stuck in complete state
+                            if (currentStatus === 'complete') {
+                                window.location.reload();
+                            }
+                        } catch (error) {
+                            console.warn('Mollie: Could not reset checkout state on back navigation:', error);
+                        }
+                    }
+                });
+            };
+
+            setupBackNavigationHandler();
         };
 
         initializeStoreDependent();


### PR DESCRIPTION
If the user press the browser back button when the payment is initiated in the block checkout, then it would see that the place order button is frozen, as the status of the checkout is completed. Only refreshing makes the transaction possible again.

Seems the WooCommerce checkout entirely depends on a redirectUrl after onCheckoutSuccess(). If there is no redirect, core WC will simply do nothing, leaving a nonfunctional checkout page with a greyed-out blocked Pay button. The only known recovery is dispatch(CHECKOUT_STORE_KEY).__internalSetIdle(). However, that's using an internal function that might be unsafe and could be removed any time. So we will do a heavy lifting and just refresh the page until we find a better solution.

