### PR TITLE
Fix `mollie-applepaydirect` CSS enqueue

### DIFF
--- a/src/Assets/MollieCheckoutBlocksSupport.php
+++ b/src/Assets/MollieCheckoutBlocksSupport.php
@@ -33,7 +33,13 @@ final class MollieCheckoutBlocksSupport
 
     public static function localizeWCBlocksData($dataService, $gatewayInstances, $container)
     {
-        wp_enqueue_style('mollie-applepaydirect');
+        if (
+            (mollieWooCommerceIsApplePayDirectEnabled('product') && is_product()) ||
+            (mollieWooCommerceIsApplePayDirectEnabled('cart') && is_cart())
+        ) {
+            wp_enqueue_style('mollie-applepaydirect');
+        }
+
         wp_localize_script(
             self::$scriptHandle,
             'mollieBlockData',


### PR DESCRIPTION
Only enqueue the `mollie-applepaydirect` CSS when the Apple Pay button is enabled for the current context (product or cart), instead of loading it globally.