### PR TITLE
Change input type from 'tel' to 'text' for Billie fields

### DIFF
--- a/src/PaymentMethods/PaymentFieldsStrategies/BillieFieldsStrategy.php
+++ b/src/PaymentMethods/PaymentFieldsStrategies/BillieFieldsStrategy.php
@@ -50,7 +50,7 @@ class BillieFieldsStrategy extends AbstractPaymentFieldsRenderer implements Paym
             <abbr class="required" title="required">*</abbr>
         </label>
         <span class="woocommerce-input-wrapper">
-            <input type="tel" class="input-text" name="' . esc_attr(
+            <input type="text" class="input-text" name="' . esc_attr(
             FieldConstants::BILLIE_COMPANY
         ) . '" id="' . esc_attr(
             FieldConstants::BILLIE_COMPANY


### PR DESCRIPTION
Fixing bug that did not allow type Company name on the dedicated text field.