### PR TITLE
Exclude node_modules in scoper

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -36,6 +36,7 @@ $finders = [
                       '.idea',
                       'modules.local',
                       'tests',
+                      'node_modules',
                   ])
         ->in('.'),
 ];


### PR DESCRIPTION
Looks like Scoper was wasting time going through every file in `node_modules`.

Now it's excluded and the packages should be created faster.

<img width="722" height="216" alt="image" src="https://github.com/user-attachments/assets/ce61844f-b397-462e-a122-511f51a17086" />

For some reason the build currently fails at the `wp` command in the end but this seems unrelated, the same in `develop`.

I diffed the old and the new packages (`interim-built.zip`), all files are the same, so it should be ok.

<img width="866" height="421" alt="image" src="https://github.com/user-attachments/assets/10d82ae0-7cfd-45f2-be79-713f2895fee4" />
