### PR TITLE
Apple pay express checkout displays shipping excluding vat in woo commerce (784)

### DIFF
--- a/src/Buttons/ApplePayButton/AppleAjaxRequests.php
+++ b/src/Buttons/ApplePayButton/AppleAjaxRequests.php
@@ -437,7 +437,7 @@ class AppleAjaxRequests
             $shippingMethodsArray[] = [
                 "label" => $rate->get_label(),
                 "detail" => "",
-                "amount" => $rate->get_cost(),
+                "amount" => round((float)$rate->get_cost() + array_sum($rate->get_taxes()), 2),
                 "identifier" => $rate->get_id(),
             ];
             if (!$done) {
@@ -491,7 +491,7 @@ class AppleAjaxRequests
      * @param $shippingMethodsArray
      */
     protected function cartCalculationResults(
-        $cart,
+        WC_Cart $cart,
         $selectedShippingMethod,
         $shippingMethodsArray
     ): array {


### PR DESCRIPTION
This PR fixes the shipping amount passed to the Apple modal, now it includes taxes