### PR TITLE
Send shipping rate with taxes to apple modal (784)

### DIFF
--- a/src/Buttons/ApplePayButton/AppleAjaxRequests.php
+++ b/src/Buttons/ApplePayButton/AppleAjaxRequests.php
@@ -437,7 +437,7 @@ class AppleAjaxRequests
             $shippingMethodsArray[] = [
                 "label" => $rate->get_label(),
                 "detail" => "",
-                "amount" => $rate->get_cost(),
+                "amount" => round((float)$rate->get_cost() + array_sum($rate->get_taxes()), 2),
                 "identifier" => $rate->get_id(),
             ];
             if (!$done) {


### PR DESCRIPTION
This PR fixes the shipping amount passed to the Apple modal, now it includes taxes