### PR TITLE
Restore applePayToken in ApplePayTokenDecorator

### DIFF
--- a/src/Payment/Request/Middleware/ApplePayTokenMiddleware.php
+++ b/src/Payment/Request/Middleware/ApplePayTokenMiddleware.php
@@ -29,9 +29,9 @@ class ApplePayTokenMiddleware implements RequestMiddlewareInterface
         }
         $encodedApplePayToken = wp_json_encode($applePayToken);
         if ($context === 'order') {
-            $requestData['payment']['applePayToken'] = $encodedApplePayToken;
+            $requestData['payment']['applePayPaymentToken'] = $encodedApplePayToken;
         } elseif ($context === 'payment') {
-            $requestData['applePayToken'] = $encodedApplePayToken;
+            $requestData['applePayPaymentToken'] = $encodedApplePayToken;
         }
         return $next($requestData, $order, $context);
     }


### PR DESCRIPTION
This PR changes `applePayToken` into `applePayPaymentToken` in previous releases for consistency across integrations