### PR TITLE
[QA] Optimize refund tests

### DIFF
--- a/tests/qa/package.json
+++ b/tests/qa/package.json
@@ -45,7 +45,8 @@
     "setup:tax:inc": "npx playwright test --grep=\"setup:tax:inc;\"",
     "setup:tax:exc": "npx playwright test --grep=\"setup:tax:exc;\"",
     "setup:mollie:germany": "npx playwright test --grep \"setup:mollie:germany;\"",
-    "test:all": "npx playwright test --project=all --workers=1"
+    "test:all": "npx playwright test --project=all --workers=1",
+    "test:refund": "npx playwright test --project=refund --workers=4"
   },
   "eslintConfig": {
     "extends": [

--- a/tests/qa/playwright.config.ts
+++ b/tests/qa/playwright.config.ts
@@ -109,9 +109,15 @@ export default defineConfig< TestBaseExtend >( {
 			testIgnore: /refund\.spec\.ts/,
 		},
 		{
-			name: 'refund',
+			name: 'setup-refund',
 			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /refund\.setup\.ts/,
 			fullyParallel: false,
+		},
+		{
+			name: 'refund',
+			dependencies: [ 'setup-refund' ],
+			fullyParallel: true,
 			testMatch: /refund\.spec\.ts/,
 		},
 	],

--- a/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
@@ -42,6 +42,15 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 		? 'Mollie Dashboard'
 		: 'WooCommerce';
 
+	const isWooCommerceFullRefund =
+		! isMollieClientApiRefund && refundPercentage === 100;
+	const isMollieFullRefund =
+		isMollieClientApiRefund && refundPercentage === 100;
+	const isWooCommercePartialRefund =
+		! isMollieClientApiRefund && refundPercentage < 100;
+	const isMolliePartialRefund =
+		isMollieClientApiRefund && refundPercentage < 100;
+
 	const testTitle = `${ testId } | Refund - ${ refundPart } - ${ gatewayLabel } - Via ${ refundVia }`;
 
 	test(
@@ -57,192 +66,204 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 			wooCommerceOrderEdit,
 		} ) => {
 			test.setTimeout( 16 * 60_000 );
-			// Preconditions
-			await updateCurrencyIfNeeded( wooCommerceApi, currency );
-
-			const orderTotals = await countTotals( testData );
-			payment.amount = orderTotals.order;
-			const refundAvailable = orderTotals.order;
-			const refundAmount = getAmountPercentage(
-				refundAvailable,
-				testData.refundPercentage
-			);
-
-			await utils.fillVisitorsCart( testData.products );
-
-			await classicCheckout.makeOrder( testData );
-
-			await mollieHostedCheckout.assertUrl();
-			const orderId = await mollieHostedCheckout.captureOrderNumber();
-			await mollieHostedCheckout.payForOrder( payment );
-
-			await processMolliePaymentStatus(
-				{ mollieHostedCheckout, orderReceived, payForOrder },
-				Number( orderId ),
-				testData
-			);
-
-			const { transaction_id: transactionId } =
-				await wooCommerceApi.getOrder( orderId );
-
-			// Test
-			await expect(
-				transactionId,
-				`Assert transaction ID ${ transactionId } is defined`
-			).toBeDefined();
-
-			// Make refund via Mollie client API
-			if ( isMollieClientApiRefund ) {
-				const idempotencyKey = `${ transactionId }-refund-${ orderId }`;
-				await mollieClientApi.refunds.create( {
-					paymentId: transactionId,
-					idempotencyKey,
-					refundRequest: {
-						amount: {
-							value: refundAmount,
-							currency,
-						},
-						description: testTitle,
-						metadata: {},
-					},
-				} );
-				await wooCommerceOrderEdit.visit( orderId );
-			}
-			// Make refund via WooCommerce admin
-			else {
-				await wooCommerceOrderEdit.visit( orderId );
-				await wooCommerceOrderEdit.refundButton().click();
-
-				// Assertions before refund
-				await expect(
-					wooCommerceOrderEdit.restockRefundedItemsCheckbox(),
-					'Assert restock refunded items checkbox is visible'
-				).toBeVisible();
-				await expect(
-					wooCommerceOrderEdit.totalAmountAlreadyRefunded(),
-					'Assert total amount already refunded is 0'
-				).toHaveText( `-${ formatMoney( 0, currency ) }` );
-				await expect(
-					wooCommerceOrderEdit.totalAvailableToRefund(),
-					'Assert total available to refund is correct'
-				).toHaveText(
-					formatMoney( Number( refundAvailable ), currency )
-				);
-				await wooCommerceOrderEdit.makeRefund(
-					gateway.name,
-					refundAmount
-				);
-			}
-
-			// Assert URL after page is reloaded
-			await wooCommerceOrderEdit.assertUrl( orderId );
-
-			// Assert via API WooCommerce Order refund status and presence of refunds
+			let transactionId: string;
+			let orderId: number;
+			let refundAmount: string;
+			let refundAvailable: number;
+			let refundTransactionId: number;
 			let orderTotal: string;
 			let refunds = [];
 			let refundMeta: { key: string; value: any };
 			let statusAfterRefund: string;
+			// Preconditions
+			await test.step( 'Precondition: create WooCommerce order', async step => {
+				await updateCurrencyIfNeeded( wooCommerceApi, currency );
 
-			// Delayed webhooks cause following values to arrive in ~10 minutes after refund creation
-			await expect( async () => {
-				const order = await wooCommerceApi.getOrder( orderId );
-				orderTotal = order.total;
-				statusAfterRefund = order.status;
-				refunds = order.refunds;
-				refundMeta = order.meta_data.find(
-					( meta ) => meta.key === '_mollie_processed_refund_ids'
+				const orderTotals = await countTotals( testData );
+				payment.amount = orderTotals.order;
+				refundAvailable = orderTotals.order;
+				refundAmount = getAmountPercentage(
+					refundAvailable,
+					testData.refundPercentage
 				);
+
+				await utils.fillVisitorsCart( testData.products );
+
+				await classicCheckout.makeOrder( testData );
+
+				await mollieHostedCheckout.assertUrl();
+				orderId = await mollieHostedCheckout.captureOrderNumber();
+				await mollieHostedCheckout.payForOrder( payment );
+
+				await processMolliePaymentStatus(
+					{ mollieHostedCheckout, orderReceived, payForOrder },
+					Number( orderId ),
+					testData
+				);
+
+				const order = await wooCommerceApi.getOrder( orderId );
+				transactionId = order.transaction_id;
+				await expect(
+					transactionId,
+					`Assert transaction ID ${ transactionId } is defined`
+				).toBeDefined();
+			} );
+
+			// Test
+
+			// Make refund via Mollie client API
+			if ( isMollieClientApiRefund ) {
+				await test.step( 'Make refund via Mollie client API', async step => {
+					const idempotencyKey = `${ transactionId }-refund-${ orderId }`;
+					await mollieClientApi.refunds.create( {
+						paymentId: transactionId,
+						idempotencyKey,
+						refundRequest: {
+							amount: {
+								value: refundAmount,
+								currency,
+							},
+							description: testTitle,
+							metadata: {},
+						},
+					} );
+					await wooCommerceOrderEdit.visit( orderId );
+				} );
+			}
+			// Make refund via WooCommerce admin
+			else {
+				await test.step( 'Make refund via WooCommerce', async step => {
+					await wooCommerceOrderEdit.visit( orderId );
+					await wooCommerceOrderEdit.refundButton().click();
+
+					// Assertions before refund
+					await expect(
+						wooCommerceOrderEdit.restockRefundedItemsCheckbox(),
+						'Assert restock refunded items checkbox is visible'
+					).toBeVisible();
+					await expect(
+						wooCommerceOrderEdit.totalAmountAlreadyRefunded(),
+						'Assert total amount already refunded is 0'
+					).toHaveText( `-${ formatMoney( 0, currency ) }` );
+					await expect(
+						wooCommerceOrderEdit.totalAvailableToRefund(),
+						'Assert total available to refund is correct'
+					).toHaveText(
+						formatMoney( Number( refundAvailable ), currency )
+					);
+					await wooCommerceOrderEdit.makeRefund(
+						gateway.name,
+						refundAmount
+					);
+					// Assert URL after page is reloaded
+					await wooCommerceOrderEdit.assertUrl( orderId );
+				} );
+			}
+
+			await test.step( 'Wait for webhook and assert refund meta ~10 min', async step => {
+				// Assert via API WooCommerce Order refund status and presence of refunds
+				// Delayed webhooks cause following values to arrive in ~10 minutes after refund creation
+				await expect( async () => {
+					const order = await wooCommerceApi.getOrder( orderId );
+					orderTotal = order.total;
+					statusAfterRefund = order.status;
+					refunds = order.refunds;
+					refundMeta = order.meta_data.find(
+						( meta ) => meta.key === '_mollie_processed_refund_ids'
+					);
+
+					await expect(
+						refundMeta,
+						'Assert refund meta is defined'
+					).toBeDefined();
+					await wooCommerceOrderEdit.page.reload();
+				} ).toPass( {
+					intervals: [ 60_000 ],
+					timeout: 14 * 60_000,
+				} );
+
+				await expect(
+					refundMeta.value,
+					'Assert refund meta value has length 1'
+				).toHaveLength( 1 );
+				refundTransactionId = refundMeta.value[ 0 ];
+			} );
+			
+			await test.step( 'Assert refund details', async step => {
+				step.skip( isMolliePartialRefund, 'Not availabe for partial refund via Mollie dashboard' );
+
 				await expect(
 					refunds,
 					`Assert refunds array has length 1`
 				).toHaveLength( 1 );
+				const { total: refundTotal, id: refundId } = refunds[ 0 ];
+
 				await expect(
-					refundMeta,
-					'Assert refund meta is defined'
-				).toBeDefined();
-				await wooCommerceOrderEdit.page.reload();
-			} ).toPass( {
-				intervals: [ 60_000 ],
-				timeout: 14 * 60_000,
-			} );
+					statusAfterRefund,
+					`Assert order status is ${ expectedRefundOrderStatus }`
+				).toEqual( expectedRefundOrderStatus );
 
-			const { total: refundTotal, id: refundId } = refunds[ 0 ];
+				const expectedRefundTotal = `-${ Number( refundAmount ).toFixed(
+					2
+				) }`;
+				await expect(
+					refundTotal,
+					`Assert refund total is ${ expectedRefundTotal }`
+				).toEqual( expectedRefundTotal );
 
-			await expect(
-				refundMeta.value,
-				'Assert refund meta value has length 1'
-			).toHaveLength( 1 );
-			const refundTransactionId = refundMeta.value[ 0 ];
-
-			await expect(
-				statusAfterRefund,
-				`Assert order status is ${ expectedRefundOrderStatus }`
-			).toEqual( expectedRefundOrderStatus );
-
-			const expectedRefundTotal = `-${ Number( refundAmount ).toFixed(
-				2
-			) }`;
-			await expect(
-				refundTotal,
-				`Assert refund total is ${ expectedRefundTotal }`
-			).toEqual( expectedRefundTotal );
-
-			// Assert on OrderEdit page that WooCommerce and PayPal refund fields are displayed and have expected values
-			await wooCommerceOrderEdit.assertRefundData( {
-				currency,
-				orderStatus: capitalizeFirst( expectedRefundOrderStatus ),
-				refundId,
-				refundAmount: Number( refundAmount ),
-				refundTotal: Number( refundAmount ),
-				netPayment:
-					parseFloat( orderTotal ) - parseFloat( refundAmount ),
+				// Assert on OrderEdit page that WooCommerce and PayPal refund fields are displayed and have expected values
+				await wooCommerceOrderEdit.assertRefundData( {
+					currency,
+					orderStatus: capitalizeFirst( expectedRefundOrderStatus ),
+					refundId,
+					refundAmount: Number( refundAmount ),
+					refundTotal: Number( refundAmount ),
+					netPayment:
+						parseFloat( orderTotal ) - parseFloat( refundAmount ),
+				} );
 			} );
 
 			// Assert order notes via WC API
-			const formattedRefundAmount = parseFloat( refundAmount ).toString();
-			let expectedNotes = [];
-			// Expected notes for Full via WooCommerce:
-			if ( ! isMollieClientApiRefund && refundPercentage === 100 ) {
-				expectedNotes = [
-					`Refunded ${ currency }${ formattedRefundAmount } - Payment: ${ transactionId }, Refund: ${ refundTransactionId }`,
-					`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
-				];
-			}
-			// Expected notes for Full via Mollie:
-			else if ( isMollieClientApiRefund && refundPercentage === 100 ) {
-				expectedNotes = [
-					`Mollie - ${
-						gateway.name
-					} payment _order_status_refunded via Mollie (${ transactionId } - test mode). You will need to manually review the payment (and adjust product stocks if you use it). Order status changed from Processing to ${ capitalizeFirst(
-						expectedRefundOrderStatus
-					) }.`,
-					`Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.`,
-					`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
-				];
-			}
-			// Expected notes for Partial via WooCommerce:
-			else if ( ! isMollieClientApiRefund && refundPercentage < 100 ) {
-				expectedNotes = [
-					`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
-					`Refunded ${ currency }${ formattedRefundAmount } - Payment: ${ transactionId }, Refund: ${ refundTransactionId }`,
-				];
-			}
-			// Expected notes for Partial via Mollie:
-			else if ( isMollieClientApiRefund && refundPercentage < 100 ) {
-				expectedNotes = [
-					`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
-				];
-			}
+			await test.step( 'Assert refund Order Notes', async step => {
+				const formattedRefundAmount = parseFloat( refundAmount ).toString();
+				let expectedNotes = [];
+				if ( isWooCommerceFullRefund ) {
+					expectedNotes = [
+						`Refunded ${ currency }${ formattedRefundAmount } - Payment: ${ transactionId }, Refund: ${ refundTransactionId }`,
+						`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
+						`Order status changed from Processing to ${ capitalizeFirst(
+							expectedRefundOrderStatus
+						) }.`,
+					];
+				}
+				if ( isMollieFullRefund ) {
+					expectedNotes = [
+						`Mollie - ${
+							gateway.name
+						} payment _order_status_refunded via Mollie (${ transactionId } - test mode). You will need to manually review the payment (and adjust product stocks if you use it). Order status changed from Processing to ${ capitalizeFirst(
+							expectedRefundOrderStatus
+						) }.`,
+						`Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.`,
+						`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
+						`Order status changed from Processing to ${ capitalizeFirst(
+							expectedRefundOrderStatus
+						) }.`,
+					];
+				}
+				if ( isWooCommercePartialRefund ) {
+					expectedNotes = [
+						`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
+						`Refunded ${ currency }${ formattedRefundAmount } - Payment: ${ transactionId }, Refund: ${ refundTransactionId }`,
+					];
+				}
+				if ( isMolliePartialRefund ) {
+					expectedNotes = [
+						`New refund ${ refundTransactionId } processed in Mollie Dashboard! Order note added, but order not updated.`,
+					];
+				}
 
-			if ( refundPercentage === 100 ) {
-				expectedNotes.unshift(
-					`Order status changed from Processing to ${ capitalizeFirst(
-						expectedRefundOrderStatus
-					) }.`
-				);
-			}
-
-			await assertOrderNotes( wooCommerceApi, orderId, expectedNotes );
+				await assertOrderNotes( wooCommerceApi, orderId, expectedNotes );
+			} );
 		}
 	);
 };

--- a/tests/qa/tests/06-refund/refund.setup.ts
+++ b/tests/qa/tests/06-refund/refund.setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { test as setup } from '../../utils';
+import { shopConfigGermany } from '../../resources';
+
+setup( 'Setup Mollie', async ( { utils, wooCommerceApi }, testInfo ) => {
+	if ( ! [ 'setup-refund', 'refund' ].includes( testInfo.project.name ) ) {
+		return;
+	}
+	
+	await utils.configureStore( {
+		...shopConfigGermany,
+		enableClassicPages: true,
+	} );
+	await utils.installAndActivateMollie();
+	await utils.cleanReconnectMollie();
+	await wooCommerceApi.deleteAllOrders();
+} );

--- a/tests/qa/tests/06-refund/refund.spec.ts
+++ b/tests/qa/tests/06-refund/refund.spec.ts
@@ -1,49 +1,31 @@
 /**
  * Internal dependencies
  */
-import { test } from '../../utils';
 import { testRefund } from './_test-scenarios';
 import { refundViaWooCommerce, refundViaMollieDashboard } from './_test-data';
-import { MollieSettings, shopSettings } from '../../resources';
+import { MollieSettings } from '../../resources';
 
 const testedApiMethod =
 	( process.env.MOLLIE_API_METHOD as MollieSettings.ApiMethod ) || 'payment';
 
-test.beforeAll( async ( { utils }, testInfo ) => {
-	if ( testInfo.project.name !== 'refund' ) {
-		return;
+for ( const testData of refundViaWooCommerce ) {
+	// exclude tests for payment methods if not available for tested API
+	const availableForApiMethods =
+		testData.payment.gateway.availableForApiMethods;
+	if ( ! availableForApiMethods.includes( testedApiMethod ) ) {
+		continue;
 	}
 
-	await utils.configureStore( {
-		settings: {
-			general: shopSettings.germany.general,
-		},
-		enableClassicPages: false,
-	} );
-	await utils.installAndActivateMollie();
-	await utils.cleanReconnectMollie();
-} );
+	testRefund( testData );
+}
 
-test.describe( () => {
-	for ( const testData of refundViaWooCommerce ) {
-		// exclude tests for payment methods if not available for tested API
-		const availableForApiMethods =
-			testData.payment.gateway.availableForApiMethods;
-		if ( ! availableForApiMethods.includes( testedApiMethod ) ) {
-			continue;
-		}
-
-		testRefund( testData );
+for ( const testData of refundViaMollieDashboard ) {
+	// exclude tests for payment methods if not available for tested API
+	const availableForApiMethods =
+		testData.payment.gateway.availableForApiMethods;
+	if ( ! availableForApiMethods.includes( testedApiMethod ) ) {
+		continue;
 	}
 
-	for ( const testData of refundViaMollieDashboard ) {
-		// exclude tests for payment methods if not available for tested API
-		const availableForApiMethods =
-			testData.payment.gateway.availableForApiMethods;
-		if ( ! availableForApiMethods.includes( testedApiMethod ) ) {
-			continue;
-		}
-
-		testRefund( testData );
-	}
-} );
+	testRefund( testData );
+}


### PR DESCRIPTION
### Description

- Add `test:refund` script to `package.json` (parallel execution with 4 workers).
- Add `setup-refund` project to fulfil preconditions for parallel execution.
- Add `test.step` to `refund.scenario`:
    - `test.step` allows to split complex test scenario into logical blocks.