### PR TITLE
Add fallback to plugin file url

### DIFF
--- a/lib/payment-gateway/src/PaymentGatewayModule.php
+++ b/lib/payment-gateway/src/PaymentGatewayModule.php
@@ -195,6 +195,7 @@ class PaymentGatewayModule implements ServiceModule, ExecutableModule
          * We will be doing string comparisons, so we have to ensure we work with
          * sanitized data
          */
+        $absoluteFilePath = realpath($absoluteFilePath) ?: '';
         $absoluteFilePath = wp_normalize_path($absoluteFilePath);
         $activePlugins = wp_get_active_and_valid_plugins();
         $networkPlugins = function_exists('wp_get_active_network_plugins')
@@ -210,6 +211,7 @@ class PaymentGatewayModule implements ServiceModule, ExecutableModule
             /**
              * Again, ensure the path is sanitized before doing the comparison
              */
+            $pluginPath = realpath($pluginPath) ?: '';
             $pluginPath = wp_normalize_path($pluginPath);
             if (0 === strpos($absoluteFilePath, $pluginPath)) {
                 $relativePath = (string) substr($absoluteFilePath, strlen($pluginPath) + 1);
@@ -219,7 +221,10 @@ class PaymentGatewayModule implements ServiceModule, ExecutableModule
             }
         }
 
-        throw new \RuntimeException('Could not derive plugin path'); // File not found in active plugins
+        // Fallback: return a best-guess URL based on the plugin directory structure
+        $pluginDirName = basename(dirname(dirname(dirname(__DIR__))));
+        $relativePath = basename($absoluteFilePath);
+        return plugins_url('lib/payment-gateway/' . $relativePath, $pluginDirName . '/' . $pluginDirName . '.php');
     }
 
     /**


### PR DESCRIPTION
Now we use realpath() before wp_normalize_path() taking into consideration that realpath() can return false. 
If all fails we fallback to a best-guess URL based on the plugin directory structure