### PR TITLE
Add option to hide order lines in payment API (840)

### DIFF
--- a/src/Payment/LineItems/LineItemProvider.php
+++ b/src/Payment/LineItems/LineItemProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\Payment\LineItems;
+
+use WC_Order;
+
+interface LineItemProvider
+{
+    public function order_lines(WC_Order $order): array;
+}

--- a/src/Payment/LineItems/OrderLines.php
+++ b/src/Payment/LineItems/OrderLines.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Mollie\WooCommerce\Payment;
+namespace Mollie\WooCommerce\Payment\LineItems;
 
 use Mollie\WooCommerce\PaymentMethods\Constants;
 use Mollie\WooCommerce\PaymentMethods\Voucher;
 use Mollie\WooCommerce\Shared\Data;
 use WC_Order;
 use WC_Order_Item;
-use WC_Order_Item_Fee;
 use WC_Tax;
 
-class PaymentLines
+class OrderLines implements LineItemProvider
 {
     /**
      * Formatted order lines.
@@ -57,7 +56,7 @@ class PaymentLines
      *
      * @return array
      */
-    public function order_lines($order)
+    public function order_lines(WC_Order $order): array
     {
         $this->order_lines = [];
         $this->order = $order;
@@ -68,9 +67,7 @@ class PaymentLines
         $this->process_gift_cards();
         $this->process_mismatch();
 
-        return  [
-            'lines' => $this->get_order_lines(),
-        ];
+        return $this->get_order_lines();
     }
 
     private function process_mismatch()
@@ -87,7 +84,7 @@ class PaymentLines
         }
         $mismatch =  [
             'type' => $orderTotalDiff > 0 ? 'surcharge' : 'discount',
-            'description' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
+            'name' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
             'quantity' => 1,
             'vatRate' => 0,
             'unitPrice' =>  [
@@ -102,7 +99,11 @@ class PaymentLines
                 'currency' => $this->currency,
                 'value' => $this->dataHelper->formatCurrencyValue(0, $this->currency),
             ],
+            'metadata' =>  [
+                'order_item_id' => 'rounding_diff',
+            ],
         ];
+
         $this->order_lines[] = $mismatch;
     }
 
@@ -135,35 +136,41 @@ class PaymentLines
                 }
 
                 $this->currency = $this->dataHelper->getOrderCurrency($this->order);
+                $vatRate = round($this->get_item_vatRate($cart_item, $product), 2);
+                $wcTotalValue = $this->get_item_total_amount($cart_item);
+                $wcUnitPrice = $this->get_item_price($cart_item);
 
-                $vatRate = 0;
-                if ($cart_item['line_tax'] > 0 && $cart_item['line_total'] > 0) {
-                    $vatRate = round($cart_item['line_tax'] / $cart_item['line_total'], 4) * 100;
-                }
+                // Calculate Mollie prices, they expect price including VAT
+                $mollieTotal = $this->getMolliePrice($wcTotalValue, $vatRate);
+                $mollieUnit = $this->getMolliePrice($wcUnitPrice, $vatRate);
 
                 $mollie_order_item =  [
                     'sku' => $this->get_item_reference($product),
                     'type' => ($product instanceof \WC_Product && $product->is_virtual()) ? 'digital' : 'physical',
-                    'description' => $this->get_item_name($cart_item),
+                    'name' => $this->get_item_name($cart_item),
                     'quantity' => $this->get_item_quantity($cart_item),
                     'vatRate' => $vatRate,
                     'unitPrice' =>  [
                         'currency' => $this->currency,
-                        'value' => $this->dataHelper->formatCurrencyValue($this->get_item_price($cart_item), $this->currency),
+                        'value' => $this->dataHelper->formatCurrencyValue($mollieUnit['grossPrice'], $this->currency),
                     ],
                     'totalAmount' =>  [
                         'currency' => $this->currency,
-                        'value' => $this->dataHelper->formatCurrencyValue($this->get_item_total_amount($cart_item), $this->currency),
+                        'value' => $this->dataHelper->formatCurrencyValue($mollieTotal['grossPrice'], $this->currency),
                     ],
                     'vatAmount' =>
                          [
                             'currency' => $this->currency,
-                            'value' => $this->dataHelper->formatCurrencyValue($this->get_item_tax_amount($cart_item), $this->currency),
+                            'value' => $this->dataHelper->formatCurrencyValue($mollieTotal['vatAmount'], $this->currency),
                         ],
                     'discountAmount' =>
                          [
                             'currency' => $this->currency,
                             'value' => $this->dataHelper->formatCurrencyValue($this->get_item_discount_amount($cart_item), $this->currency),
+                        ],
+                    'metadata' =>
+                        [
+                            'order_item_id' => $cart_item->get_id(),
                         ],
                     'productUrl' => ($product instanceof \WC_Product) ? $product->get_permalink() : null,
                 ];
@@ -185,7 +192,7 @@ class PaymentLines
                 if ($paymentMethod === 'mollie_wc_gateway_' . Constants::VOUCHER && $product instanceof \WC_Product) {
                     $categories = Voucher::getCategoriesForProduct($product);
                     if ($categories) {
-                        $mollie_order_item['categories'] = $categories;
+                        $mollie_order_item['category'] = array_shift($categories);
                     }
                 }
                 $this->order_lines[] = $mollie_order_item;
@@ -211,7 +218,7 @@ class PaymentLines
                 }
                 $shipping = [
                     'type' => 'shipping_fee',
-                    'description' => $shipping_method->get_name() ?: __('Shipping', 'mollie-payments-for-woocommerce'),
+                    'name' => $shipping_method->get_name() ?: __('Shipping', 'mollie-payments-for-woocommerce'),
                     'quantity' => 1,
                     'vatRate' => $vatRate,
                     'unitPrice' =>  [
@@ -225,6 +232,9 @@ class PaymentLines
                     'vatAmount' =>  [
                         'currency' => $this->currency,
                         'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total_tax(), $this->currency),
+                    ],
+                    'metadata' => [
+                        'order_item_id' => $shipping_method->get_id(),
                     ],
                 ];
 
@@ -242,7 +252,6 @@ class PaymentLines
     {
         if (! empty($this->order->get_items('fee'))) {
             foreach ($this->order->get_items('fee') as $cart_fee) {
-                assert($cart_fee instanceof WC_Order_Item_Fee);
                 if ($cart_fee['tax_status'] === 'taxable') {
                     // Calculate tax rate.
                     $tmp_rates = WC_Tax::get_rates($cart_fee['tax_class']);
@@ -271,7 +280,7 @@ class PaymentLines
 
                 $fee =  [
                     'type' => $cart_fee_total > 0 ? 'surcharge' : 'discount',
-                    'description' => $cart_fee['name'],
+                    'name' => $cart_fee['name'],
                     'quantity' => 1,
                     'vatRate' => $this->dataHelper->formatCurrencyValue($cart_fee_vat_rate, $this->currency),
                     'unitPrice' =>  [
@@ -285,6 +294,9 @@ class PaymentLines
                     'vatAmount' =>  [
                         'currency' => $this->currency,
                         'value' => $this->dataHelper->formatCurrencyValue($cart_fee_tax_amount, $this->currency),
+                    ],
+                    'metadata' =>  [
+                        'order_item_id' => $cart_fee->get_id(),
                     ],
                 ];
 
@@ -304,7 +316,7 @@ class PaymentLines
             foreach ($this->order->get_items('gift_card') as $cart_gift_card) {
                 $gift_card = [
                     'type' => 'gift_card',
-                    'description' => $cart_gift_card->get_name(),
+                    'name' => $cart_gift_card->get_name(),
                     'unitPrice' => [
                         'currency' => $this->currency,
                         'value' =>  $this->dataHelper->formatCurrencyValue(-$cart_gift_card->get_amount(), $this->currency),
@@ -357,6 +369,41 @@ class PaymentLines
     private function get_item_tax_amount($cart_item)
     {
         return $cart_item['line_tax'];
+    }
+
+    /**
+     * Calculate item tax percentage.
+     *
+     * @since  1.0
+     * @access private
+     *
+     * @param  WC_Order_Item  $cart_item Cart item.
+     * @param  null|false|\WC_Product $product   Product object.
+     *
+     * @return integer $item_vatRate Item tax percentage formatted for Mollie Orders API.
+     */
+    private function get_item_vatRate($cart_item, $product)
+    {
+        if ($product && $product->is_taxable() && $cart_item['line_subtotal_tax'] > 0) {
+            // Calculate tax rate.
+            $_tax = new WC_Tax();
+            $tmp_rates = $_tax->get_rates($product->get_tax_class());
+            $item_vatRate = 0;
+            foreach ($tmp_rates as $rate) {
+                if (isset($rate['rate'])) {
+                    if ($rate['compound'] === "yes") {
+                        $compoundRate = round($item_vatRate * ($rate['rate'] / 100)) + $rate['rate'];
+                        $item_vatRate += $compoundRate;
+                        continue;
+                    }
+                    $item_vatRate += $rate['rate'];
+                }
+            }
+        } else {
+            $item_vatRate = 0;
+        }
+
+        return $item_vatRate;
     }
 
     /**
@@ -451,5 +498,22 @@ class PaymentLines
     private function get_item_total_amount($cart_item)
     {
         return $cart_item['line_total'] + $cart_item['line_tax'];
+    }
+
+    /**
+     * Build price data for Mollie API.
+     *
+     * @param float $wcPrice
+     * @param float $vatRate
+     * @return float[]
+     */
+    private function getMolliePrice(float $wcPrice, float $vatRate): array
+    {
+        $grossPrice = wc_prices_include_tax() ? $wcPrice : $wcPrice * (1 + ($vatRate / 100));
+
+        return [
+            'grossPrice' => $grossPrice,
+            'vatAmount' => $grossPrice * ($vatRate / (100 + $vatRate)),
+        ];
     }
 }

--- a/src/Payment/LineItems/PaymentLines.php
+++ b/src/Payment/LineItems/PaymentLines.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Mollie\WooCommerce\Payment;
+namespace Mollie\WooCommerce\Payment\LineItems;
 
 use Mollie\WooCommerce\PaymentMethods\Constants;
 use Mollie\WooCommerce\PaymentMethods\Voucher;
 use Mollie\WooCommerce\Shared\Data;
 use WC_Order;
 use WC_Order_Item;
+use WC_Order_Item_Fee;
 use WC_Tax;
 
-class OrderLines
+class PaymentLines implements LineItemProvider
 {
     /**
      * Formatted order lines.
@@ -56,7 +57,7 @@ class OrderLines
      *
      * @return array
      */
-    public function order_lines($order)
+    public function order_lines(WC_Order $order): array
     {
         $this->order_lines = [];
         $this->order = $order;
@@ -67,9 +68,7 @@ class OrderLines
         $this->process_gift_cards();
         $this->process_mismatch();
 
-        return  [
-            'lines' => $this->get_order_lines(),
-        ];
+        return $this->get_order_lines();
     }
 
     private function process_mismatch()
@@ -86,7 +85,7 @@ class OrderLines
         }
         $mismatch =  [
             'type' => $orderTotalDiff > 0 ? 'surcharge' : 'discount',
-            'name' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
+            'description' => __('Rounding difference', 'mollie-payments-for-woocommerce'),
             'quantity' => 1,
             'vatRate' => 0,
             'unitPrice' =>  [
@@ -101,11 +100,7 @@ class OrderLines
                 'currency' => $this->currency,
                 'value' => $this->dataHelper->formatCurrencyValue(0, $this->currency),
             ],
-            'metadata' =>  [
-                'order_item_id' => 'rounding_diff',
-            ],
         ];
-
         $this->order_lines[] = $mismatch;
     }
 
@@ -138,41 +133,35 @@ class OrderLines
                 }
 
                 $this->currency = $this->dataHelper->getOrderCurrency($this->order);
-                $vatRate = round($this->get_item_vatRate($cart_item, $product), 2);
-                $wcTotalValue = $this->get_item_total_amount($cart_item);
-                $wcUnitPrice = $this->get_item_price($cart_item);
 
-                // Calculate Mollie prices, they expect price including VAT
-                $mollieTotal = $this->getMolliePrice($wcTotalValue, $vatRate);
-                $mollieUnit = $this->getMolliePrice($wcUnitPrice, $vatRate);
+                $vatRate = 0;
+                if ($cart_item['line_tax'] > 0 && $cart_item['line_total'] > 0) {
+                    $vatRate = round($cart_item['line_tax'] / $cart_item['line_total'], 4) * 100;
+                }
 
                 $mollie_order_item =  [
                     'sku' => $this->get_item_reference($product),
                     'type' => ($product instanceof \WC_Product && $product->is_virtual()) ? 'digital' : 'physical',
-                    'name' => $this->get_item_name($cart_item),
+                    'description' => $this->get_item_name($cart_item),
                     'quantity' => $this->get_item_quantity($cart_item),
                     'vatRate' => $vatRate,
                     'unitPrice' =>  [
                         'currency' => $this->currency,
-                        'value' => $this->dataHelper->formatCurrencyValue($mollieUnit['grossPrice'], $this->currency),
+                        'value' => $this->dataHelper->formatCurrencyValue($this->get_item_price($cart_item), $this->currency),
                     ],
                     'totalAmount' =>  [
                         'currency' => $this->currency,
-                        'value' => $this->dataHelper->formatCurrencyValue($mollieTotal['grossPrice'], $this->currency),
+                        'value' => $this->dataHelper->formatCurrencyValue($this->get_item_total_amount($cart_item), $this->currency),
                     ],
                     'vatAmount' =>
                          [
                             'currency' => $this->currency,
-                            'value' => $this->dataHelper->formatCurrencyValue($mollieTotal['vatAmount'], $this->currency),
+                            'value' => $this->dataHelper->formatCurrencyValue($this->get_item_tax_amount($cart_item), $this->currency),
                         ],
                     'discountAmount' =>
                          [
                             'currency' => $this->currency,
                             'value' => $this->dataHelper->formatCurrencyValue($this->get_item_discount_amount($cart_item), $this->currency),
-                        ],
-                    'metadata' =>
-                        [
-                            'order_item_id' => $cart_item->get_id(),
                         ],
                     'productUrl' => ($product instanceof \WC_Product) ? $product->get_permalink() : null,
                 ];
@@ -194,7 +183,7 @@ class OrderLines
                 if ($paymentMethod === 'mollie_wc_gateway_' . Constants::VOUCHER && $product instanceof \WC_Product) {
                     $categories = Voucher::getCategoriesForProduct($product);
                     if ($categories) {
-                        $mollie_order_item['category'] = array_shift($categories);
+                        $mollie_order_item['categories'] = $categories;
                     }
                 }
                 $this->order_lines[] = $mollie_order_item;
@@ -220,7 +209,7 @@ class OrderLines
                 }
                 $shipping = [
                     'type' => 'shipping_fee',
-                    'name' => $shipping_method->get_name() ?: __('Shipping', 'mollie-payments-for-woocommerce'),
+                    'description' => $shipping_method->get_name() ?: __('Shipping', 'mollie-payments-for-woocommerce'),
                     'quantity' => 1,
                     'vatRate' => $vatRate,
                     'unitPrice' =>  [
@@ -234,9 +223,6 @@ class OrderLines
                     'vatAmount' =>  [
                         'currency' => $this->currency,
                         'value' => $this->dataHelper->formatCurrencyValue($shipping_method->get_total_tax(), $this->currency),
-                    ],
-                    'metadata' => [
-                        'order_item_id' => $shipping_method->get_id(),
                     ],
                 ];
 
@@ -254,6 +240,7 @@ class OrderLines
     {
         if (! empty($this->order->get_items('fee'))) {
             foreach ($this->order->get_items('fee') as $cart_fee) {
+                assert($cart_fee instanceof WC_Order_Item_Fee);
                 if ($cart_fee['tax_status'] === 'taxable') {
                     // Calculate tax rate.
                     $tmp_rates = WC_Tax::get_rates($cart_fee['tax_class']);
@@ -282,7 +269,7 @@ class OrderLines
 
                 $fee =  [
                     'type' => $cart_fee_total > 0 ? 'surcharge' : 'discount',
-                    'name' => $cart_fee['name'],
+                    'description' => $cart_fee['name'],
                     'quantity' => 1,
                     'vatRate' => $this->dataHelper->formatCurrencyValue($cart_fee_vat_rate, $this->currency),
                     'unitPrice' =>  [
@@ -296,9 +283,6 @@ class OrderLines
                     'vatAmount' =>  [
                         'currency' => $this->currency,
                         'value' => $this->dataHelper->formatCurrencyValue($cart_fee_tax_amount, $this->currency),
-                    ],
-                    'metadata' =>  [
-                        'order_item_id' => $cart_fee->get_id(),
                     ],
                 ];
 
@@ -318,7 +302,7 @@ class OrderLines
             foreach ($this->order->get_items('gift_card') as $cart_gift_card) {
                 $gift_card = [
                     'type' => 'gift_card',
-                    'name' => $cart_gift_card->get_name(),
+                    'description' => $cart_gift_card->get_name(),
                     'unitPrice' => [
                         'currency' => $this->currency,
                         'value' =>  $this->dataHelper->formatCurrencyValue(-$cart_gift_card->get_amount(), $this->currency),
@@ -371,41 +355,6 @@ class OrderLines
     private function get_item_tax_amount($cart_item)
     {
         return $cart_item['line_tax'];
-    }
-
-    /**
-     * Calculate item tax percentage.
-     *
-     * @since  1.0
-     * @access private
-     *
-     * @param  WC_Order_Item  $cart_item Cart item.
-     * @param  null|false|\WC_Product $product   Product object.
-     *
-     * @return integer $item_vatRate Item tax percentage formatted for Mollie Orders API.
-     */
-    private function get_item_vatRate($cart_item, $product)
-    {
-        if ($product && $product->is_taxable() && $cart_item['line_subtotal_tax'] > 0) {
-            // Calculate tax rate.
-            $_tax = new WC_Tax();
-            $tmp_rates = $_tax->get_rates($product->get_tax_class());
-            $item_vatRate = 0;
-            foreach ($tmp_rates as $rate) {
-                if (isset($rate['rate'])) {
-                    if ($rate['compound'] === "yes") {
-                        $compoundRate = round($item_vatRate * ($rate['rate'] / 100)) + $rate['rate'];
-                        $item_vatRate += $compoundRate;
-                        continue;
-                    }
-                    $item_vatRate += $rate['rate'];
-                }
-            }
-        } else {
-            $item_vatRate = 0;
-        }
-
-        return $item_vatRate;
     }
 
     /**
@@ -500,22 +449,5 @@ class OrderLines
     private function get_item_total_amount($cart_item)
     {
         return $cart_item['line_total'] + $cart_item['line_tax'];
-    }
-
-    /**
-     * Build price data for Mollie API.
-     *
-     * @param float $wcPrice
-     * @param float $vatRate
-     * @return float[]
-     */
-    private function getMolliePrice(float $wcPrice, float $vatRate): array
-    {
-        $grossPrice = wc_prices_include_tax() ? $wcPrice : $wcPrice * (1 + ($vatRate / 100));
-
-        return [
-            'grossPrice' => $grossPrice,
-            'vatAmount' => $grossPrice * ($vatRate / (100 + $vatRate)),
-        ];
     }
 }

--- a/src/Payment/Request/Middleware/OrderLinesMiddleware.php
+++ b/src/Payment/Request/Middleware/OrderLinesMiddleware.php
@@ -43,17 +43,25 @@ class OrderLinesMiddleware implements RequestMiddlewareInterface
      */
     public function __invoke(array $requestData, WC_Order $order, $context, $next): array
     {
-        $methodId = $requestData['method'] ?? '';
-        $optionName = 'mollie_wc_gateway_' . $methodId . '_settings';
-        $hideOrderLines = get_option($optionName, false)['hide_order_lines'] === 'yes';
-
-        if (!$hideOrderLines) {
-            if ($context === 'payment') {
-                $requestData['lines'] = $this->paymentLines->order_lines($order);
-            } else {
-                $requestData['lines'] = $this->orderLines->order_lines($order);
+        if ($context === 'payment') {
+            $methodId = $requestData['method'] ?? '';
+            $optionName = 'mollie_wc_gateway_' . $methodId . '_settings';
+            $hideOrderLines = get_option($optionName, false)['hide_order_lines'] === 'yes';
+            if ($hideOrderLines) {
+                /**
+                 * Merchant has configured to hide order lines via payment method settings.
+                 */
+                return $next($requestData, $order, $context);
             }
+            $requestData['lines'] = $this->paymentLines->order_lines($order);
+            return $next($requestData, $order, $context);
         }
+
+        /**
+         * lines are required when Orders API is in use.
+         * @see https://docs.mollie.com/reference/create-order
+         */
+        $requestData['lines'] = $this->orderLines->order_lines($order);
         return $next($requestData, $order, $context);
     }
 }

--- a/src/Payment/Request/Middleware/OrderLinesMiddleware.php
+++ b/src/Payment/Request/Middleware/OrderLinesMiddleware.php
@@ -49,12 +49,18 @@ class OrderLinesMiddleware implements RequestMiddlewareInterface
      */
     public function __invoke(array $requestData, WC_Order $order, $context, $next): array
     {
-        if ($context === 'payment') {
-            $orderLines = $this->paymentLines->order_lines($order);
-        } else {
-            $orderLines = $this->orderLines->order_lines($order);
+        $methodId = $requestData['method'] ?? '';
+        $optionName = 'mollie_wc_gateway_' . $methodId . '_settings';
+        $hideOrderLines = get_option($optionName, false)['hide_order_lines'] === 'yes';
+
+        if (!$hideOrderLines) {
+            if ($context === 'payment') {
+                $orderLines = $this->paymentLines->order_lines($order);
+            } else {
+                $orderLines = $this->orderLines->order_lines($order);
+            }
+            $requestData['lines'] = $orderLines['lines'];
         }
-        $requestData['lines'] = $orderLines['lines'];
         return $next($requestData, $order, $context);
     }
 }

--- a/src/Payment/Request/Middleware/OrderLinesMiddleware.php
+++ b/src/Payment/Request/Middleware/OrderLinesMiddleware.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\Payment\Request\Middleware;
 
-use Mollie\WooCommerce\Payment\OrderLines;
-use Mollie\WooCommerce\Payment\PaymentLines;
+use Mollie\WooCommerce\Payment\LineItems\LineItemProvider;
 use WC_Order;
 
 /**
@@ -18,21 +17,16 @@ use WC_Order;
 class OrderLinesMiddleware implements RequestMiddlewareInterface
 {
     /**
-     * @var OrderLines The order lines handler.
+     * @var LineItemProvider The order lines handler (Orders API context).
      */
-    private OrderLines $orderLines;
+    private LineItemProvider $orderLines;
 
     /**
-     * @var PaymentLines The payment lines handler.
+     * @var LineItemProvider The payment lines handler (Payments API context).
      */
-    private PaymentLines $paymentLines;
+    private LineItemProvider $paymentLines;
 
-    /**
-     * OrderLinesMiddleware constructor.
-     *
-     * @param OrderLines $orderLines The order lines handler.
-     */
-    public function __construct(OrderLines $orderLines, PaymentLines $paymentLines)
+    public function __construct(LineItemProvider $orderLines, LineItemProvider $paymentLines)
     {
         $this->orderLines = $orderLines;
         $this->paymentLines = $paymentLines;
@@ -55,11 +49,10 @@ class OrderLinesMiddleware implements RequestMiddlewareInterface
 
         if (!$hideOrderLines) {
             if ($context === 'payment') {
-                $orderLines = $this->paymentLines->order_lines($order);
+                $requestData['lines'] = $this->paymentLines->order_lines($order);
             } else {
-                $orderLines = $this->orderLines->order_lines($order);
+                $requestData['lines'] = $this->orderLines->order_lines($order);
             }
-            $requestData['lines'] = $orderLines['lines'];
         }
         return $next($requestData, $order, $context);
     }

--- a/src/Payment/inc/services.php
+++ b/src/Payment/inc/services.php
@@ -7,9 +7,10 @@ use Mollie\WooCommerce\Payment\MollieObject;
 use Mollie\WooCommerce\Payment\MollieOrder;
 use Mollie\WooCommerce\Payment\MollieOrderService;
 use Mollie\WooCommerce\Payment\MolliePayment;
-use Mollie\WooCommerce\Payment\OrderLines;
+use Mollie\WooCommerce\Payment\LineItems\LineItemProvider;
+use Mollie\WooCommerce\Payment\LineItems\OrderLines;
+use Mollie\WooCommerce\Payment\LineItems\PaymentLines;
 use Mollie\WooCommerce\Payment\PaymentFactory;
-use Mollie\WooCommerce\Payment\PaymentLines;
 use Mollie\WooCommerce\Payment\Request\Middleware\AddCustomRequestFieldsMiddleware;
 use Mollie\WooCommerce\Payment\Request\Middleware\AddressMiddleware;
 use Mollie\WooCommerce\Payment\Request\Middleware\AddSequenceTypeForSubscriptionsMiddleware;
@@ -53,12 +54,12 @@ return static function (): array {
             $requestFactory = $container->get(RequestFactory::class);
             return new MollieObject($data, $logger, $paymentFactory, $apiHelper, $settingsHelper, $pluginId, $requestFactory);
         },
-        OrderLines::class => static function (ContainerInterface $container): OrderLines {
+        OrderLines::class => static function (ContainerInterface $container): LineItemProvider {
             $data = $container->get('settings.data_helper');
             $pluginId = $container->get('shared.plugin_id');
             return new OrderLines($data, $pluginId);
         },
-        PaymentLines::class => static function (ContainerInterface $container): PaymentLines {
+        PaymentLines::class => static function (ContainerInterface $container): LineItemProvider {
             $data = $container->get('settings.data_helper');
             $pluginId = $container->get('shared.plugin_id');
             return new PaymentLines($data, $pluginId);

--- a/src/PaymentMethods/Billie.php
+++ b/src/PaymentMethods/Billie.php
@@ -91,6 +91,16 @@ class Billie extends AbstractPaymentMethod implements PaymentMethodI
         unset($generalFormFields[1]);
         unset($generalFormFields['allowed_countries']);
 
+        /**
+         * This payment method requires line items to be sent
+         *
+         * @see https://docs.mollie.com/reference/create-payment
+         * @see https://docs.mollie.com/reference/create-order
+         */
+        if (isset($generalFormFields['hide_order_lines'])) {
+            unset($generalFormFields['hide_order_lines']);
+        }
+
         return $generalFormFields;
     }
 

--- a/src/PaymentMethods/In3.php
+++ b/src/PaymentMethods/In3.php
@@ -47,6 +47,16 @@ class In3 extends AbstractPaymentMethod implements PaymentMethodI
 
     public function getFormFields($generalFormFields): array
     {
+        /**
+         * This payment method requires line items to be sent
+         *
+         * @see https://docs.mollie.com/reference/create-payment
+         * @see https://docs.mollie.com/reference/create-order
+         */
+        if (isset($generalFormFields['hide_order_lines'])) {
+            unset($generalFormFields['hide_order_lines']);
+        }
+
         return $generalFormFields;
     }
 }

--- a/src/PaymentMethods/Klarna.php
+++ b/src/PaymentMethods/Klarna.php
@@ -40,7 +40,12 @@ class Klarna extends AbstractPaymentMethod implements PaymentMethodI
 
     public function getFormFields($generalFormFields): array
     {
-        // Remove hide_order_lines_settings as Klarna requires order lines
+        /**
+         * This payment method requires line items to be sent
+         *
+         * @see https://docs.mollie.com/reference/create-payment
+         * @see https://docs.mollie.com/reference/create-order
+         */
         if (isset($generalFormFields['hide_order_lines'])) {
             unset($generalFormFields['hide_order_lines']);
         }

--- a/src/PaymentMethods/Klarna.php
+++ b/src/PaymentMethods/Klarna.php
@@ -40,6 +40,11 @@ class Klarna extends AbstractPaymentMethod implements PaymentMethodI
 
     public function getFormFields($generalFormFields): array
     {
+        // Remove hide_order_lines_settings as Klarna requires order lines
+        if (isset($generalFormFields['hide_order_lines'])) {
+            unset($generalFormFields['hide_order_lines']);
+        }
+
         return $generalFormFields;
     }
 }

--- a/src/PaymentMethods/Riverty.php
+++ b/src/PaymentMethods/Riverty.php
@@ -49,6 +49,16 @@ class Riverty extends AbstractPaymentMethod implements PaymentMethodI
 
     public function getFormFields($generalFormFields): array
     {
+        /**
+         * This payment method requires line items to be sent
+         *
+         * @see https://docs.mollie.com/reference/create-payment
+         * @see https://docs.mollie.com/reference/create-order
+         */
+        if (isset($generalFormFields['hide_order_lines'])) {
+            unset($generalFormFields['hide_order_lines']);
+        }
+
         return $generalFormFields;
     }
 }

--- a/src/PaymentMethods/Voucher.php
+++ b/src/PaymentMethods/Voucher.php
@@ -134,6 +134,17 @@ class Voucher extends AbstractPaymentMethod implements PaymentMethodI
                 'description' => __('In order to process it, all products in the order must have a category. This selector will assign the default categories for the shop products. If orders API is active only the first category will be used!', 'mollie-payments-for-woocommerce'),
             ],
         ];
+
+        /**
+         * This payment method requires line items to be sent
+         *
+         * @see https://docs.mollie.com/reference/create-payment
+         * @see https://docs.mollie.com/reference/create-order
+         */
+        if (isset($generalFormFields['hide_order_lines'])) {
+            unset($generalFormFields['hide_order_lines']);
+        }
+
         return array_merge($generalFormFields, $paymentMethodFormFieds);
     }
 

--- a/src/Settings/General/MollieGeneralSettings.php
+++ b/src/Settings/General/MollieGeneralSettings.php
@@ -2,7 +2,6 @@
 
 namespace Mollie\WooCommerce\Settings\General;
 
-use Mollie\WooCommerce\Gateway\MolliePaymentGatewayHandler;
 use Mollie\WooCommerce\Gateway\Surcharge;
 use Mollie\WooCommerce\Shared\SharedDataDictionary;
 
@@ -11,7 +10,8 @@ class MollieGeneralSettings
     public function gatewayFormFields(
         $defaultTitle,
         $defaultDescription,
-        $paymentConfirmation
+        $paymentConfirmation,
+        bool $isOrderApi = false
     ) {
 
         $formFields = [
@@ -283,9 +283,18 @@ class MollieGeneralSettings
         $formFields['hide_order_lines'] = [
             'title' => __('Hide order lines', 'mollie-payments-for-woocommerce'),
             'label' => __('Do not send order lines to Mollie', 'mollie-payments-for-woocommerce'),
-            'description' => __('Enable this option to prevent order line details from being sent to Mollie. This may be useful for certain payment methods or compliance requirements.', 'mollie-payments-for-woocommerce'),
+            'description' => $isOrderApi
+                ? __(
+                    'Not available when using the Orders API. Order lines are always sent for Orders API payments.',
+                    'mollie-payments-for-woocommerce'
+                )
+                : __(
+                    'Enable this option to prevent order line details from being sent to Mollie. This may be useful for certain payment methods or compliance requirements.',
+                    'mollie-payments-for-woocommerce'
+                ),
             'type' => 'checkbox',
             'default' => 'no',
+            'custom_attributes' => $isOrderApi ? ['disabled' => 'disabled'] : [],
         ];
 
         $formFields['activate_expiry_days_setting'] = [

--- a/src/Settings/General/MollieGeneralSettings.php
+++ b/src/Settings/General/MollieGeneralSettings.php
@@ -31,7 +31,7 @@ class MollieGeneralSettings
             'display' => [
                 'id' => $defaultTitle . '_' . 'title',
                 'title' => sprintf(
-                    /* translators: Placeholder 1: Gateway title */
+                /* translators: Placeholder 1: Gateway title */
                     __('%s display settings', 'mollie-payments-for-woocommerce'),
                     $defaultTitle
                 ),
@@ -279,6 +279,14 @@ class MollieGeneralSettings
                 ),
             ];
         }
+
+        $formFields['hide_order_lines'] = [
+            'title' => __('Hide order lines', 'mollie-payments-for-woocommerce'),
+            'label' => __('Do not send order lines to Mollie', 'mollie-payments-for-woocommerce'),
+            'description' => __('Enable this option to prevent order line details from being sent to Mollie. This may be useful for certain payment methods or compliance requirements.', 'mollie-payments-for-woocommerce'),
+            'type' => 'checkbox',
+            'default' => 'no',
+        ];
 
         $formFields['activate_expiry_days_setting'] = [
             'title' => __('Activate expiry time setting', 'mollie-payments-for-woocommerce'),

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -7,13 +7,11 @@ namespace Mollie\WooCommerce\Settings;
 use DateInterval;
 use DateTime;
 use Mollie\Api\Exceptions\ApiException;
-use Mollie\WooCommerce\Gateway\MolliePaymentGatewayHandler;
 use Mollie\WooCommerce\Gateway\Surcharge;
 use Mollie\WooCommerce\Notice\AdminNotice;
 use Mollie\WooCommerce\Payment\PaymentProcessor;
 use Mollie\WooCommerce\Settings\General\MollieGeneralSettings;
 use Mollie\WooCommerce\Shared\SharedDataDictionary;
-use WC_Payment_Gateway;
 
 class Settings
 {
@@ -63,7 +61,12 @@ class Settings
     ): array {
 
         $generalSettings = new MollieGeneralSettings();
-        return $generalSettings->gatewayFormFields($defaultTitle, $defaultDescription, $paymentConfirmation);
+        return $generalSettings->gatewayFormFields(
+            $defaultTitle,
+            $defaultDescription,
+            $paymentConfirmation,
+            $this->isOrderApiSetting()
+        );
     }
 
     public function processSettings(string $gatewayId)
@@ -162,7 +165,7 @@ class Settings
      */
     public function isOrderApiSetting()
     {
-        $orderApiSetting = get_option($this->getSettingId('api_switch'));
+        $orderApiSetting = get_option($this->getSettingId('api_switch'), PaymentProcessor::PAYMENT_METHOD_TYPE_PAYMENT);
         return !$orderApiSetting || is_string($orderApiSetting) && trim($orderApiSetting) === PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER;
     }
     /**

--- a/tests/php/Functional/HelperMocks.php
+++ b/tests/php/Functional/HelperMocks.php
@@ -14,7 +14,7 @@ use Mollie\WooCommerce\Payment\MolliePayment;
 use Mollie\WooCommerce\Payment\Request\RequestFactory;
 use Mollie\WooCommerce\PaymentMethods\InstructionStrategies\OrderInstructionsManager;
 use Mollie\WooCommerce\Gateway\Refund\OrderItemsRefunder;
-use Mollie\WooCommerce\Payment\OrderLines;
+use Mollie\WooCommerce\Payment\LineItems\OrderLines;
 use Mollie\WooCommerce\Payment\MollieObject;
 use Mollie\WooCommerce\Payment\PaymentFactory;
 use Mollie\WooCommerce\Payment\PaymentProcessor;

--- a/tests/php/Functional/Payment/OrderRequestStrategyTest.php
+++ b/tests/php/Functional/Payment/OrderRequestStrategyTest.php
@@ -5,7 +5,7 @@ namespace Mollie\WooCommerceTests\Functional\Payment;
 
 use Mockery;
 use Mollie\Api\MollieApiClient;
-use Mollie\WooCommerce\Payment\OrderLines;
+use Mollie\WooCommerce\Payment\LineItems\OrderLines;
 use Mollie\WooCommerce\Payment\Request\Middleware\MiddlewareHandler;
 use Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware;
 use Mollie\WooCommerce\Payment\Request\Strategies\OrderRequestStrategy;


### PR DESCRIPTION
This PR adds a setting so that merchant can hide the order lines when it's Payments API. This API does not need the order lines, only is required in Klarna. 
So in the middleware, whenever that setting is true, we bail the line creation