### PR TITLE
[QA] Add Bizum payment method to surcharge tests

### DIFF
--- a/tests/qa/package.json
+++ b/tests/qa/package.json
@@ -53,6 +53,8 @@
     "setup:tax:inc": "npx playwright test --grep=\"setup:tax:inc;\"",
     "setup:tax:exc": "npx playwright test --grep=\"setup:tax:exc;\"",
     "setup:mollie:germany": "npx playwright test --grep \"setup:mollie:germany;\"",
+    "setup:bizum": "npx playwright test --grep=\"setup:bizum;\"",
+"test:bizum": "npm run setup:bizum && npx playwright test tests/03-plugin-settings/surcharge/surcharge.spec.ts --grep \"bizum\"", 
     "test:all": "npx playwright test --project=all --workers=1",
     "test:critical": "npx playwright test --project=all --workers=1 --grep \"@Critical\"",
     "test:refund": "npx playwright test --project=refund --workers=4",

--- a/tests/qa/resources/gateways.ts
+++ b/tests/qa/resources/gateways.ts
@@ -152,6 +152,20 @@ const blik: MollieGateway = {
 		title: 'Blik',
 	},
 };
+const bizum: MollieGateway = {
+	country: 'spain', // Spain and Andorra
+	currency: 'EUR',
+	minAmount: '0.01',
+	maxAmount: '1000.00',
+	slug: 'bizum',
+	name: 'Bizum',
+	availableForApiMethods: [ 'payment' ],
+	settings: {
+		...defaultGatewaySettings,
+		id: 'mollie_wc_gateway_bizum',
+		title: 'Bizum',
+	},
+};
 
 const creditcard: MollieGateway = {
 	country: 'germany', // Global availability
@@ -532,6 +546,7 @@ export const gateways: {
 	belfius,
 	billie, // >100.00
 	blik, // currency: PLN
+	bizum,
 	creditcard,
 	directdebit,
 	eps,

--- a/tests/qa/resources/index.ts
+++ b/tests/qa/resources/index.ts
@@ -23,3 +23,4 @@ export { default as subscriptionsPlugin } from './woocommerce-subscriptions-plug
 export { default as disableWcSetupWizard } from './disable-wc-setup-wizard-plugin.json';
 export { default as disableGutenbergWelcomeGuide } from './disable-gutenberg-welcome-guide-plugin.json';
 export { default as featureFlagsPlugin } from './feature-flags-plugin';
+export { default as enableBizumPlugin } from './enable-bizum-plugin';

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-and-percentage-over-limit.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-and-percentage-over-limit.ts
@@ -50,5 +50,6 @@ export const surchargeFixedAndPercentageOverLimit: MollieTestData.SurchargeTests
 				gateway: 'swish',
 				expectedFeeText: '+ kr 10 + 10% fee might apply (excl. VAT)',
 			},
+			{ testId: 'C4257954', gateway: 'bizum' },
 		],
 	};

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-and-percentage-under-limit.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-and-percentage-under-limit.ts
@@ -50,5 +50,6 @@ export const surchargeFixedAndPercentageUnderLimit: MollieTestData.SurchargeTest
 				gateway: 'swish',
 				expectedFeeText: '+ kr 10 + 10% fee might apply (excl. VAT)',
 			},
+			{ testId: 'C4257953', gateway: 'bizum' },
 		],
 	};

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-and-percentage.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-and-percentage.ts
@@ -48,5 +48,6 @@ export const surchargeFixedAndPercentage: MollieTestData.SurchargeTestsGroup = {
 			gateway: 'swish',
 			expectedFeeText: '+ kr 10 + 10% fee might apply (excl. VAT)',
 		},
+		{ testId: 'C4257952', gateway: 'bizum' },
 	],
 };

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-over-limit.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-over-limit.ts
@@ -47,6 +47,8 @@ export const surchargeFixedOverLimit: MollieTestData.SurchargeTestsGroup = {
 			testId: 'C4237549',
 			gateway: 'swish',
 			expectedFeeText: '+ kr 10 fee might apply (excl. VAT)',
+			
 		},
+		{ testId: 'C4257948', gateway: 'bizum' },
 	],
 };

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-under-limit.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed-under-limit.ts
@@ -48,5 +48,6 @@ export const surchargeFixedUnderLimit: MollieTestData.SurchargeTestsGroup = {
 			gateway: 'swish',
 			expectedFeeText: '+ kr 10 fee might apply (excl. VAT)',
 		},
+		{ testId: 'C4257947', gateway: 'bizum' },
 	],
 };

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-fixed.ts
@@ -46,7 +46,9 @@ export const surchargeFixed: MollieTestData.SurchargeTestsGroup = {
 		{
 			testId: 'C4237551',
 			gateway: 'swish',
+			
 			expectedFeeText: '+ kr 10 fee might apply (excl. VAT)',
 		},
+		{ testId: 'C4257946', gateway: 'bizum' },
 	],
 };

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-percentage-over-limit.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-percentage-over-limit.ts
@@ -41,5 +41,6 @@ export const surchargePercentageOverLimit: MollieTestData.SurchargeTestsGroup =
 			{ testId: 'C4237528', gateway: 'mbway' },
 			{ testId: 'C4237519', gateway: 'multibanco' },
 			{ testId: 'C4237546', gateway: 'swish' },
+			{ testId: 'C4257951', gateway: 'bizum' },
 		],
 	};

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-percentage-under-limit.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-percentage-under-limit.ts
@@ -42,5 +42,6 @@ export const surchargePercentageUnderLimit: MollieTestData.SurchargeTestsGroup =
 			{ testId: 'C4237527', gateway: 'mbway' },
 			{ testId: 'C4237518', gateway: 'multibanco' },
 			{ testId: 'C4237547', gateway: 'swish' },
+			{ testId: 'C4257950', gateway: 'bizum' },
 		],
 	};

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-percentage.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-fee-percentage.ts
@@ -40,5 +40,6 @@ export const surchargePercentage: MollieTestData.SurchargeTestsGroup = {
 		{ testId: 'C4237526', gateway: 'mbway' },
 		{ testId: 'C4237517', gateway: 'multibanco' },
 		{ testId: 'C4237548', gateway: 'swish' },
+		{ testId: 'C4257949', gateway: 'bizum' },
 	],
 };

--- a/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-no-fee.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/_test-data/data-surcharge-no-fee.ts
@@ -40,5 +40,6 @@ export const surchargeNoFee: MollieTestData.SurchargeTestsGroup = {
 		{ testId: 'C4237522', gateway: 'mbway' },
 		{ testId: 'C4237513', gateway: 'multibanco' },
 		{ testId: 'C4237552', gateway: 'swish' },
+		{ testId: 'C4257945', gateway: 'bizum' },
 	],
 };

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
@@ -708,4 +708,36 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 			status: 'expired',
 		},
 	},
+	{
+                ...baseOrder,
+                testId: 'C4257955',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'paid',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257956',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'failed',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257957',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'canceled',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257958',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'expired',
+                },
+        },
 ];

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
@@ -706,4 +706,36 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 			status: 'expired',
 		},
 	},
+	{
+                ...baseOrder,
+                testId: 'C4257959',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'paid',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257960',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'failed',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257961',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'canceled',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257962',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'expired',
+                },
+        },
 ];

--- a/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
@@ -706,4 +706,36 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 			status: 'expired',
 		},
 	},
+	{
+                ...baseOrder,
+                testId: 'C4257963',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'paid',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257964',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'failed',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257965',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'canceled',
+                },
+        },
+        {
+                ...baseOrder,
+                testId: 'C4257966',
+                payment: {
+                        gateway: gateways.bizum,
+                        status: 'expired',
+                },
+        },
 ];

--- a/tests/qa/tests/_setup/mollie.setup.ts
+++ b/tests/qa/tests/_setup/mollie.setup.ts
@@ -8,6 +8,7 @@ import {
 	MollieSettings,
 	ShopConfig,
 	shopSettings,
+	enableBizumPlugin,
 } from '../../resources';
 
 type EnvConfig = {
@@ -84,4 +85,7 @@ configureEnv( {
 		cleanDb: true,
 		apiKeys: mollieApiKeys.default,
 	},
+} );
+setup( 'setup:bizum; Activate Bizum feature flag', async ( { utils } ) => {
+    await utils.installAndActivateBizum();
 } );

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+/**
+ * External dependencies
+ */
 import { Locator } from '@playwright/test';
 import {
 	expect,
@@ -54,7 +57,7 @@ export class Checkout extends CheckoutBase {
 	mobilepayPhoneInput = () =>
 		this.page.locator( '#billing-phone-mollie_wc_gateway_mobilepay' );
 	bizumPhoneInput = () =>
-    this.page.locator( '#billing-phone-mollie_wc_gateway_bizum' );
+		this.page.locator( '#billing-phone-mollie_wc_gateway_bizum' );
 	paymentOptionLabel = ( slug ) =>
 		this.paymentOptionsContainer().locator(
 			`label[for="radio-control-wc-payment-method-options-mollie_wc_gateway_${ slug }"]`
@@ -218,13 +221,13 @@ export class Checkout extends CheckoutBase {
 			await phoneInput.fill( customer.billing.phone );
 		}
 		if ( gateway.slug === 'bizum' ) {
-    const phoneInput = this.bizumPhoneInput();
-    await expect(
-        phoneInput,
-        'Assert bizum phone input is visible'
-    ).toBeVisible();
-    await phoneInput.fill( '+34612345678' );
-}
+			const phoneInput = this.bizumPhoneInput();
+			await expect(
+				phoneInput,
+				'Assert bizum phone input is visible'
+			).toBeVisible();
+			await phoneInput.fill( '+34612345678' );
+		}
 	};
 
 	/**
@@ -293,7 +296,10 @@ export class Checkout extends CheckoutBase {
 		await this.page.waitForLoadState();
 
 		// Terms and conditions checkbox was removed (found on 04.12.2025)
-		await expect( this.termsAndConditionsCheckbox(), 'Assert terms and conditions checkbox is visible' ).toBeVisible();
+		await expect(
+			this.termsAndConditionsCheckbox(),
+			'Assert terms and conditions checkbox is visible'
+		).toBeVisible();
 		await this.termsAndConditionsCheckbox().check();
 
 		await this.placeOrder();

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -53,6 +53,8 @@ export class Checkout extends CheckoutBase {
 		this.page.locator( '#billing-phone-mollie_wc_gateway_vipps' );
 	mobilepayPhoneInput = () =>
 		this.page.locator( '#billing-phone-mollie_wc_gateway_mobilepay' );
+	bizumPhoneInput = () =>
+    this.page.locator( '#billing-phone-mollie_wc_gateway_bizum' );
 	paymentOptionLabel = ( slug ) =>
 		this.paymentOptionsContainer().locator(
 			`label[for="radio-control-wc-payment-method-options-mollie_wc_gateway_${ slug }"]`
@@ -215,6 +217,14 @@ export class Checkout extends CheckoutBase {
 			).toBeVisible();
 			await phoneInput.fill( customer.billing.phone );
 		}
+		if ( gateway.slug === 'bizum' ) {
+    const phoneInput = this.bizumPhoneInput();
+    await expect(
+        phoneInput,
+        'Assert bizum phone input is visible'
+    ).toBeVisible();
+    await phoneInput.fill( '+34612345678' );
+}
 	};
 
 	/**

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-/**
- * External dependencies
- */
 import { Locator } from '@playwright/test';
 import {
 	expect,

--- a/tests/qa/utils/frontend/classic-checkout.ts
+++ b/tests/qa/utils/frontend/classic-checkout.ts
@@ -48,6 +48,7 @@ export class ClassicCheckout extends ClassicCheckoutBase {
 	rivertyPhoneInput = () => this.page.locator( '#billing_phone_riverty' );
 	vippsPhoneInput = () => this.page.locator( '#billing_phone_vipps' );
 	mobilepayPhoneInput = () => this.page.locator( '#billing_phone_mobilepay' );
+	bizumPhoneInput = () => this.page.locator( '#billing_phone_bizum' );
 	paymentOptionListitems = (): Locator =>
 		this.paymentOptionsContainer().locator( 'li' );
 	paymentOptionFee = ( name: string ): Locator =>
@@ -215,6 +216,14 @@ export class ClassicCheckout extends ClassicCheckoutBase {
 			).toBeVisible();
 			await phoneInput.fill( customer.billing.phone );
 		}
+		if ( gateway.slug === 'bizum' ) {
+    const phoneInput = this.bizumPhoneInput();
+    await expect(
+        phoneInput,
+        'Assert bizum phone input is visible'
+    ).toBeVisible();
+    await phoneInput.fill( '+34612345678' );
+}
 	};
 
 	/**

--- a/tests/qa/utils/frontend/classic-checkout.ts
+++ b/tests/qa/utils/frontend/classic-checkout.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+/**
+ * External dependencies
+ */
 import { Locator } from '@playwright/test';
 import {
 	expect,
@@ -217,13 +220,13 @@ export class ClassicCheckout extends ClassicCheckoutBase {
 			await phoneInput.fill( customer.billing.phone );
 		}
 		if ( gateway.slug === 'bizum' ) {
-    const phoneInput = this.bizumPhoneInput();
-    await expect(
-        phoneInput,
-        'Assert bizum phone input is visible'
-    ).toBeVisible();
-    await phoneInput.fill( '+34612345678' );
-}
+			const phoneInput = this.bizumPhoneInput();
+			await expect(
+				phoneInput,
+				'Assert bizum phone input is visible'
+			).toBeVisible();
+			await phoneInput.fill( '+34612345678' );
+		}
 	};
 
 	/**

--- a/tests/qa/utils/frontend/classic-checkout.ts
+++ b/tests/qa/utils/frontend/classic-checkout.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-/**
- * External dependencies
- */
 import { Locator } from '@playwright/test';
 import {
 	expect,

--- a/tests/qa/utils/frontend/mollie-hosted-checkout.ts
+++ b/tests/qa/utils/frontend/mollie-hosted-checkout.ts
@@ -45,6 +45,7 @@ export class MollieHostedCheckout extends WpPage {
 			.locator( '#verificationCode' );
 	payButton = () => this.page.locator( '#submit-button' );
 	continueButton = () => this.page.locator( 'button[name="submit"]' );
+	
 
 	// Actions
 
@@ -78,6 +79,7 @@ export class MollieHostedCheckout extends WpPage {
 		await this.payButton().click();
 		await this.page.waitForLoadState();
 	};
+	
 
 	payForOrder = async ( payment: MolliePayment ) => {
 		await this.assertPaymentAmount( payment.amount );
@@ -99,6 +101,7 @@ export class MollieHostedCheckout extends WpPage {
 		) {
 			await this.payWithCard( payment.card );
 		}
+		
 
 		await this.page.waitForURL( this.testModeUrlRegex );
 		await this.paymentStatusRadio( payment.status ).click();

--- a/tests/qa/utils/frontend/pay-for-order.ts
+++ b/tests/qa/utils/frontend/pay-for-order.ts
@@ -1,6 +1,9 @@
 /**
  * External dependencies
  */
+/**
+ * External dependencies
+ */
 import {
 	expect,
 	PayForOrder as PayForOrderBase,
@@ -202,13 +205,13 @@ export class PayForOrder extends PayForOrderBase {
 			await phoneInput.fill( customer.billing.phone );
 		}
 		if ( gateway.slug === 'bizum' ) {
-    const phoneInput = this.bizumPhoneInput();
-    await expect(
-        phoneInput,
-        'Assert bizum phone input is visible'
-    ).toBeVisible();
-    await phoneInput.fill( '+34612345678' );
-}
+			const phoneInput = this.bizumPhoneInput();
+			await expect(
+				phoneInput,
+				'Assert bizum phone input is visible'
+			).toBeVisible();
+			await phoneInput.fill( '+34612345678' );
+		}
 
 		await this.payForOrderButton().click();
 	};

--- a/tests/qa/utils/frontend/pay-for-order.ts
+++ b/tests/qa/utils/frontend/pay-for-order.ts
@@ -49,6 +49,7 @@ export class PayForOrder extends PayForOrderBase {
 	rivertyPhoneInput = () => this.page.locator( '#billing_phone_riverty' );
 	vippsPhoneInput = () => this.page.locator( '#billing_phone_vipps' );
 	mobilepayPhoneInput = () => this.page.locator( '#billing_phone_mobilepay' );
+	bizumPhoneInput = () => this.page.locator( '#billing_phone_bizum' );
 
 	// Actions
 
@@ -200,6 +201,14 @@ export class PayForOrder extends PayForOrderBase {
 			).toBeVisible();
 			await phoneInput.fill( customer.billing.phone );
 		}
+		if ( gateway.slug === 'bizum' ) {
+    const phoneInput = this.bizumPhoneInput();
+    await expect(
+        phoneInput,
+        'Assert bizum phone input is visible'
+    ).toBeVisible();
+    await phoneInput.fill( '+34612345678' );
+}
 
 		await this.payForOrderButton().click();
 	};

--- a/tests/qa/utils/frontend/pay-for-order.ts
+++ b/tests/qa/utils/frontend/pay-for-order.ts
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-/**
- * External dependencies
- */
 import {
 	expect,
 	PayForOrder as PayForOrderBase,

--- a/tests/qa/utils/utils.ts
+++ b/tests/qa/utils/utils.ts
@@ -8,6 +8,7 @@ import {
 	WooCommerceUtils,
 	restLogin,
 } from '@inpsyde/playwright-utils/build';
+import path from 'path';
 /**
  * Internal dependencies
  */
@@ -20,6 +21,7 @@ import {
 import {
 	MollieSettings,
 	molliePlugin,
+	enableBizumPlugin,
 	mollieApiKeys,
 	subscriptionsPlugin,
 	ShopConfig,
@@ -70,6 +72,16 @@ export class Utils {
 		}
 		await this.requestUtils.activatePlugin( molliePlugin.slug );
 	};
+	installAndActivateBizum = async () => {
+	if (
+		! ( await this.requestUtils.isPluginInstalled( enableBizumPlugin.slug ) )
+	) {
+		await this.plugins.installPluginFromFile(
+			path.resolve( __dirname, '../resources/files/enable-bizum.zip' )
+		);
+	}
+	await this.requestUtils.activatePlugin( 'enable-bizum' );
+};
 
 	/**
 	 * Resets and reconnects Mollie:


### PR DESCRIPTION
## Changes Made

### 1. Gateway Configuration
- Added Bizum gateway definition in `gateways.ts`
  - Country: Spain/Andorra
  - Currency: EUR
  - Available for Payment API

### 2. Surcharge Test Data (10 files)
Added Bizum test cases to all surcharge types:
- ✅ No fee (C4257945)
- ✅ Fixed fee (C4257946)
- ✅ Fixed under limit (C4257947)
- ✅ Fixed over limit (C4257948)
- ✅ Percentage (C4257949)
- ✅ Percentage under limit (C4257950)
- ✅ Percentage over limit (C4257951)
- ✅ Fixed and percentage (C4257952)
- ✅ Fixed and percentage under limit (C4257953)
- ✅ Fixed and percentage over limit (C4257954)

### 3. Transaction Test Data (3 files)
- ✅ Classic checkout: paid, failed, canceled, expired (C4257955–C4257958)
- ✅ Block checkout: paid, failed, canceled, expired (C4257959–C4257962)
- ✅ Pay for order: paid, failed, canceled, expired (C4257963–C4257966)

### 4. Bizum Feature Flag Activation
- Added `enable-bizum-plugin.ts` in resources
- Added `installAndActivateBizum()` method in `utils.ts`
- Added `setup:bizum` step in `mollie.setup.ts`

### 5. Checkout Support
- Added `bizumPhoneInput` locator and handling in `checkout.ts`
- Added `bizumPhoneInput` locator and handling in `classic-checkout.ts`
- Added `bizumPhoneInput` locator and handling in `pay-for-order.ts`

### 6. NPM Scripts
- `npm run setup:bizum` — activates Bizum feature flag
- `npm run test:bizum` — activates Bizum + runs all Bizum surcharge tests

## Known Issues
- `expired` status redirects to `order-pay` instead of `test-mode/completed` — already reported, not Bizum-specific (same behavior for iDEAL)

## Testing
- All 10 Bizum surcharge tests passing ✅
- Bizum transaction tests passing for paid/failed/canceled ✅
- No conflicts with existing test suite ✅