### PR TITLE
[PIWOO-849] - Improve type checking and add null/array annotations in ManualCapture::enableOrderCaptureButton

### DIFF
--- a/src/MerchantCapture/Capture/Type/ManualCapture.php
+++ b/src/MerchantCapture/Capture/Type/ManualCapture.php
@@ -24,11 +24,29 @@ class ManualCapture
         add_filter('woocommerce_mollie_wc_gateway_creditcard_args', [$this, 'sendManualCaptureMode']);
     }
 
-    public function enableOrderCaptureButton(array $actions, \WC_Order $order): array
+    /**
+     * @param ?array $actions
+     * @param ?\WC_Order $order
+     * @return array|mixed
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     * @psalm-suppress PossiblyNullArgument
+     * @psalm-suppress MissingParamType
+     */
+    public function enableOrderCaptureButton($actions, $order)
     {
+        if (!is_array($actions)) {
+            return [];
+        }
+
+        if (!$order instanceof \WC_Order) {
+            return $actions;
+        }
+
         if (!$this->container->get('merchant.manual_capture.can_capture_the_order')($order)) {
             return $actions;
         }
+
         $actions[self::MOLLIE_MANUAL_CAPTURE_ACTION] = __(
             'Capture authorized Mollie payment',
             'mollie-payments-for-woocommerce'


### PR DESCRIPTION
# Problem outline

A fatal TypeError occurs when AutomateWoo applies the woocommerce_order_actions filter while Mollie's Manual Capture functionality is active.

**Root Cause:** AutomateWoo passes null as the second parameter when applying the woocommerce_order_actions filter:

```php

$actions = (array) apply_filters(
    'woocommerce_order_actions',
    [
        'regenerate_download_permissions' => __( 'Generate download permissions', 'automatewoo' ),
    ],
    null  // ← Passes null instead of WC_Order object
);
```

While WooCommerce core allows `null` for this filter, Mollie's `ManualCapture::enableOrderCaptureButton()` method in `/src/MerchantCapture/Capture/Type/ManualCapture.php` has a strict type requirement for `WC_Order`, causing the fatal error when receiving `null`.

**Error Details:**
```
Uncaught TypeError: Mollie\WooCommerce\MerchantCapture\Capture\Type\ManualCapture::enableOrderCaptureButton(): 
Argument #2 ($order) must be of type WC_Order, null given
```

## Acceptance Criteria:

ManualCapture::enableOrderCaptureButton() handles null order parameter gracefully

No fatal errors occur when AutomateWoo applies the filter

Manual capture functionality remains intact when valid WC_Order is provided

Solution maintains compatibility with WooCommerce core filter behavior

**Solution:** Add null-check or make the $order parameter nullable in ManualCapture::enableOrderCaptureButton() method signature and implementation.