### PR TITLE
Show SEPA DD failure reasons in WooCommerce order notes

### DIFF
--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -683,7 +683,9 @@ class MollieObject
         );
 
         //check if there is a reason for failed payment and print it to order note
-        $failureReason = $payment->details->failureReason ?? '';
+        // CC payments use failureReason/failureMessage; SEPA DD uses bankReasonCode/bankReason
+        $failureReason = $payment->details->failureReason ?? $payment->details->bankReasonCode ?? '';
+        $failureMessage = $payment->details->failureMessage ?? $payment->details->bankReason ?? '';
         if ($failureReason) {
             $orderNote = sprintf(
             /* translators: Placeholder 1: payment method title, placeholder 2: payment ID, placeholder 3: failure reason, placeholder 4: failure message */
@@ -694,7 +696,7 @@ class MollieObject
                 $paymentMethodTitle,
                 $paymentID,
                 $failureReason,
-                $payment->details->failureMessage ?? ''
+                $failureMessage
             );
         }
 

--- a/src/Payment/Webhooks/WebhookHandler.php
+++ b/src/Payment/Webhooks/WebhookHandler.php
@@ -346,10 +346,11 @@ class WebhookHandler
             $payment
         );
 
-        if (isset($payment->details->failureReason)) {
+        $loggedReason = $payment->details->failureReason ?? $payment->details->bankReasonCode ?? null;
+        if ($loggedReason) {
             $this->logger->debug(
                 __METHOD__ . ' called for order ' . $orderId . ' and payment ' . $payment->id
-                . ', regular payment failed because of ' . esc_attr($payment->details->failureReason) . '.'
+                . ', regular payment failed because of ' . esc_attr($loggedReason) . '.'
             );
         } else {
             $this->logger->debug(


### PR DESCRIPTION
The Mollie API uses different field names per payment method:
- CC:      details.failureReason / details.failureMessage
- SEPA DD: details.bankReasonCode / details.bankReason

The failure-note logic only checked CC fields, so SEPA DD renewals always fell back to the generic "payment failed" note with no reason. Fall back to the SEPA DD fields when the CC fields are absent.