### PR TITLE
Replace old documentation link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -163,7 +163,7 @@ Yes, you can with a separate plugin. At the moment we have tested and can recomm
 
 = Why do orders with payment method BankTransfer and Direct Debit get the status 'on-hold'? =
 
-These payment methods take longer than a few hours to complete. The order status is set to 'on-hold' to prevent the WooCommerce setting 'Hold stock (minutes)' (https://docs.woothemes.com/document/configuring-woocommerce-settings/#inventory-options) will
+These payment methods take longer than a few hours to complete. The order status is set to 'on-hold' to prevent the WooCommerce setting 'Hold stock (minutes)' (https://woocommerce.com/document/configuring-woocommerce-settings/products/#inventory) will
 cancel the order. The order stock is also reduced to reserve stock for these orders. The stock is restored if the payment fails or is cancelled. You can change the initial order status for these payment methods on their setting page.
 
 = I have a different question about this plugin =


### PR DESCRIPTION
### Description
Replaces a broken link to the WooThemes documentation with the current WooCommerce URL.

### Changes
- `readme.txt`, line 166: Updated link from `https://docs.woothemes.com/document/configuring-woocommerce-settings/#inventory-options` to `https://woocommerce.com/document/configuring-woocommerce-settings/products/#inventory`

### Reason
The previous link points to the retired WooThemes domain and is redirected to the wrong location. The new link directs to the official WooCommerce documentation at the correct current URL.
