### PR TITLE
[8.1.5 hotfix] Refactor PayPalExpressButton bootstrap

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -70,7 +70,13 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
                 'mollie_wc_gateway_' . Constants::KLARNASLICEIT,
             ];
             foreach ($gateways as $key => $gateway) {
-                if (mollieWooCommerceIsMollieGateway($gateway) && in_array($gateway->id, $orderMandatoryPaymentMethods, true)) {
+                if (
+                    mollieWooCommerceIsMollieGateway($gateway) && in_array(
+                        $gateway->id,
+                        $orderMandatoryPaymentMethods,
+                        true
+                    )
+                ) {
                     unset($gateways[$key]);
                 }
             }
@@ -148,7 +154,9 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         assert($surchargeService instanceof Surcharge);
         $this->gatewaySurchargeHandling($surchargeService);
 
-        $this->paymentButtonsBootstrap($container);
+        add_action('woocommerce_init', function () use ($container) {
+            $this->paymentButtonsBootstrap($container);
+        });
 
         $maybeDisableVoucher = new MaybeDisableGateway();
         $dataService = $container->get('settings.data_helper');
@@ -188,24 +196,36 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
                 $paymentMethod->updateSettingsWithDefaults($container);
             }
         });
-        add_filter('woocommerce_get_transaction_url', static function ($return_url, $order, \WC_Payment_Gateway $wcGateway) {
-            if ($return_url || strpos($wcGateway->id, 'mollie_wc_gateway_') === false) {
-                return $return_url;
-            }
-            $transactionId = $order->get_transaction_id();
-            $isPaymentApi = substr($transactionId, 0, 3) === 'tr_'  ;
-            $resource = ($transactionId && !$isPaymentApi) ? 'orders' : 'payments';
-            return 'https://my.mollie.com/dashboard/' . $resource . '/' . trim($transactionId) . '?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner';
-        }, 10, 3);
+        add_filter(
+            'woocommerce_get_transaction_url',
+            static function ($return_url, $order, \WC_Payment_Gateway $wcGateway) {
+                if ($return_url || strpos($wcGateway->id, 'mollie_wc_gateway_') === false) {
+                    return $return_url;
+                }
+                $transactionId = $order->get_transaction_id();
+                $isPaymentApi = substr($transactionId, 0, 3) === 'tr_';
+                $resource = ($transactionId && !$isPaymentApi) ? 'orders' : 'payments';
+                return 'https://my.mollie.com/dashboard/' . $resource . '/' . trim(
+                    $transactionId
+                ) . '?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner';
+            },
+            10,
+            3
+        );
 
         add_filter(
             'woocommerce_cancel_unpaid_order',
             static function (bool $createdViaCheckout, \WC_Order $order) use ($container): bool {
-                if (! $createdViaCheckout || ! apply_filters('mollie_payments_for_woocommerce_check_payment_for_unpaid_order_on_cancel_unpaid_order', true)) {
+                if (
+                    !$createdViaCheckout || !apply_filters(
+                        'mollie_payments_for_woocommerce_check_payment_for_unpaid_order_on_cancel_unpaid_order',
+                        true
+                    )
+                ) {
                     return $createdViaCheckout;
                 }
                 $mollieOrderService = $container->get(MollieOrderService::class);
-                return ! $mollieOrderService->checkPaymentForUnpaidOrder($order);
+                return !$mollieOrderService->checkPaymentForUnpaidOrder($order);
             },
             5,
             2
@@ -214,7 +234,12 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         add_action(
             'woocommerce_thankyou',
             static function ($orderId) use ($container) {
-                if (! apply_filters('mollie_payments_for_woocommerce_check_payment_for_unpaid_order_on_woocommerce_thankyou_page', false)) {
+                if (
+                    !apply_filters(
+                        'mollie_payments_for_woocommerce_check_payment_for_unpaid_order_on_woocommerce_thankyou_page',
+                        false
+                    )
+                ) {
                     return;
                 }
                 $order = wc_get_order($orderId);
@@ -232,10 +257,12 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
                 if (!$order instanceof \WC_Order) {
                     return $actions;
                 }
-                if ($order->is_paid() || !$order->has_status('pending') || strpos(
+                if (
+                    $order->is_paid() || !$order->has_status('pending') || strpos(
                         $order->get_payment_method(),
                         'mollie_wc_gateway_'
-                    ) === false) {
+                    ) === false
+                ) {
                     return $actions;
                 }
                 $actions['mollie_wc_check_payment_for_unpaid_order'] = __(
@@ -252,7 +279,12 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
             'woocommerce_order_action_mollie_wc_check_payment_for_unpaid_order',
             static function ($orderId) use ($container) {
                 $order = wc_get_order($orderId);
-                if (! $order || $order->is_paid() || ! $order->has_status('pending') || strpos($order->get_payment_method(), 'mollie_wc_gateway_') === false) {
+                if (
+                    !$order || $order->is_paid() || !$order->has_status('pending') || strpos(
+                        $order->get_payment_method(),
+                        'mollie_wc_gateway_'
+                    ) === false
+                ) {
                     return;
                 }
                 $mollieOrderService = $container->get(MollieOrderService::class);
@@ -263,7 +295,10 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         add_filter(
             'bulk_actions-woocommerce_page_wc-orders',
             static function ($bulk_actions) {
-                $bulk_actions['mollie_wc_check_payment_for_unpaid_order'] = __('Check payment on mollie', 'mollie-payments-for-woocommerce');
+                $bulk_actions['mollie_wc_check_payment_for_unpaid_order'] = __(
+                    'Check payment on mollie',
+                    'mollie-payments-for-woocommerce'
+                );
                 return $bulk_actions;
             }
         );
@@ -277,7 +312,12 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
 
                 foreach ($post_ids as $post_id) {
                     $order = wc_get_order($post_id);
-                    if (! $order || $order->is_paid() || ! $order->has_status('pending') || strpos($order->get_payment_method(), 'mollie_wc_gateway_') === false) {
+                    if (
+                        !$order || $order->is_paid() || !$order->has_status('pending') || strpos(
+                            $order->get_payment_method(),
+                            'mollie_wc_gateway_'
+                        ) === false
+                    ) {
                         continue;
                     }
                     $mollieOrderService = $container->get(MollieOrderService::class);
@@ -352,7 +392,7 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
      */
     public function addShopOrderMetabox(object $post)
     {
-        if (! $post instanceof \WC_Order) {
+        if (!$post instanceof \WC_Order) {
             return;
         }
         $meta = $post->get_meta('_mollie_payment_instructions');
@@ -362,13 +402,20 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         $screen = wc_get_container()->get(CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
             ? wc_get_page_screen_id('shop-order')
             : 'shop_order';
-        add_meta_box('mollie_order_details', __('Mollie Payment Details', 'mollie-payments-for-woocommerce'), static function () use ($meta) {
-            $allowedTags = ['strong' => []];
-            printf(
-                '<p style="border-bottom:solid 1px #eee;padding-bottom:13px;">%s</p>',
-                wp_kses($meta, $allowedTags)
-            );
-        }, $screen, 'side', 'high');
+        add_meta_box(
+            'mollie_order_details',
+            __('Mollie Payment Details', 'mollie-payments-for-woocommerce'),
+            static function () use ($meta) {
+                $allowedTags = ['strong' => []];
+                printf(
+                    '<p style="border-bottom:solid 1px #eee;padding-bottom:13px;">%s</p>',
+                    wp_kses($meta, $allowedTags)
+                );
+            },
+            $screen,
+            'side',
+            'high'
+        );
     }
 
     public function gatewaySurchargeHandling(Surcharge $surcharge)
@@ -402,10 +449,10 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         if (class_exists('WC_Subscription')) {
             // Do not disable if account page is also checkout
             // (workaround for bug in WC), do disable on change payment method page (param)
-            if ((! is_checkout() && is_account_page()) || ! empty($_GET['change_payment_method'])) {
+            if ((!is_checkout() && is_account_page()) || !empty($_GET['change_payment_method'])) {
                 foreach ($available_gateways as $key => $value) {
                     if (strpos($key, 'mollie_') !== false) {
-                        unset($available_gateways[ $key ]);
+                        unset($available_gateways[$key]);
                     }
                 }
             }
@@ -441,6 +488,8 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
      */
     public function paymentButtonsBootstrap(ContainerInterface $container): void
     {
+        $wooCommerceGateways = WC()->payment_gateways()->payment_gateways;
+
         $applePayDirectHandler = $container->get(ApplePayDirectHandler::class);
         if ($applePayDirectHandler instanceof ApplePayDirectHandler) {
             $buttonEnabledCart = mollieWooCommerceIsApplePayDirectEnabled('cart');
@@ -448,6 +497,17 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
             if ($buttonEnabledCart || $buttonEnabledProduct) {
                 $applePayDirectHandler->bootstrap($buttonEnabledProduct, $buttonEnabledCart);
             }
+        }
+
+        if (
+            !count(array_filter($wooCommerceGateways, static function ($gateway) {
+                return $gateway->id === 'mollie_wc_gateway_paypal';
+            }))
+        ) {
+            /**
+             * Only set up PayPalExpressButton if PayPal is available...
+             */
+            return;
         }
 
         $paypalButtonHandler = $container->get(PayPalExpressButton::class);
@@ -483,6 +543,7 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         }
         return $paymentMethods;
     }
+
     /**
      * @param string $id
      * @param IconFactory $iconFactory

--- a/src/Gateway/inc/services.php
+++ b/src/Gateway/inc/services.php
@@ -205,17 +205,26 @@ return static function (): array {
             return new ApplePayDirectHandler($notice, $ajaxRequests);
         },
         PayPalExpressButton::class => static function (ContainerInterface $container): PayPalExpressButton {
+            $wooCommerceGateways = WC()->payment_gateways()->payment_gateways;
+            $matchingPayPalGateway = array_filter($wooCommerceGateways, static function ($gateway) {
+                return $gateway->id === 'mollie_wc_gateway_paypal';
+            });
+            if (!count($matchingPayPalGateway)) {
+                /**
+                 * Bail if PayPal is not available...
+                 */
+                throw new \RuntimeException(
+                    'Mollie PayPal Express Button requires PayPal payment method (Mollie) to be enabled'
+                );
+            }
+            $matchingPayPalGateway = reset($matchingPayPalGateway);
+            assert($matchingPayPalGateway instanceof PaymentGateway);
             $notice = $container->get(AdminNotice::class);
             assert($notice instanceof AdminNotice);
             $logger = $container->get(Logger::class);
             assert($logger instanceof Logger);
-            $paymentGateways = $container->get('payment_gateways');
-            if (!in_array('mollie_wc_gateway_paypal', $paymentGateways)) {
-                return false;
-            }
-            $paypalGateway = new Inpsyde\PaymentGateway\PaymentGateway('mollie_wc_gateway_paypal', $container);
             $pluginUrl = $container->get('shared.plugin_url');
-            $ajaxRequests = new PayPalAjaxRequests($paypalGateway, $notice, $logger);
+            $ajaxRequests = new PayPalAjaxRequests($matchingPayPalGateway, $notice, $logger);
             $data = new DataToPayPal($pluginUrl);
             $enabledInProduct = (mollieWooCommerceIsPayPalButtonEnabled('product'));
             $enabledInCart = (mollieWooCommerceIsPayPalButtonEnabled('cart'));


### PR DESCRIPTION
## Fix: Defer payment buttons bootstrap and guard against missing PayPal gateway

### Problem

On fresh installations — where no API keys have been configured and no payment methods have been enabled yet — the plugin bootstrap was crashing. Two things were going wrong:

1. **Too-early bootstrap**: `paymentButtonsBootstrap()` was called directly during the module's `run()` phase, before WooCommerce had finished initialising its payment gateways. This meant `WC()->payment_gateways()->payment_gateways` could be empty or incomplete, leading to errors when the code tried to resolve gateway-dependent services.

2. **Fragile PayPal gateway resolution**: The `PayPalExpressButton` container service was being constructed by looking up a string key from a `payment_gateways` list, then creating a bare `PaymentGateway` instance by ID. If the PayPal gateway wasn't registered yet (e.g. no API key, no enabled methods), `in_array()` would return `false` and the factory would return `false` — a type that doesn't satisfy the expected `PayPalExpressButton` return type, causing a fatal downstream.

### Fix

- Wraps the `paymentButtonsBootstrap()` call in a `woocommerce_init` action hook, ensuring it only runs once WooCommerce's gateway registry is fully populated.
- Adds an explicit guard in `paymentButtonsBootstrap()` itself: if `mollie_wc_gateway_paypal` is not present in the registered gateways, the method returns early before attempting to bootstrap the PayPal Express Button.
- Replaces the fragile string-based lookup + manual instantiation in the `PayPalExpressButton` container factory with a proper `array_filter` over the live WooCommerce gateway list. If the gateway is missing, a `RuntimeException` is thrown with a descriptive message instead of silently returning a wrong type.
- The `ApplePayDirectHandler` bootstrap is unaffected and continues to run as before; only the PayPal path is guarded.

### Result

Activating the plugin on a fresh site with no credentials or payment methods configured no longer causes a fatal error. The bootstrap degrades gracefully and the PayPal Express Button is simply not initialised until the gateway is actually available.