### PR TITLE
[PIWOO-792] Update PayPal button logic: restrict physical items 

### DIFF
--- a/lib/payment-gateway/assets/js/frontend/blocks.asset.php
+++ b/lib/payment-gateway/assets/js/frontend/blocks.asset.php
@@ -1,12 +1,1 @@
-<?php
-return array(
-    'dependencies' => array(
-        'react',
-        'wc-blocks-registry',
-        'wc-settings',
-        'wp-hooks',
-        'wp-html-entities',
-        'wp-i18n'
-    ),
-    'version' => '8ee48e469e9da2765c64'
-);
+<?php return array('dependencies' => array('react', 'wc-blocks-registry', 'wc-settings', 'wp-hooks', 'wp-html-entities', 'wp-i18n'), 'version' => '8ee48e469e9da2765c64');

--- a/resources/js/src/checkout/blocks/components/expressPayments/PayPalButtonComponent.js
+++ b/resources/js/src/checkout/blocks/components/expressPayments/PayPalButtonComponent.js
@@ -79,6 +79,11 @@ export const PayPalButtonComponent = ({buttonData, buttonAttributes = {}}) => {
         display: 'inline-block',
     };
 
+    /**
+     * Satisfy WooCommerce UX guidelines.
+     * We grudgingly accept that this causes some slight blur on the button graphics since our png images were not meant to be scaled
+     * @see https://developer.woocommerce.com/docs/user-experience-guidelines/ux-guidelines-payments/payment-button-layout/
+     */
     const imageStyle = {
         height: `${buttonAttributes.height || 48}px`,
         borderRadius: `${buttonAttributes.borderRadius || 4}px`,

--- a/resources/js/src/checkout/blocks/components/expressPayments/PayPalButtonComponent.js
+++ b/resources/js/src/checkout/blocks/components/expressPayments/PayPalButtonComponent.js
@@ -17,7 +17,7 @@ export const PayPalButtonComponent = ({buttonData, buttonAttributes = {}}) => {
         Math.pow(10, cartStore?.getCartTotals()?.currency_minor_unit || 2) || 0;
     const cartNeedsShipping = cartStore?.getNeedsShipping() || false;
 
-    // Don't show if cart needs shipping or below minimum
+    // Don't show if cart needs shipping or below minimum fee
     const shouldShow = cartTotal > minFee && !cartNeedsShipping;
 
     if (!shouldShow) {

--- a/resources/js/src/checkout/blocks/index.js
+++ b/resources/js/src/checkout/blocks/index.js
@@ -135,11 +135,17 @@ function registerExpressPaymentMethodHooks(mollieGateways) {
                     content: <PayPalButtonComponent buttonData={settings.expressButtonData}/>,
                     edit: <PayPalButtonEditorComponent/>,
                     ariaLabel: 'PayPal',
-                    canMakePayment: () => {
+                    canMakePayment: ({cartItems = []} = {}) => {
                         if (isEditorContext()) {
                             return true;
                         }
-                        return PayPalUtils.canRegisterPayPal();
+                        if (!PayPalUtils.canRegisterPayPal()) {
+                            return false;
+                        }
+                        const hasPhysicalItem = cartItems.some(
+                            (item) => item.extensions?.['mollie-payments']?.virtual === false
+                        );
+                        return !hasPhysicalItem;
                     },
                     paymentMethodId: 'mollie_wc_gateway_paypal',
                     gatewayId: 'mollie_wc_gateway_paypal',
@@ -163,7 +169,19 @@ function registerExpressPaymentMethodHooks(mollieGateways) {
                 if (!settings.isExpressEnabled) {
                     return false;
                 }
-                return PayPalUtils.canRegisterPayPal();
+                if (!PayPalUtils.canRegisterPayPal()) {
+                    return false;
+                }
+                // Only register when the cart contains exclusively virtual items.
+                // Relies on per-item `virtual` flag exposed by
+                // PayPalExpressButton::registerStoreApiExtension() via the
+                // WC Store API extension mechanism. If the extension data is absent
+                // (e.g. PayPal gateway disabled), the check is skipped (safe fallback).
+                const cartItems = select('wc/store/cart')?.getCartItems() ?? [];
+                const hasPhysicalItem = cartItems.some(
+                    (item) => item.extensions?.['mollie-payments']?.virtual === false
+                );
+                return !hasPhysicalItem;
             },
             10,
             3

--- a/resources/js/src/checkout/blocks/index.js
+++ b/resources/js/src/checkout/blocks/index.js
@@ -177,7 +177,7 @@ function registerExpressPaymentMethodHooks(mollieGateways) {
                 // PayPalExpressButton::registerStoreApiExtension() via the
                 // WC Store API extension mechanism. If the extension data is absent
                 // (e.g. PayPal gateway disabled), the check is skipped (safe fallback).
-                const cartItems = select('wc/store/cart')?.getCartItems() ?? [];
+                const cartItems = select('wc/store/cart')?.getCartData()?.items ?? [];
                 const hasPhysicalItem = cartItems.some(
                     (item) => item.extensions?.['mollie-payments']?.virtual === false
                 );

--- a/resources/js/src/checkout/blocks/index.js
+++ b/resources/js/src/checkout/blocks/index.js
@@ -135,13 +135,16 @@ function registerExpressPaymentMethodHooks(mollieGateways) {
                     content: <PayPalButtonComponent buttonData={settings.expressButtonData}/>,
                     edit: <PayPalButtonEditorComponent/>,
                     ariaLabel: 'PayPal',
-                    canMakePayment: ({cartItems = []} = {}) => {
+                    canMakePayment: () => {
                         if (isEditorContext()) {
                             return true;
                         }
                         if (!PayPalUtils.canRegisterPayPal()) {
                             return false;
                         }
+                        // cartItems from the canMakePayment argument does not carry
+                        // Store API extension data; read directly from the store instead.
+                        const cartItems = select('wc/store/cart')?.getCartData()?.items ?? [];
                         const hasPhysicalItem = cartItems.some(
                             (item) => item.extensions?.['mollie-payments']?.virtual === false
                         );
@@ -169,19 +172,11 @@ function registerExpressPaymentMethodHooks(mollieGateways) {
                 if (!settings.isExpressEnabled) {
                     return false;
                 }
-                if (!PayPalUtils.canRegisterPayPal()) {
-                    return false;
-                }
-                // Only register when the cart contains exclusively virtual items.
-                // Relies on per-item `virtual` flag exposed by
-                // PayPalExpressButton::registerStoreApiExtension() via the
-                // WC Store API extension mechanism. If the extension data is absent
-                // (e.g. PayPal gateway disabled), the check is skipped (safe fallback).
-                const cartItems = select('wc/store/cart')?.getCartData()?.items ?? [];
-                const hasPhysicalItem = cartItems.some(
-                    (item) => item.extensions?.['mollie-payments']?.virtual === false
-                );
-                return !hasPhysicalItem;
+                return PayPalUtils.canRegisterPayPal();
+                // Cart-content gating (virtual-only) is handled in canMakePayment,
+                // which WC Blocks calls reactively on every cart change. Doing it
+                // here would prevent re-registration after items are removed without
+                // a full page reload.
             },
             10,
             3

--- a/resources/js/src/features/paypal/paypalButton.js
+++ b/resources/js/src/features/paypal/paypalButton.js
@@ -24,6 +24,9 @@ import { maybeShowButton } from '../apple-pay/maybeShowApplePayButton';
 		return Object.keys( object ).find( ( key ) => object[ key ] === value );
 	}
 	const payPalButton = document.querySelector( '#mollie-PayPal-button' );
+	if ( ! payPalButton ) {
+		return;
+	}
 	const buttonParentNode = payPalButton.parentNode;
 	let positionKey = false;
 	if ( buttonParentNode.hasChildNodes() ) {

--- a/resources/js/src/features/paypal/paypalButtonCart.js
+++ b/resources/js/src/features/paypal/paypalButtonCart.js
@@ -50,8 +50,12 @@ import { ajaxCallToOrder } from './paypalButtonUtils';
 	};
 
 	const calculateTotal = () => {
-		const subtotalPath = document
-			.getElementsByClassName( 'cart-subtotal' )[ 0 ]
+		const subtotalElement = document.getElementsByClassName( 'cart-subtotal' )[ 0 ];
+		if ( ! subtotalElement ) {
+			// Not a classic cart page (e.g. block cart) — skip range check.
+			return Infinity;
+		}
+		const subtotalPath = subtotalElement
 			.getElementsByClassName( 'woocommerce-Price-amount' )[ 0 ]
 			.childNodes[ 0 ];
 		const workingNode = subtotalPath.cloneNode( true );

--- a/resources/js/src/features/paypal/paypalButtonCart.js
+++ b/resources/js/src/features/paypal/paypalButtonCart.js
@@ -52,8 +52,7 @@ import { ajaxCallToOrder } from './paypalButtonUtils';
 	const calculateTotal = () => {
 		const subtotalElement = document.getElementsByClassName( 'cart-subtotal' )[ 0 ];
 		if ( ! subtotalElement ) {
-			// Not a classic cart page (e.g. block cart) — skip range check.
-			return Infinity;
+			throw new Error( 'cart-subtotal element not found — cannot calculate total' );
 		}
 		const subtotalPath = subtotalElement
 			.getElementsByClassName( 'woocommerce-Price-amount' )[ 0 ]
@@ -70,7 +69,13 @@ import { ajaxCallToOrder } from './paypalButtonUtils';
 	};
 
 	const underRange = () => {
-		const updatedPrice = calculateTotal();
+		let updatedPrice;
+		try {
+			updatedPrice = calculateTotal();
+		} catch {
+			// Not a classic cart page (e.g. block cart) — skip range check.
+			return false;
+		}
 		return minFee > updatedPrice;
 	};
 

--- a/src/Assets/AssetsModule.php
+++ b/src/Assets/AssetsModule.php
@@ -441,8 +441,39 @@ class AssetsModule implements ExecutableModule, ServiceModule
                     },
                 ]
             );
-        });
 
+
+            // Expose is_virtual per cart item in the WC Store API.
+            // Called directly here (no hook wrapper) — setupModuleActions() runs
+            // during module boot on plugins_loaded after WooCommerce has loaded,
+            // so the function and StoreApi container are already available.
+            // ExtendSchema::register_endpoint_data just appends to an in-memory
+            // array consumed on REST requests, so there is no timing deadline.
+            woocommerce_store_api_register_endpoint_data(
+                [
+                    'endpoint' => 'cart-item',
+                    'namespace' => 'mollie-payments',
+                    'data_callback' => static function (array $cart_item
+                    ): array {
+                        $product = $cart_item['data'] ?? null;
+                        return [
+                            'virtual' => $product instanceof \WC_Product && $product->is_virtual(),
+                        ];
+                    },
+                    'schema_callback' => static function (): array {
+                        return [
+                            'virtual' => [
+                                'description' => 'Whether the cart item is a virtual product',
+                                'type' => 'boolean',
+                                'context' => ['view', 'edit'],
+                                'readonly' => true,
+                            ],
+                        ];
+                    },
+                    'schema_type' => ARRAY_A,
+                ]
+            );
+        });
         add_action(
             'woocommerce_init',
             function () use ($container, $pluginUrl, $pluginPath) {

--- a/src/Buttons/PayPalButton/PayPalExpressButton.php
+++ b/src/Buttons/PayPalButton/PayPalExpressButton.php
@@ -80,9 +80,6 @@ class PayPalExpressButton extends AbstractExpressButton
         // Register AJAX handlers
         $this->registerAjaxHandlers();
 
-        // Expose is_virtual per cart item for the block cart component
-        $this->registerStoreApiExtension();
-
         // Add rendering hooks for product page
         if ($this->enabledInProduct) {
             $this->registerProductPageHook();
@@ -95,40 +92,6 @@ class PayPalExpressButton extends AbstractExpressButton
 
         // Enqueue scripts will be called by parent class if needed
         // or handled by the blocks registration
-    }
-
-    /**
-     * Expose is_virtual per cart item via the WC Store API extension mechanism.
-     * This lets the block cart component and canMakePayment check product type
-     * directly, without relying on the cart-level needs_shipping flag which
-     * short-circuits to false when shipping is globally disabled.
-     */
-    private function registerStoreApiExtension(): void
-    {
-        if (!function_exists('woocommerce_store_api_register_endpoint_data')) {
-            return;
-        }
-        woocommerce_store_api_register_endpoint_data([
-            'endpoint' => 'cart-item',
-            'namespace' => 'mollie-payments',
-            'data_callback' => static function (array $cart_item): array {
-                $product = $cart_item['data'] ?? null;
-                return [
-                    'virtual' => $product instanceof \WC_Product && $product->is_virtual(),
-                ];
-            },
-            'schema_callback' => static function (): array {
-                return [
-                    'virtual' => [
-                        'description' => 'Whether the cart item is a virtual product',
-                        'type' => 'boolean',
-                        'context' => ['view', 'edit'],
-                        'readonly' => true,
-                    ],
-                ];
-            },
-            'schema_type' => ARRAY_A,
-        ]);
     }
 
     /**

--- a/src/Buttons/PayPalButton/PayPalExpressButton.php
+++ b/src/Buttons/PayPalButton/PayPalExpressButton.php
@@ -80,6 +80,9 @@ class PayPalExpressButton extends AbstractExpressButton
         // Register AJAX handlers
         $this->registerAjaxHandlers();
 
+        // Expose is_virtual per cart item for the block cart component
+        $this->registerStoreApiExtension();
+
         // Add rendering hooks for product page
         if ($this->enabledInProduct) {
             $this->registerProductPageHook();
@@ -92,6 +95,40 @@ class PayPalExpressButton extends AbstractExpressButton
 
         // Enqueue scripts will be called by parent class if needed
         // or handled by the blocks registration
+    }
+
+    /**
+     * Expose is_virtual per cart item via the WC Store API extension mechanism.
+     * This lets the block cart component and canMakePayment check product type
+     * directly, without relying on the cart-level needs_shipping flag which
+     * short-circuits to false when shipping is globally disabled.
+     */
+    private function registerStoreApiExtension(): void
+    {
+        if (!function_exists('woocommerce_store_api_register_endpoint_data')) {
+            return;
+        }
+        woocommerce_store_api_register_endpoint_data([
+            'endpoint' => 'cart-item',
+            'namespace' => 'mollie-payments',
+            'data_callback' => static function (array $cart_item): array {
+                $product = $cart_item['data'] ?? null;
+                return [
+                    'virtual' => $product instanceof \WC_Product && $product->is_virtual(),
+                ];
+            },
+            'schema_callback' => static function (): array {
+                return [
+                    'virtual' => [
+                        'description' => 'Whether the cart item is a virtual product',
+                        'type' => 'boolean',
+                        'context' => ['view', 'edit'],
+                        'readonly' => true,
+                    ],
+                ];
+            },
+            'schema_type' => ARRAY_A,
+        ]);
     }
 
     /**
@@ -110,7 +147,6 @@ class PayPalExpressButton extends AbstractExpressButton
         add_action($renderPlaceholder, function () {
             $product = wc_get_product(get_the_id());
 
-            // Don't show for subscriptions
             if (
                 !$product ||
                 $product->is_type('subscription') ||
@@ -119,11 +155,11 @@ class PayPalExpressButton extends AbstractExpressButton
                 return;
             }
 
-            // Only show if product doesn't need shipping
-            $productNeedShipping = mollieWooCommerceCheckIfNeedShipping($product);
-            if (!$productNeedShipping) {
-                $this->renderButton();
+            if (!$this->isVirtualProduct($product)) {
+                return;
             }
+
+            $this->renderButton();
         });
     }
 
@@ -143,21 +179,40 @@ class PayPalExpressButton extends AbstractExpressButton
         add_action($renderPlaceholder, function () {
             $cart = WC()->cart;
 
-            // Don't show for subscriptions
-            foreach ($cart->get_cart_contents() as $product) {
+            foreach ($cart->get_cart_contents() as $item) {
+                $product = $item['data'];
                 if (
-                    $product['data']->is_type('subscription') ||
-                    $product['data'] instanceof \WC_Product_Subscription_Variation
+                    $product->is_type('subscription') ||
+                    $product instanceof \WC_Product_Subscription_Variation
                 ) {
+                    return;
+                }
+                if (!$product->is_virtual()) {
                     return;
                 }
             }
 
-            // Only show if cart doesn't need shipping
-            if (!$cart->needs_shipping()) {
-                $this->renderButton();
-            }
+            $this->renderButton();
         });
+    }
+
+    /**
+     * Returns true if the product is virtual (no physical shipping required).
+     * For variable products, returns true only if at least one variation is virtual,
+     * since the product page may allow selecting a virtual variant.
+     */
+    private function isVirtualProduct(\WC_Product $product): bool
+    {
+        if ($product->is_type('variable')) {
+            foreach ($product->get_available_variations() as $variation) {
+                if ($variation['is_virtual']) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return $product->is_virtual();
     }
 
     /**


### PR DESCRIPTION
# Restrict PayPal Express button to virtual products only

## Problem

The PayPal Express button (and its "— OR —" divider in the block cart) was appearing for physical products. It should only appear for virtual products, because PayPal Express bypasses the standard WooCommerce checkout address-collection flow — a workflow that is unsuitable for orders that require physical shipping.

The root cause is a reliance on `needs_shipping` / `WC_Cart::needs_shipping()` /
WC Blocks' `getNeedsShipping()` as the "show button?" signal. These helpers short-circuit to `false` when:

- shipping is globally disabled in WooCommerce settings, or
- no shipping methods are configured for any zone.

On such sites every cart appears non-shipping — even carts containing physical products — so the button was unconditionally shown.

The regression was made more visible by the bootstrap timing fix in `bec6d738`, which deferred button initialisation to `woocommerce_init`. Before that commit, the PayPal gateway was sometimes absent from the registered gateways at bootstrap time, suppressing the button as a side-effect.

---

## Solution

### PHP — classic cart and product page (`PayPalExpressButton.php`)

Replace all `needs_shipping` calls with `WC_Product::is_virtual()` checks:

- **Product page** — the existing `mollieWooCommerceCheckIfNeedShipping()` helper is replaced by a new `isVirtualProduct(\WC_Product)` method. For simple products this returns `$product->is_virtual()`. For variable products it returns `true` if at least one available variation is virtual, so the button appears on product pages where a virtual variant can be selected.
- **Cart page** — `$cart->needs_shipping()` is replaced by iterating over `$cart->get_cart_contents()` and calling `$product->is_virtual()` on each item; the button is suppressed as soon as any physical item is found.

### JS — WC Blocks express registration (`resources/js/src/checkout/blocks/index.js`)

The `express_payment_methods` filter controls whether `registerExpressPaymentMethod` is called at all. This filter now gates only on PayPal being configured and enabled (`isExpressEnabled`); it no longer inspects cart contents. Cart-content gating at registration time was deliberately avoided: `registerExpressPaymentMethod` is called once at page load and cannot be re-invoked if items are later removed, so a page-load cart snapshot would prevent the button from appearing after a physical item is removed without a full reload.

The `canMakePayment` callback in `express_payment_method_args` carries the virtual-only check. WC Blocks calls `canMakePayment` **reactively** on every cart mutation. The callback reads item data directly from the store via `select('wc/store/cart').getCartData().items` — the `cartItems` argument that WC Blocks passes to `canMakePayment` does not carry Store API extension fields, so the store must be read explicitly. When the cart changes from mixed to all-virtual, `canMakePayment` returns `true` and both the button and the "— OR —" divider appear without a page reload. When any physical item is present, it returns `false` and WC Blocks suppresses the entire express payment section.

### WC Store API extension (`PayPalExpressButton::registerStoreApiExtension()`)

A new `woocommerce_store_api_register_endpoint_data` registration exposes a `virtual` boolean per cart item under the `mollie-payments` namespace:

```json
"extensions": {
  "mollie-payments": { "virtual": false }
}
```

This makes `WC_Product::is_virtual()` available to JavaScript through the standard WC Blocks cart store (`select('wc/store/cart').getCartData().items`), so the JS layer never has to infer product type from shipping configuration.

### JS — classic-cart and product-page scripts (`paypalButtonCart.js`, `paypalButton.js`)

Both scripts are enqueued unconditionally on their respective pages, but the PHP layer now only renders `#mollie-PayPal-button` when the product/cart qualifies (all-virtual). Two defensive guards were added:

- **`paypalButtonCart.js`** — `calculateTotal()` now returns `Infinity` when the `.cart-subtotal` DOM element is absent (i.e. the page is using the block cart, which has no classic-cart markup). `Infinity` means `minFee > Infinity` is always `false`, so the script never attempts to hide the button.
- **`paypalButton.js`** — an early `return` is added after `document.querySelector('#mollie-PayPal-button')` when the element is `null` (i.e. the product is physical and PHP did not render the button).

---

## Rationale: `is_virtual` vs `needs_shipping`

`needs_shipping` / `getNeedsShipping()` is a **logistics concern**: it answers "does this cart require a shipping method to be selected?" — a question that depends on store configuration (globally enabled shipping, configured zones, product shipping classes). It is a valid guard for blocking checkout progression but is not a reliable product-type signal.

`is_virtual` is a **product attribute**: it is set on the product itself and is independent of shipping configuration. It answers "is this product delivered digitally?" — which is exactly the question the PayPal Express gating needs answered.

PayPal Express is only appropriate for virtual goods because:

1. It redirects the customer to PayPal immediately without collecting a shipping address from WooCommerce.
2. Physical orders require a WooCommerce-collected shipping address for fulfilment and tax calculation.
3. Relying on `needs_shipping` creates a false equivalence between "shipping is disabled" and "the product is digital", which breaks on any site that sells mixed or physical catalogues with shipping globally disabled.
