### PR TITLE
[PIWOO-862] Apple pay express button is missed on block checkout page

### DIFF
--- a/resources/js/src/features/apple-pay/applepayDirectCart.js
+++ b/resources/js/src/features/apple-pay/applepayDirectCart.js
@@ -16,9 +16,11 @@ import { maybeShowButton } from './maybeShowApplePayButton.js';
 		return;
 	}
 
-	const nonce = document.getElementById(
-		'woocommerce-process-checkout-nonce'
-	).value;
+	const nonceElement = document.getElementById( 'woocommerce-process-checkout-nonce' );
+	if ( ! nonceElement ) {
+		return;
+	}
+	const nonce = nonceElement.value;
 
 	let updatedContactInfo = [];
 	let selectedShippingMethod = [];

--- a/src/Assets/AssetsModule.php
+++ b/src/Assets/AssetsModule.php
@@ -75,6 +75,9 @@ class AssetsModule implements ExecutableModule, ServiceModule
                 $dataToScripts->applePayScriptData()
             );
         }
+        if (mollieWooCommerceIsApplePayDirectEnabled('express_checkout') && is_checkout()) {
+            wp_enqueue_style('mollie-applepaydirect');
+        }
     }
 
     /**

--- a/src/Assets/AssetsModule.php
+++ b/src/Assets/AssetsModule.php
@@ -75,7 +75,7 @@ class AssetsModule implements ExecutableModule, ServiceModule
                 $dataToScripts->applePayScriptData()
             );
         }
-        if (mollieWooCommerceIsApplePayDirectEnabled('express_checkout') && is_checkout()) {
+        if (mollieWooCommerceIsApplePayDirectEnabled('express_checkout') && (is_checkout() || is_cart())) {
             wp_enqueue_style('mollie-applepaydirect');
         }
     }

--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -494,7 +494,8 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         if ($applePayDirectHandler instanceof ApplePayDirectHandler) {
             $buttonEnabledCart = mollieWooCommerceIsApplePayDirectEnabled('cart');
             $buttonEnabledProduct = mollieWooCommerceIsApplePayDirectEnabled('product');
-            if ($buttonEnabledCart || $buttonEnabledProduct) {
+            $buttonEnabledExpressCheckout = mollieWooCommerceIsApplePayDirectEnabled('express_checkout');
+            if ($buttonEnabledCart || $buttonEnabledProduct || $buttonEnabledExpressCheckout) {
                 $applePayDirectHandler->bootstrap($buttonEnabledProduct, $buttonEnabledCart);
             }
         }


### PR DESCRIPTION
## Problem

With "Enable Apple Pay Express Button on Checkout page" turned on, the button did not appear in the WooCommerce Blocks express-payment section on the block checkout page. The same grey placeholder was also reported on the block cart page. The issue was confirmed from version 8.1.5 beta onwards.

Three independent defects combined to produce the symptom.

### 1. AJAX handlers not registered when only the express checkout button is enabled

`GatewayModule::paymentButtonsBootstrap()` gates the call to `ApplePayDirectHandler::bootstrap()` on whether the **product** or **cart** direct button is enabled:

```php
if ($buttonEnabledCart || $buttonEnabledProduct) {
    $applePayDirectHandler->bootstrap($buttonEnabledProduct, $buttonEnabledCart);
}
```

`bootstrap()` is the only place `AppleAjaxRequests::bootstrapAjaxRequest()` is called, which is where all Apple Pay AJAX actions (`mollie_apple_pay_validation`, `mollie_apple_pay_update_shipping_contact`, `mollie_apple_pay_update_shipping_method`, `mollie_apple_pay_create_order_cart`) are registered with WordPress.

When a merchant enables **only** the express checkout button (option key `mollie_apple_pay_button_enabled_express_checkout`) and leaves the product and cart buttons off, the condition is never satisfied. No AJAX handlers are registered. Any Apple Pay session initiated from the block checkout silently fails at the merchant-validation step.

### 2. Apple Pay button CSS not enqueued on block checkout or block cart

`AssetsModule::enqueueApplePayDirectScripts()` loads `mollie-applepaydirect.min.css` only inside the `is_product()` and `is_cart()` branches — neither of which is true on the block checkout page. The stylesheet provides the CSS rule that makes the button visible:

```css
.apple-pay-button {
    display: inline-block;
    width: 100%;
    -webkit-appearance: -apple-pay-button;
}
```

Without it the Apple Pay `<button>` element rendered by `ApplePayButtonComponent` collapses to zero width (no text, no inline width) and is invisible on Safari. On non-Apple platforms it renders as a plain grey empty button, which is the "grey placeholder" reported by testers.

The same stylesheet is needed on the **block cart** page: WC Blocks calls `registerExpressPaymentMethod` once globally and the registered method appears in the express-payment section on both the block cart and the block checkout. The cart page was therefore also affected.

### 3. `applepayDirectCart.js` crashes on the block cart page

The classic-cart Apple Pay script reads the WooCommerce nonce immediately on load:

```js
const nonce = document.getElementById('woocommerce-process-checkout-nonce').value;
```

This element is injected by the PHP `applePayDirectButton()` method, which is hooked onto `woocommerce_cart_totals_after_order_total` — a classic-cart hook that does not fire on the WooCommerce block cart. When only the classic cart button is enabled the script is enqueued on `is_cart()` pages, but on block cart the placeholder `<div>` is never rendered. The null dereference throws `TypeError: Cannot read properties of null (reading 'value')` and halts script execution.

---

## Solution

### `src/Gateway/GatewayModule.php` — register AJAX handlers for express-only configuration

`$buttonEnabledExpressCheckout` is added as a third condition so that `bootstrap()` is called whenever any Apple Pay surface is enabled:

```php
$buttonEnabledExpressCheckout = mollieWooCommerceIsApplePayDirectEnabled('express_checkout');
if ($buttonEnabledCart || $buttonEnabledProduct || $buttonEnabledExpressCheckout) {
    $applePayDirectHandler->bootstrap($buttonEnabledProduct, $buttonEnabledCart);
}
```

When `$buttonEnabledCart` and `$buttonEnabledProduct` are both false, `bootstrap(false, false)` is called. `bootstrap()` still runs the `isApplePayCompatible()` (HTTPS) and `merchantValidated()` checks — their admin notices remain active — and then calls `bootstrapAjaxRequest()` to register all AJAX handlers. The product- and cart-button DOM hooks are simply not added (both flags are false), which is the correct behaviour.

### `src/Assets/AssetsModule.php` — enqueue button CSS on block checkout and block cart

A new branch in `enqueueApplePayDirectScripts()` loads `mollie-applepaydirect.min.css` whenever the express checkout button is enabled and the current page is either the checkout or the cart:

```php
if (mollieWooCommerceIsApplePayDirectEnabled('express_checkout') && (is_checkout() || is_cart())) {
    wp_enqueue_style('mollie-applepaydirect');
}
```

No JS script and no `wp_localize_script` call are needed here. The block checkout express button is fully handled by the `ApplePayButtonComponent` React component bundled inside `mollieBlockIndex.min.js`. That component reads its data from `settings.expressButtonData`, which is populated server-side by `Applepay::blocksExpressData()` through the `inpsyde_payment_gateway_blocks_data` filter — a data channel separate from `mollieApplePayDirectData`.

### `resources/js/src/features/apple-pay/applepayDirectCart.js` — guard the nonce read

The unconditional nonce element access is replaced with an explicit null check that exits cleanly when the element is absent:

```js
const nonceElement = document.getElementById('woocommerce-process-checkout-nonce');
if (!nonceElement) {
    return;
}
const nonce = nonceElement.value;
```

On the block cart the placeholder `<div id="mollie-applepayDirect-button">` (and the nonce field it contains) is never rendered, so returning early is correct: without a nonce no Apple Pay session could be completed anyway.
