### PR TITLE
[QA] Fix refund.scenario for Order API

### DIFF
--- a/tests/qa/tests/03-plugin-settings/surcharge/surcharge.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/surcharge/surcharge.spec.ts
@@ -62,7 +62,7 @@ for ( const surcharge of allTests ) {
 			} ) => {
 				test.skip(
 					! gateway.availableForApiMethods.includes( mollieApiMethod ), 
-					`Test is not eliginle for ${ mollieApiMethod } API method.`
+					`Test is not eligible for ${ mollieApiMethod } API method.`
 				);
 				await wooCommerceApi.updateGeneralSettings(
 					shopSettings[ country ].general

--- a/tests/qa/tests/05-transaction/_test-scenarios/checkout-classic.scenario.ts
+++ b/tests/qa/tests/05-transaction/_test-scenarios/checkout-classic.scenario.ts
@@ -23,6 +23,7 @@ export const testPaymentStatusOnClassicCheckout = (
 
 	const customer = guests[ gateway.country ];
 	const currency = gateway.currency;
+	Object.assign( testData, { customer, currency } );
 	const gatewayLabel = buildMollieGatewayLabel( gateway );
 	const label = testLabel ? ` ${ testLabel }` : '';
 
@@ -43,13 +44,11 @@ export const testPaymentStatusOnClassicCheckout = (
 			`Test is not eligible for ${ mollieApiMethod } API method.`
 		);
 
-		const orderStatus = getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
-		Object.assign( testData, { orderStatus, customer, currency } );
-		
-		testInfo.annotations.push({
-			type: 'orderStatus',
-			description: orderStatus,
-		});
+		// Sets the default orderStatus based on API method, if specific is not set
+		if ( ! testData.orderStatus ) {
+			testData.orderStatus =
+				await getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
+		}
 
 		await updateCurrencyIfNeeded( wooCommerceApi, currency );
 

--- a/tests/qa/tests/05-transaction/_test-scenarios/checkout.scenario.ts
+++ b/tests/qa/tests/05-transaction/_test-scenarios/checkout.scenario.ts
@@ -23,6 +23,7 @@ export const testPaymentStatusOnCheckout = (
 
 	const customer = guests[ gateway.country ];
 	const currency = gateway.currency;
+	Object.assign( testData, { customer, currency } );
 	const gatewayLabel = buildMollieGatewayLabel( gateway );
 	const label = testLabel ? ` ${ testLabel }` : '';
 
@@ -36,15 +37,18 @@ export const testPaymentStatusOnCheckout = (
 		wooCommerceOrderEdit,
 		isMultistepCheckout,
 		mollieApiMethod,
-	} ) => {
+	}, testInfo ) => {
 		// exclude tests for payment methods if not available for tested API
 		test.skip(
 			! gateway.availableForApiMethods.includes( mollieApiMethod ), 
 			`Test is not eligible for ${ mollieApiMethod } API method.`
 		);
 
-		const orderStatus = getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
-		Object.assign( testData, { orderStatus, customer, currency } );
+		// Sets the default orderStatus based on API method, if specific is not set
+		if ( ! testData.orderStatus ) {
+			testData.orderStatus =
+				await getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
+		}
 		
 		await updateCurrencyIfNeeded( wooCommerceApi, gateway.currency );
 

--- a/tests/qa/tests/05-transaction/_test-scenarios/pay-for-order.scenario.ts
+++ b/tests/qa/tests/05-transaction/_test-scenarios/pay-for-order.scenario.ts
@@ -23,6 +23,7 @@ export const testPaymentStatusOnPayForOrder = (
 
 	const customer = guests[ gateway.country ];
 	const currency = gateway.currency;
+	Object.assign( testData, { customer, currency } );
 	const gatewayLabel = buildMollieGatewayLabel( gateway );
 	const label = testLabel ? ` ${ testLabel }` : '';
 
@@ -34,15 +35,18 @@ export const testPaymentStatusOnPayForOrder = (
 		payForOrder,
 		wooCommerceOrderEdit,
 		mollieApiMethod,
-	} ) => {
+	}, testInfo ) => {
 		// exclude tests for payment methods if not available for tested API
 		test.skip(
 			! gateway.availableForApiMethods.includes( mollieApiMethod ), 
 			`Test is not eligible for ${ mollieApiMethod } API method.`
 		);
 
-		const orderStatus = getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
-		Object.assign( testData, { orderStatus, customer, currency } );
+		// Sets the default orderStatus based on API method, if specific is not set
+		if ( ! testData.orderStatus ) {
+			testData.orderStatus =
+				await getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
+		}
 		
 		await updateCurrencyIfNeeded( wooCommerceApi, gateway.currency );
 

--- a/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
@@ -74,6 +74,7 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 			
 			test.setTimeout( 30 * 60_000 );
 			let transactionId: string;
+			let molliePaymentId: string;
 			let orderId: number;
 			let refundAmount: string;
 			let refundAvailable: number;
@@ -109,10 +110,19 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 				);
 
 				const order = await wooCommerceApi.getOrder( orderId );
+				// In case of Payment API transactionId = paymentId but in case of Order API transactionID = orderId which appears in order notes
 				transactionId = order.transaction_id;
 				await expect(
 					transactionId,
 					`Assert transaction ID ${ transactionId } is defined`
+				).toBeDefined();
+				// In case of Order API transactionId = orderId but to make a refund paymentId is required
+				molliePaymentId = order.meta_data.find(
+					( meta ) => meta.key === '_mollie_payment_id'
+				)?.value;
+				await expect(
+					molliePaymentId,
+					`Assert payment ID ${ molliePaymentId } is defined`
 				).toBeDefined();
 			} );
 
@@ -121,9 +131,9 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 			// Make refund via Mollie client API
 			if ( isMollieClientApiRefund ) {
 				await test.step( 'Make refund via Mollie client API', async () => {
-					const idempotencyKey = `${ transactionId }-refund-${ orderId }`;
+					const idempotencyKey = `${ molliePaymentId }-refund-${ orderId }`;
 					await mollieClientApi.refunds.create( {
-						paymentId: transactionId,
+						paymentId: molliePaymentId,
 						idempotencyKey,
 						refundRequest: {
 							amount: {
@@ -167,7 +177,7 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 				} );
 			}
 
-			await test.step( 'Wait for webhook and assert refund meta ~10 min', async () => {
+			await test.step( 'Wait for webhook and assert refund meta ~15 min', async () => {
 				// Assert via API WooCommerce Order refund status and presence of refunds
 				// Delayed webhooks cause following values to arrive in ~10-30 minutes after refund creation
 				await expect( async () => {

--- a/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
@@ -31,6 +31,8 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 	} = testData;
 	const { gateway } = payment;
 	const customer = guests[ gateway.country ];
+	Object.assign( testData, { customer, currency } );
+
 	const gatewayLabel = buildMollieGatewayLabel( gateway );
 
 	const refundPart = refundPercentage === 100 ? 'Full' : 'Partial';
@@ -62,15 +64,18 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 			payForOrder,
 			wooCommerceOrderEdit,
 			mollieApiMethod,
-		} ) => {
+		}, testInfo ) => {
 			// exclude tests for payment methods if not available for tested API
 			test.skip(
 				! gateway.availableForApiMethods.includes( mollieApiMethod ), 
 				`Test is not eligible for ${ mollieApiMethod } API method.`
 			);
 
-			const orderStatus = getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
-			Object.assign( testData, { orderStatus, customer, currency } );
+			// Sets the default orderStatus based on API method, if specific is not set
+			if ( ! testData.orderStatus ) {
+				testData.orderStatus =
+					await getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
+			}
 			
 			test.setTimeout( 30 * 60_000 );
 			let transactionId: string;

--- a/tests/qa/utils/helpers/woocommerce.helper.ts
+++ b/tests/qa/utils/helpers/woocommerce.helper.ts
@@ -159,10 +159,6 @@ export const setupWooCommerce = async () => {
 		await wooCommerceUtils.createCustomer( customers.germany );
 	} );
 
-	setup( 'Setup Delete Previous Orders', async ( { wooCommerceApi } ) => {
-		await wooCommerceApi.deleteAllOrders();
-	} );
-
 	setup( 'Setup coupons', async ( { wooCommerceUtils } ) => {
 		// create test coupons
 		const couponItems = {};


### PR DESCRIPTION

## Description

- Fix in refunds:
    Refunds for Mollie dashboard in auto tests are done via [Mollie-api-typescript](https://github.com/mollie/mollie-api-typescript/) which works with `mollie_payment_id`. When testing with Order API enabled the `mollie_payment_id` has to be retrieved from `meta_data` unlike Payment API where WC order `transaction_id` = `mollie_payment_id`.

- Fix for pre-set order statuses:
    Set the default orderStatus based on API method, if specific is not set

- Remove deleteAllOrders from woocommerce.setup