### PR TITLE
Limit surcharge checkout refresh to gateways with active surcharge

### DIFF
--- a/resources/js/src/features/surcharge/gatewaySurcharge.js
+++ b/resources/js/src/features/surcharge/gatewaySurcharge.js
@@ -1,16 +1,44 @@
 ( function ( { jQuery, surchargeData } ) {
-	jQuery( function ( $ ) {
-		$( 'body' ).on( 'change', 'input[name="payment_method"]', function () {
-			$( 'body' ).trigger( 'update_checkout' );
-		} );
-	} );
 	if ( ! surchargeData ) {
 		return;
 	}
 
+	const surchargeGatewayIds = Array.isArray( surchargeData.surchargeGatewayIds )
+		? surchargeData.surchargeGatewayIds
+		: [];
+
+	const gatewayHasSurcharge = ( gatewayId ) =>
+		surchargeGatewayIds.indexOf( gatewayId ) !== -1;
+
 	const isOrderPay = document.body.classList.contains(
 		'woocommerce-order-pay'
 	);
+
+	if ( ! isOrderPay ) {
+		jQuery( function ( $ ) {
+			let previousPaymentMethod =
+				$( 'input[name="payment_method"]:checked' ).val() || '';
+
+			$( 'body' ).on(
+				'change',
+				'input[name="payment_method"]',
+				function () {
+					const currentPaymentMethod =
+						$( 'input[name="payment_method"]:checked' ).val() ||
+						'';
+
+					if (
+						gatewayHasSurcharge( previousPaymentMethod ) ||
+						gatewayHasSurcharge( currentPaymentMethod )
+					) {
+						$( 'body' ).trigger( 'update_checkout' );
+					}
+
+					previousPaymentMethod = currentPaymentMethod;
+				}
+			);
+		} );
+	}
 
 	if ( isOrderPay ) {
 		jQuery( function ( $ ) {

--- a/resources/js/src/features/surcharge/gatewaySurcharge.js
+++ b/resources/js/src/features/surcharge/gatewaySurcharge.js
@@ -19,6 +19,11 @@
 			let previousPaymentMethod =
 				$( 'input[name="payment_method"]:checked' ).val() || '';
 
+			$( 'body' ).on( 'updated_checkout', function () {
+				previousPaymentMethod =
+					$( 'input[name="payment_method"]:checked' ).val() || '';
+			} );
+
 			$( 'body' ).on(
 				'change',
 				'input[name="payment_method"]',

--- a/src/Shared/GatewaySurchargeHandler.php
+++ b/src/Shared/GatewaySurchargeHandler.php
@@ -64,8 +64,42 @@ class GatewaySurchargeHandler
             [
                 'ajaxUrl' => admin_url('admin-ajax.php'),
                 'gatewayFeeLabel' => $this->gatewayFeeLabel,
+                'surchargeGatewayIds' => $this->surchargeGatewayIds(),
             ]
         );
+    }
+
+    protected function surchargeGatewayIds(): array
+    {
+        if (!function_exists('WC') || !WC()->payment_gateways()) {
+            return [];
+        }
+
+        $paymentGateways = WC()->payment_gateways()->payment_gateways();
+        $gatewayIds = [];
+
+        foreach ($paymentGateways as $gatewayId => $gateway) {
+            $gatewayId = (string) $gatewayId;
+
+            if (!$this->isMollieGateway($gatewayId)) {
+                continue;
+            }
+
+            $gatewaySettings = $this->gatewaySettings($gatewayId);
+
+            if (!$gatewaySettings) {
+                continue;
+            }
+
+            if (
+                isset($gatewaySettings['payment_surcharge'])
+                && $gatewaySettings['payment_surcharge'] !== Surcharge::NO_FEE
+            ) {
+                $gatewayIds[] = $gatewayId;
+            }
+        }
+
+        return $gatewayIds;
     }
 
     public function addSurchargeFeeProductPage($order, $gateway)


### PR DESCRIPTION
## Summary

This PR limits the classic checkout refresh triggered by the Mollie surcharge script.

Previously, the surcharge script triggered `update_checkout` on every `input[name="payment_method"]` change, including non-Mollie gateways. This caused unnecessary checkout refreshes when switching between payment methods that cannot affect Mollie surcharge totals.

The refresh is now only triggered when the previous or current payment method is a Mollie gateway with active `payment_surcharge` settings. It also keeps the previous payment method state in sync after `updated_checkout`.

Order-pay surcharge handling is unchanged.

## Testing

Manually tested on classic checkout with:
- one Mollie gateway with active surcharge
- one Mollie gateway with `payment_surcharge = no_fee`
- non-Mollie gateways such as Cash on Delivery and bank transfer

Verified that:
- switching between non-Mollie gateways does not trigger the Mollie surcharge checkout refresh
- switching to or away from a Mollie gateway with active surcharge still triggers checkout recalculation
- Mollie gateways with `payment_surcharge = no_fee` do not trigger the surcharge refresh