### PR TITLE
[PIWOO-878] Refactor `initDb` to improve readability and error suppression logic

### DIFF
--- a/src/Activation/ActivationModule.php
+++ b/src/Activation/ActivationModule.php
@@ -43,31 +43,33 @@ class ActivationModule implements ExecutableModule
     /**
      *
      */
-    public function initDb()
+    public function initDb(): void
     {
         global $wpdb;
-        global $EZSQL_ERROR;
         $wpdb->mollie_pending_payment = $wpdb->prefix . SharedDataDictionary::PENDING_PAYMENT_DB_TABLE_NAME;
-        if (get_option(SharedDataDictionary::DB_VERSION_PARAM_NAME, '') !== SharedDataDictionary::DB_VERSION) {
-            $pendingPaymentConfirmTable = $wpdb->prefix . SharedDataDictionary::PENDING_PAYMENT_DB_TABLE_NAME;
-            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-            if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $pendingPaymentConfirmTable)) !== $pendingPaymentConfirmTable) {
-                $sql = "
-					CREATE TABLE " . $pendingPaymentConfirmTable . " (
-                    id int(11) NOT NULL AUTO_INCREMENT,
-                    post_id bigint NOT NULL,
-                    expired_time int NOT NULL,
-                    PRIMARY KEY id (id)
-                );";
-                dbDelta($sql);
 
-                /**
-                 * Remove redundant 'DESCRIBE *__mollie_pending_payment' error so it doesn't show up in error logs
-                 */
-                array_pop($EZSQL_ERROR);
-            }
-            update_option(SharedDataDictionary::DB_VERSION_PARAM_NAME, SharedDataDictionary::DB_VERSION);
+        if (get_option(SharedDataDictionary::DB_VERSION_PARAM_NAME, '') === SharedDataDictionary::DB_VERSION) {
+            return;
         }
+
+        $table = $wpdb->prefix . SharedDataDictionary::PENDING_PAYMENT_DB_TABLE_NAME;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) !== $table) {
+            $sql = "CREATE TABLE {$table} (
+                id int(11) NOT NULL AUTO_INCREMENT,
+                post_id bigint NOT NULL,
+                expired_time int NOT NULL,
+                PRIMARY KEY id (id)
+            );";
+            // dbDelta() runs DESCRIBE on a non-existent table as part of its schema diff;
+            // suppress that expected false-positive instead of manipulating $EZSQL_ERROR directly.
+            $previousSuppressErrors = $wpdb->suppress_errors(true);
+            dbDelta($sql);
+            $wpdb->suppress_errors($previousSuppressErrors);
+        }
+
+        update_option(SharedDataDictionary::DB_VERSION_PARAM_NAME, SharedDataDictionary::DB_VERSION);
     }
 
     /**


### PR DESCRIPTION
 # Problem                                                          
                                                                   
On WordPress Playground (SQLite backend), activating the plugin  
caused a fatal TypeError at startup:                             
                                                                   
```
array_pop(): Argument #1 ($array) must be of type array, null    
given    
```                                                        
                                                                   
dbDelta() internally runs `DESCRIBE <table>` when diffing schema for a new table. On MySQL this appends a false-positive error entry to the global $EZSQL_ERROR array, which the code immediately removed with array_pop(). SQLite-backed environments never initialise $EZSQL_ERROR, so it's null and the pop crashes. 
                                                                   
## Solution                                                         

Replace the global array manipulation with $wpdb->suppress_errors(), which is the supported wpdb API for silencing expected query noise. 
The suppress/restore pattern wraps only the dbDelta() call, so the false-positive DESCRIBE error is never surfaced — without touching any globals.          
                                                                   
##Implications                                                     
                                                                   
- Fixes the fatal on WordPress Playground; no behaviour change on
 standard MySQL installs
- On MySQL, the DESCRIBE error is now suppressed rather than retroactively removed from $EZSQL_ERROR — functionally equivalent for error logging purposes
- Drops the dependency on $EZSQL_ERROR being a non-null array, making the code robust against alternative DB backends  