### PR TITLE
[QA] Remove extraHTTPHeaders after free Ngrok hack removal

### DIFF
--- a/tests/qa/global-setup.ts
+++ b/tests/qa/global-setup.ts
@@ -23,7 +23,6 @@ async function globalSetup( config: FullConfig ) {
 		baseURL: projectUse.baseURL,
 		httpCredentials: projectUse.httpCredentials,
 		storageStatePath: `${ process.env.STORAGE_STATE_PATH }/guest.json`,
-		extraHTTPHeaders,
 	} );
 }
 


### PR DESCRIPTION
### Description

Missed to remove `extraHTTPHeaders` in `global-setup.ts` for guest, after free Ngrok hack removal.

Double tested by the [this CI run](https://github.com/mollie/WooCommerce/actions/runs/25574916864/job/75079910439) (had to recreate a PR because artifact has been added in the PR of original branch). 