### PR TITLE
[PIWOO-854] Replace orderId with orderKey in surcharge processing logic

### DIFF
--- a/resources/js/src/features/surcharge/gatewaySurcharge.js
+++ b/resources/js/src/features/surcharge/gatewaySurcharge.js
@@ -14,12 +14,12 @@
 
 	if ( isOrderPay ) {
 		jQuery( function ( $ ) {
-			let orderId = false;
+			let orderKey = false;
 			const hiddenField = $(
-				'input:hidden[name="mollie-woocommerce-orderId"]'
+				'input:hidden[name="mollie-woocommerce-orderKey"]'
 			);
 			if ( hiddenField.length ) {
-				orderId = hiddenField.val();
+				orderKey = hiddenField.val();
 			}
 			const gatewayLabel = surchargeData.gatewayFeeLabel;
 			const updateSurcharge = () => {
@@ -31,7 +31,7 @@
 						method: $(
 							'input:radio[name="payment_method"]:checked'
 						).val(),
-						orderId,
+						orderKey,
 						nonce: $(
 							'input[name="mollie-surcharge-nonce"]'
 						).val(),

--- a/src/Shared/GatewaySurchargeHandler.php
+++ b/src/Shared/GatewaySurchargeHandler.php
@@ -45,9 +45,10 @@ class GatewaySurchargeHandler
 
     public function setHiddenOrderId($item_id, $item, $order, $bool = false)
     {
-        $nonce = wp_create_nonce('mollie_surcharge_' . $order->get_id());
+        $orderKey = $order->get_order_key();
+        $nonce = wp_create_nonce('mollie_surcharge_' . $orderKey);
         ?>
-        <input type="hidden" name="mollie-woocommerce-orderId" value="<?php echo esc_attr($order->get_id()) ?>">
+        <input type="hidden" name="mollie-woocommerce-orderKey" value="<?php echo esc_attr($orderKey) ?>">
         <input type="hidden" name="mollie-surcharge-nonce" value="<?php echo esc_attr($nonce) ?>">
         <?php
     }
@@ -179,14 +180,14 @@ class GatewaySurchargeHandler
      */
     protected function verifyNonce(): bool
     {
-        $orderId = (int) wc_get_post_data_by_key('orderId', '');
+        $orderKey = sanitize_text_field(wc_get_post_data_by_key('orderKey', ''));
         $nonce = wc_get_post_data_by_key('nonce', '');
 
-        if (!$orderId || !$nonce) {
+        if (!$orderKey || !$nonce) {
             return false;
         }
 
-        return (bool) wp_verify_nonce($nonce, 'mollie_surcharge_' . $orderId);
+        return (bool) wp_verify_nonce($nonce, 'mollie_surcharge_' . $orderKey);
     }
 
     protected function chosenGateway()
@@ -255,13 +256,18 @@ class GatewaySurchargeHandler
      */
     protected function canProcessOrder()
     {
-        $postedOrderId = (int) wc_get_post_data_by_key('orderId', '');
+        $orderKey = sanitize_text_field(wc_get_post_data_by_key('orderKey', ''));
 
-        if (!$postedOrderId) {
+        if (!$orderKey) {
             return false;
         }
 
-        $order = wc_get_order($postedOrderId);
+        $orderId = wc_get_order_id_by_order_key($orderKey);
+        if (!$orderId) {
+            return false;
+        }
+
+        $order = wc_get_order($orderId);
         if (!$order) {
             return false;
         }

--- a/src/Shared/GatewaySurchargeHandler.php
+++ b/src/Shared/GatewaySurchargeHandler.php
@@ -40,10 +40,10 @@ class GatewaySurchargeHandler
         add_action('wp_ajax_nopriv_update_surcharge_order_pay', function () {
             $this->updateSurchargeOrderPay();
         });
-        add_action('woocommerce_order_item_meta_end', [$this, 'setHiddenOrderId'], 10, 4);
+        add_action('woocommerce_order_item_meta_end', [$this, 'renderHiddenOrderKeyFields'], 10, 4);
     }
 
-    public function setHiddenOrderId($item_id, $item, $order, $bool = false)
+    public function renderHiddenOrderKeyFields($item_id, $item, $order, $bool = false)
     {
         $orderKey = $order->get_order_key();
         $nonce = wp_create_nonce('mollie_surcharge_' . $orderKey);


### PR DESCRIPTION
## Summary

- The surcharge handler was leaking the raw WooCommerce database order ID into a hidden HTML field (`mollie-woocommerce-orderId`) on the order-pay page. Because this ID is a sequential integer, any visitor who places two orders at different points in time can trivially estimate the store's order volume for that period.
- Replaced the integer ID with the WooCommerce `order_key` — a random, opaque string (e.g. `wc_order_K3mXn9qRtP7vBz`) that WooCommerce already exposes in thank-you and order-pay URLs. No order-volume information can be derived from it.
- The nonce action string is updated to bind to the order key instead of the ID, preserving the same CSRF protection.

## Changes

**`src/Shared/GatewaySurchargeHandler.php`**

- `setHiddenOrderId()`: calls `$order->get_order_key()` and writes the key into a renamed hidden field (`mollie-woocommerce-orderKey`); nonce action now uses the key.
- `verifyNonce()`: reads `orderKey` from `$_POST` (via `wc_get_post_data_by_key`), applies `sanitize_text_field`, verifies the nonce against the key.
- `canProcessOrder()`: reads `orderKey` from `$_POST`, resolves the internal order ID via `wc_get_order_id_by_order_key()`, then loads the order with `wc_get_order()`.
- Minor cleanup: removed an unreachable `return` after `wp_send_json_success()`.

**`resources/js/src/features/surcharge/gatewaySurcharge.js`**

- Reads from `input:hidden[name="mollie-woocommerce-orderKey"]` instead of the old `orderId` field.
- Posts `orderKey` instead of `orderId` in the AJAX request body.

## Security impact

| Attack vector | Before | After |
|---|---|---|
| Read page source → estimate order volume | Trivially possible | Not possible |
| Enumerate orders via forged AJAX calls | Blocked by nonce | Blocked by nonce |
| CSRF surcharge manipulation | Blocked by nonce | Blocked by nonce |
| Guess a valid order key | N/A | Infeasible (random string) |

## Backward compatibility

The hidden field name and AJAX parameter are a private contract between our own PHP and our own JS. No public filter, documented hook, or third-party integration depends on these names. No migration or deprecation notice is required.

## Scope

- 2 files changed (1 PHP, 1 JS), no new dependencies, no DB changes, no settings changes.

## References

- Ticket: PIWOO-854
- Design document: `docs/design/issue-surcharge-order-id-exposure.md`
- Reporter: Dominik Bödger (Paderborn) — external support ticket, 2026-05-18
