### PR TITLE
Sanitize SVG gateway logo uploads (870)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "psr/container": "1.1.0",
     "psr/log":"^1.1.4",
     "sniccowp/php-scoper-wordpress-excludes": "^6.6",
-    "dhii/services": "^0.1.0"
+    "dhii/services": "^0.1.0",
+    "enshrined/svg-sanitize": "^0.22.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e80ebce9c7ab43cf3dc33f2f5de2b76e",
+    "content-hash": "7b563cd52561b132e3f0e82f3153a09f",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -124,6 +124,51 @@
                 "source": "https://github.com/Dhii/services/tree/v0.1.0"
             },
             "time": "2022-01-06T14:57:20+00:00"
+        },
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/0afa95ea74be155a7bcd6c6fb60c276c39984500",
+                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
+            },
+            "time": "2025-08-12T10:13:48+00:00"
         },
         {
             "name": "inpsyde/modularity",

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -669,6 +669,16 @@ class Settings
 
             $movefile = wp_handle_upload($file, $upload_overrides);
             if ($movefile) {
+                if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) === 'svg') {
+                    $svgContent = file_get_contents($movefile['file']);
+                    $sanitizer = new \enshrined\svgSanitize\Sanitizer();
+                    $sanitized = ($svgContent !== false) ? $sanitizer->sanitize($svgContent) : false;
+                    if (!$sanitized) {
+                        wp_delete_file($movefile['file']);
+                        return;
+                    }
+                    file_put_contents($movefile['file'], $sanitized);
+                }
                 $gatewaySettings = get_option(sprintf('%s_settings', $gatewayId), []);
                 $gatewaySettings["iconFileUrl"] = $movefile['url'];
                 $gatewaySettings["iconFilePath"] = $movefile['file'];

--- a/tests/php/Unit/Settings/SettingsTest.php
+++ b/tests/php/Unit/Settings/SettingsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Settings;
+
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerceTests\TestCase;
+
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Settings\Settings::processUploadedFile
+ */
+class SettingsTest extends TestCase
+{
+    private const GATEWAY_ID = 'mollie_wc_gateway_ideal';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        when('admin_url')->justReturn('https://example.com/wp-admin/');
+        when('wp_handle_upload')->justReturn([]);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_FILES);
+        parent::tearDown();
+    }
+
+    private function makeSut(): Settings
+    {
+        return new Settings('mollie_wc', null, '8.1.4', 'https://example.com', null, false);
+    }
+
+    private function callProcessUploadedFile(Settings $sut, string $name, string $tempName, string $gatewayId): void
+    {
+        $method = new \ReflectionMethod(Settings::class, 'processUploadedFile');
+        $method->setAccessible(true);
+        $method->invoke($sut, $name, $tempName, $gatewayId);
+    }
+
+    private function createTempFile(string $content, string $extension): string
+    {
+        $path = sys_get_temp_dir() . '/mollie_test_' . uniqid() . '.' . $extension;
+        file_put_contents($path, $content);
+        return $path;
+    }
+
+    private function setUpFilesGlobal(string $gatewayId, string $name, string $tmpPath, string $type = 'image/svg+xml'): void
+    {
+        $_FILES['woocommerce_' . $gatewayId . '_upload_logo'] = [
+            'name'     => $name,
+            'type'     => $type,
+            'tmp_name' => $tmpPath,
+            'error'    => 0,
+            'size'     => (int) filesize($tmpPath),
+        ];
+    }
+
+    // T1: SVG containing <script> tag has it stripped after upload
+    public function testSvgScriptTagIsRemovedAfterUpload(): void
+    {
+        $maliciousSvg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><path d="M0 0"/></svg>';
+        $storedFile   = $this->createTempFile($maliciousSvg, 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $storedFile);
+
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $storedFile]);
+        when('get_option')->justReturn([]);
+        expect('update_option')->once()->andReturn(true);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $storedFile, self::GATEWAY_ID);
+
+        self::assertStringNotContainsString('<script', file_get_contents($storedFile));
+        @unlink($storedFile);
+    }
+
+    // T2: SVG containing on* event-handler attribute has it stripped after upload
+    public function testSvgEventHandlerAttributeIsStrippedAfterUpload(): void
+    {
+        $maliciousSvg = '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><path d="M0 0"/></svg>';
+        $storedFile   = $this->createTempFile($maliciousSvg, 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $storedFile);
+
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $storedFile]);
+        when('get_option')->justReturn([]);
+        expect('update_option')->once()->andReturn(true);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $storedFile, self::GATEWAY_ID);
+
+        self::assertStringNotContainsString('onload=', file_get_contents($storedFile));
+        @unlink($storedFile);
+    }
+
+    // T3: SVG containing javascript: URI in href attribute has it stripped after upload
+    public function testSvgJavascriptUriIsRemovedAfterUpload(): void
+    {
+        $maliciousSvg = '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><text>x</text></a></svg>';
+        $storedFile   = $this->createTempFile($maliciousSvg, 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $storedFile);
+
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $storedFile]);
+        when('get_option')->justReturn([]);
+        expect('update_option')->once()->andReturn(true);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $storedFile, self::GATEWAY_ID);
+
+        self::assertStringNotContainsString('javascript:', file_get_contents($storedFile));
+        @unlink($storedFile);
+    }
+
+    // T4: Safe SVG is stored intact and update_option receives correct iconFileUrl / iconFilePath
+    public function testSafeSvgIsStoredIntactWithCorrectSettings(): void
+    {
+        $safeSvg    = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0 L10 10"/></svg>';
+        $storedFile = $this->createTempFile($safeSvg, 'svg');
+        $fileUrl    = 'https://example.com/logo.svg';
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $storedFile);
+
+        when('wp_handle_upload')->justReturn(['url' => $fileUrl, 'file' => $storedFile]);
+        when('get_option')->justReturn([]);
+
+        $captured = null;
+        expect('update_option')
+            ->once()
+            ->andReturnUsing(static function (string $name, array $settings) use (&$captured): bool {
+                $captured = $settings;
+                return true;
+            });
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $storedFile, self::GATEWAY_ID);
+
+        self::assertStringContainsString('<path', file_get_contents($storedFile));
+        self::assertSame($fileUrl, $captured['iconFileUrl'] ?? null);
+        self::assertSame($storedFile, $captured['iconFilePath'] ?? null);
+        @unlink($storedFile);
+    }
+
+    // T5: JPEG file bypasses sanitizer entirely; file content is unchanged and settings are persisted
+    public function testNonSvgFileBypassesSanitizerAndIsPersisted(): void
+    {
+        $jpegContent = "\xFF\xD8\xFF\xE0fake-jpeg-binary";
+        $storedFile  = $this->createTempFile($jpegContent, 'jpg');
+        $fileUrl     = 'https://example.com/logo.jpg';
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.jpg', $storedFile, 'image/jpeg');
+
+        when('wp_handle_upload')->justReturn(['url' => $fileUrl, 'file' => $storedFile]);
+        when('get_option')->justReturn([]);
+        expect('update_option')->once()->andReturn(true);
+        expect('wp_delete_file')->never();
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.jpg', $storedFile, self::GATEWAY_ID);
+
+        self::assertSame($jpegContent, file_get_contents($storedFile));
+        @unlink($storedFile);
+    }
+
+    // T6: SVG with unparseable content causes sanitizer to return empty; file is deleted and settings not written
+    public function testEmptySanitizerOutputDeletesFileAndSkipsSettings(): void
+    {
+        $invalidContent = 'not-valid-xml-or-svg-content';
+        $storedFile     = $this->createTempFile($invalidContent, 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $storedFile);
+
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $storedFile]);
+        when('get_option')->justReturn([]);
+        expect('update_option')->never();
+        expect('wp_delete_file')->once()->with($storedFile);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $storedFile, self::GATEWAY_ID);
+
+        self::assertSame($invalidContent, file_get_contents($storedFile));
+        @unlink($storedFile);
+    }
+}


### PR DESCRIPTION
What and why
  
  WordPress core blocks SVG uploads by default. This plugin re-enables SVG support for gateway logos, which places
   the responsibility for safe file handling squarely on the plugin. To align with that responsibility and follow
  security best practices for user-supplied file content, SVG files are now sanitized before being stored.

  What changed

  - composer.json — adds enshrined/svg-sanitize ^0.22.0 as a production dependency, providing the sanitizer used
  to clean SVG content before storage
  - src/Settings/Settings.php — Settings::processUploadedFile() now passes uploaded SVG content through a
  sanitizer immediately after wp_handle_upload() writes it to disk, before iconFileUrl/iconFilePath are persisted
  to gateway settings

  How it works now

  After wp_handle_upload() succeeds, Settings::processUploadedFile() inspects the uploaded file's extension. For
  .svg files, it reads the stored content, passes it through \enshrined\svgSanitize\Sanitizer::sanitize(), and
  writes the cleaned content back to the same path before calling update_option(). If the sanitizer returns falsy
  output the file is deleted via wp_delete_file() and the method returns early without persisting any settings — a
   fail-safe that prevents a corrupt or unprocessable SVG from being referenced in gateway configuration. Non-SVG
  files bypass the sanitizer entirely and are stored unchanged.

  What to verify in review

  Covered by unit tests

  - ✓ An SVG containing a <script> element is overwritten on disk with the script tag removed before settings are
  persisted
  - ✓ An SVG containing an onload or other on* event-handler attribute is overwritten with that attribute stripped
  - ✓ An SVG containing a javascript: URI in an href attribute is overwritten with the attribute removed
  - ✓ A well-formed SVG (paths, shapes, fills only) is stored intact and iconFileUrl/iconFilePath are written to
  gateway settings with the correct values
  - ✓ A JPEG upload bypasses the sanitizer entirely: file content is byte-identical after the call and settings
  are persisted normally
  - ✓ When the sanitizer returns falsy output, the uploaded file is deleted via wp_delete_file and update_option
  is never called

  Contracts introduced or changed
  
  Constructor signature changed

  No class gained constructor parameters. Settings::processUploadedFile() is a protected method whose signature is
   unchanged; only its internal logic was extended.
