### PR TITLE
Wrap return in Boolean() to guarantee boolean return type (871)

### DIFF
--- a/resources/js/src/checkout/blocks/store/selectors.js
+++ b/resources/js/src/checkout/blocks/store/selectors.js
@@ -51,8 +51,9 @@ const selectors = {
 		state.gatewayComponents[ gateway ] || [],
 
 	getIsComponentReady: ( state ) => {
+		// kb-active
 		const activePaymentMethod = state.activePaymentMethod;
-		return (
+		return Boolean(
 			state.componentInitialized &&
 			state.componentMounted[ activePaymentMethod ] &&
 			! state.componentError &&


### PR DESCRIPTION
What and why
  
  For Mollie payment gateways that do not use Mollie Components (e.g. EPS, Klarna Pay Later, Bancontact), the
  client-side Redux selector getIsComponentReady could return undefined instead of a boolean. Because JavaScript's
   && short-circuit operator returns the falsy operand itself rather than false, when state.componentInitialized
  is unset the entire expression evaluates to undefined. JSON.stringify silently drops object properties whose
  value is undefined, so the componentsReady field in the payment_data array sent to POST 
  /wp-json/wc/store/v1/checkout was serialised as {"key":"componentsReady"} with no value property. WooCommerce
  core iterates payment_data expecting every entry to have both key and value; the missing property triggers a PHP
   warning in CheckoutTrait::get_request_payment_data. On any server where display_errors is enabled — common on
  shared hosting — that warning is written directly into the HTTP response body before the JSON payload,
  corrupting it. The frontend cannot parse the response, surfaces a generic "Something went wrong" error, and
  leaves the order in Draft status even though the Mollie payment itself completed successfully on the server
  side.

  What changed

  - resources/js/src/checkout/blocks/store/selectors.js — wrapped the return expression of getIsComponentReady in
  Boolean() so the method always returns a concrete true or false, eliminating the undefined return that caused
  componentsReady to be stripped from the serialised payload.
  
  How it works now

  getIsComponentReady now wraps its multi-condition return expression in Boolean(). This guarantees the return
  type is always a boolean regardless of which operand the && chain short-circuits on — for non-Components
  gateways where state.componentInitialized is falsy, Boolean(undefined) produces false instead of undefined. The
  getPaymentMethodData selector in the same file reads getIsComponentReady to populate the componentsReady field,
  so the fix flows through automatically: every payment_data entry in the Store API payload now carries a concrete
   value property, satisfying WooCommerce core's iteration contract in CheckoutTrait::get_request_payment_data.

  What to verify in review

  Covered by unit tests
  
  No JS unit test suite exists in this project. All criteria are verified by code inspection and integration.

  Not covered by unit tests
  
  - ✗ getIsComponentReady(state) returns false (not undefined) when state.componentInitialized is falsy — no JS
  unit test runner configured in the project; verifiable by code inspection.
  - ✗ getIsComponentReady(state) returns true for a fully initialised Components state — same reason.
  - ✗ getPaymentMethodData(state) produces componentsReady: false (boolean) for a non-Components gateway, so
  JSON.stringify emits {"key":"componentsReady","value":false} — same reason.
  - ✗ The POST /wp-json/wc/store/v1/checkout payload no longer contains any payment_data entry missing a value
  property — requires integration testing with a live Block Checkout and a non-Components gateway (e.g. EPS).
  - ✗ No PHP Warning: Undefined array key "value" from CheckoutTrait::get_request_payment_data — requires a server
   with display_errors enabled and a full checkout flow.

  What must not regress

  - resources/js/src/checkout/blocks/store/reducer.js — owns the Redux state shape (componentInitialized,
  componentMounted, componentError, componentInitializing); any change here would invalidate the selector logic
  the fix depends on.
  - resources/js/src/checkout/blocks/components/PaymentMethodContentRenderer.js — calls getPaymentMethodData() and
   passes the result as paymentMethodData to the WooCommerce Blocks payment setup hook; must not be modified as
  the fix is self-contained in the selector layer.