### PR TITLE
Cancel pending Mollie payment before creating a new one to prevent duplicates (877)

### DIFF
--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -92,6 +92,9 @@ class PaymentProcessor implements PaymentProcessorInterface
     public function processPayment($order, $paymentGateway): array
     {
         $orderId = $order->get_id();
+        if ($order->is_paid()) {
+            return ['result' => 'failure'];
+        }
         $this->setGateway($paymentGateway);
         $this->setGatewayHelper($paymentGateway->id);
         if ($this->deprecatedGatewayHelper === false) {
@@ -111,6 +114,8 @@ class PaymentProcessor implements PaymentProcessorInterface
         if ($this->needsSubscriptionSwitch($order, $orderId)) {
             return $this->processSubscriptionSwitch($order, $orderId, $customerId, $apiKey);
         }
+
+        $this->cancelExistingMolliePaymentIfPending($order, $apiKey);
 
         $molliePaymentType = $this->paymentTypeBasedOnGateway($paymentMethod);
         $molliePaymentType = $this->paymentTypeBasedOnProducts($order, $molliePaymentType);
@@ -829,6 +834,73 @@ class PaymentProcessor implements PaymentProcessorInterface
                 'mollie-payments-for-woocommerce'
             )
         );
+    }
+
+    private function cancelExistingMolliePaymentIfPending(WC_Order $order, string $apiKey): void
+    {
+        $mollieOrderId = $order->get_meta('_mollie_order_id', true);
+
+        try {
+            $apiClient = $this->apiHelper->getApiClient($apiKey);
+
+            if (!empty($mollieOrderId) && strpos($mollieOrderId, 'ord_') === 0) {
+                $mollieOrder = $apiClient->orders->get($mollieOrderId);
+
+                if ($mollieOrder->isCanceled()) {
+                    $this->logger->debug(
+                        "Previous Mollie order {$mollieOrderId} is already canceled, skipping cancel before new payment."
+                    );
+                    return;
+                }
+
+                if ($mollieOrder->isCreated() || $mollieOrder->isAuthorized() || $mollieOrder->isShipping()) {
+                    $mollieOrder->cancel();
+                    $order->add_order_note(
+                        sprintf(
+                            __(
+                                'Previous pending Mollie payment %s canceled before creating a new one.',
+                                'mollie-payments-for-woocommerce'
+                            ),
+                            $mollieOrderId
+                        )
+                    );
+                    return;
+                }
+
+                $this->logger->debug(
+                    "Previous Mollie order {$mollieOrderId} is in a non-cancellable state, skipping cancel before new payment."
+                );
+                return;
+            }
+
+            $molliePaymentId = $order->get_meta('_mollie_payment_id', true);
+
+            if (!empty($molliePaymentId) && strpos($molliePaymentId, 'tr_') === 0) {
+                $payment = $apiClient->payments->get($molliePaymentId);
+
+                if ($payment->isCancelable && !$payment->isCanceled() && !$payment->isPaid() && !$payment->isAuthorized()) {
+                    $apiClient->payments->cancel($molliePaymentId);
+                    $order->add_order_note(
+                        sprintf(
+                            __(
+                                'Previous pending Mollie payment %s canceled before creating a new one.',
+                                'mollie-payments-for-woocommerce'
+                            ),
+                            $molliePaymentId
+                        )
+                    );
+                    return;
+                }
+
+                $this->logger->debug(
+                    "Previous Mollie payment {$molliePaymentId} is in a non-cancellable state, skipping cancel before new payment."
+                );
+            }
+        } catch (ApiException $e) {
+            $this->logger->debug(
+                "Failed to cancel previous Mollie payment before creating new one: " . $e->getMessage()
+            );
+        }
     }
 
     /**

--- a/tests/php/Functional/Payment/PaymentProcessorTest.php
+++ b/tests/php/Functional/Payment/PaymentProcessorTest.php
@@ -1,0 +1,399 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Functional\Payment;
+
+use Mockery;
+use Mollie\Api\Endpoints\OrderEndpoint;
+use Mollie\Api\Endpoints\PaymentEndpoint;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Order as MollieApiOrder;
+use Mollie\Api\Resources\Payment as MollieApiPayment;
+use Mollie\WooCommerce\Payment\PaymentCheckoutRedirectService;
+use Mollie\WooCommerce\Payment\PaymentProcessor;
+use Mollie\WooCommerceTests\Functional\HelperMocks;
+use Mollie\WooCommerceTests\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * @covers \Mollie\WooCommerce\Payment\PaymentProcessor::processPayment
+ */
+class PaymentProcessorTest extends TestCase
+{
+    private HelperMocks $helperMocks;
+    private MollieApiClient $apiClientMock;
+    /** @var Mockery\MockInterface */
+    private $orderEndpointMock;
+    /** @var Mockery\MockInterface */
+    private $paymentEndpointMock;
+    /** @var Mockery\MockInterface&LoggerInterface */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->helperMocks = new HelperMocks();
+
+        $this->orderEndpointMock = Mockery::mock(OrderEndpoint::class);
+        $this->paymentEndpointMock = Mockery::mock(PaymentEndpoint::class);
+
+        $this->apiClientMock = $this->createMock(MollieApiClient::class);
+        $this->apiClientMock->orders = $this->orderEndpointMock;
+        $this->apiClientMock->payments = $this->paymentEndpointMock;
+
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->logger->shouldReceive('debug')->withAnyArgs()->andReturnNull()->byDefault();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private function buildSut(): PaymentProcessor
+    {
+        return new PaymentProcessor(
+            $this->helperMocks->noticeMock(),
+            $this->logger,
+            $this->helperMocks->paymentFactory(),
+            $this->helperMocks->dataHelper($this->apiClientMock),
+            $this->helperMocks->apiHelper($this->apiClientMock),
+            $this->helperMocks->settingsHelper(),
+            $this->helperMocks->pluginId(),
+            $this->createMock(PaymentCheckoutRedirectService::class),
+            []
+        );
+    }
+
+    private function invokeCancel(PaymentProcessor $sut, object $order, string $apiKey = 'test_key'): void
+    {
+        $method = new ReflectionMethod(PaymentProcessor::class, 'cancelExistingMolliePaymentIfPending');
+        $method->setAccessible(true);
+        $method->invoke($sut, $order, $apiKey);
+    }
+
+    private function wcOrderWithMeta(array $metaMap = []): object
+    {
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_meta')
+            ->withAnyArgs()
+            ->andReturnUsing(static function (string $key) use ($metaMap): string {
+                return $metaMap[$key] ?? '';
+            })
+            ->byDefault();
+        $order->shouldReceive('add_order_note')->withAnyArgs()->andReturnNull()->byDefault();
+        return $order;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 1 — ord_ meta, cancellable → cancel endpoint + order note
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When processPayment() is called for an order whose _mollie_order_id
+     *           meta is set to an 'ord_*' value and the corresponding Mollie order is
+     *           in a cancellable state (isCreated || isAuthorized || isShipping) and
+     *           not yet canceled, cancelExistingMolliePaymentIfPending() calls the
+     *           Mollie orders cancel endpoint before processPaymentForMollie() creates
+     *           a new payment, and adds an order note recording the cancelled payment id.
+     */
+    public function test_cancels_mollie_order_when_ord_meta_present_and_cancellable(): void
+    {
+        // Arrange
+        $mollieOrderId = 'ord_abc123';
+
+        $mollieOrder = Mockery::mock(MollieApiOrder::class);
+        $mollieOrder->shouldReceive('isCanceled')->andReturn(false);
+        $mollieOrder->shouldReceive('isCreated')->andReturn(true);
+        $mollieOrder->shouldReceive('cancel')->once();
+
+        $this->orderEndpointMock->shouldReceive('get')->andReturn($mollieOrder);
+
+        $order = $this->wcOrderWithMeta(['_mollie_order_id' => $mollieOrderId]);
+        $order->shouldReceive('add_order_note')
+            ->once()
+            ->withArgs(static function (string $note) use ($mollieOrderId): bool {
+                return strpos($note, $mollieOrderId) !== false;
+            });
+
+        // When
+        $this->invokeCancel($this->buildSut(), $order);
+
+        // Then — Mockery verifies cancel() once and add_order_note() once in tearDown
+        $this->assertTrue(true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 2 — tr_ meta, isCancelable=true → payments cancel + note
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When processPayment() is called for an order whose _mollie_payment_id
+     *           meta is set to a 'tr_*' value and the corresponding Mollie payment has
+     *           isCancelable=true and is not canceled/paid/authorized,
+     *           cancelExistingMolliePaymentIfPending() calls the Mollie payments cancel
+     *           endpoint before processPaymentForMollie() creates a new payment, and
+     *           adds an order note recording the cancelled payment id.
+     */
+    public function test_cancels_mollie_payment_when_tr_meta_present_and_cancelable(): void
+    {
+        // Arrange
+        $paymentId = 'tr_xyz789';
+
+        $molliePayment = Mockery::mock(MollieApiPayment::class);
+        $molliePayment->isCancelable = true;
+        $molliePayment->shouldReceive('isCanceled')->andReturn(false);
+        $molliePayment->shouldReceive('isPaid')->andReturn(false);
+        $molliePayment->shouldReceive('isAuthorized')->andReturn(false);
+
+        $this->paymentEndpointMock->shouldReceive('get')->andReturn($molliePayment);
+        $this->paymentEndpointMock->shouldReceive('cancel')->once();
+
+        $order = $this->wcOrderWithMeta([
+            '_mollie_order_id'  => '',
+            '_mollie_payment_id' => $paymentId,
+        ]);
+        $order->shouldReceive('add_order_note')
+            ->once()
+            ->withArgs(static function (string $note) use ($paymentId): bool {
+                return strpos($note, $paymentId) !== false;
+            });
+
+        // When
+        $this->invokeCancel($this->buildSut(), $order);
+
+        // Then — Mockery verifies cancel() once and add_order_note() once in tearDown
+        $this->assertTrue(true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 3 — terminal state → cancel NOT called, debug logged
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When the previous Mollie payment/order is already in a terminal state
+     *           (paid, authorized, canceled, expired, failed),
+     *           cancelExistingMolliePaymentIfPending() does NOT call the cancel endpoint
+     *           and proceeds to new-payment creation; the previous-payment status is
+     *           logged at debug level.
+     */
+    public function test_skips_cancel_when_previous_payment_in_terminal_state(): void
+    {
+        // Arrange
+        $mollieOrderId = 'ord_terminal';
+
+        $mollieOrder = Mockery::mock(MollieApiOrder::class);
+        $mollieOrder->shouldReceive('isCanceled')->andReturn(true);
+        $mollieOrder->shouldReceive('cancel')->never();
+
+        $this->orderEndpointMock->shouldReceive('get')->andReturn($mollieOrder);
+
+        $order = $this->wcOrderWithMeta(['_mollie_order_id' => $mollieOrderId]);
+        $order->shouldReceive('add_order_note')->never();
+
+        $this->logger->shouldReceive('debug')->atLeast()->once()->withAnyArgs();
+
+        // When
+        $this->invokeCancel($this->buildSut(), $order);
+
+        // Then — Mockery verifies cancel() never, add_order_note() never, debug logged
+        $this->assertTrue(true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 4 — ApiException → logged at debug, does not propagate
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When the Mollie API throws ApiException during lookup or cancel
+     *           (network error, payment-not-found, not-cancellable error code),
+     *           cancelExistingMolliePaymentIfPending() logs the exception at debug
+     *           level and returns without throwing; processPayment() continues to
+     *           create the new payment.
+     */
+    public function test_logs_and_does_not_throw_when_api_exception_during_cancel(): void
+    {
+        // Arrange
+        $mollieOrderId = 'ord_fail';
+        $exception = new ApiException('Network error');
+
+        $this->orderEndpointMock->shouldReceive('get')->andThrow($exception);
+
+        $order = $this->wcOrderWithMeta(['_mollie_order_id' => $mollieOrderId]);
+        $order->shouldReceive('add_order_note')->never();
+
+        $this->logger->shouldReceive('debug')
+            ->once()
+            ->withArgs(static function (string $message) use ($exception): bool {
+                return strpos($message, $exception->getMessage()) !== false;
+            });
+
+        // When — must not propagate the exception
+        $this->invokeCancel($this->buildSut(), $order);
+
+        // Then — no exception + debug logged with exception message
+        $this->assertTrue(true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 5 — no meta → no API call, no order note
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When processPayment() is called for an order with no _mollie_order_id
+     *           and no _mollie_payment_id meta, cancelExistingMolliePaymentIfPending()
+     *           is a no-op (no API call, no order note) and new-payment creation
+     *           proceeds normally.
+     */
+    public function test_no_api_call_when_order_has_no_mollie_meta(): void
+    {
+        // Arrange
+        $this->orderEndpointMock->shouldReceive('get')->never();
+        $this->paymentEndpointMock->shouldReceive('get')->never();
+        $this->paymentEndpointMock->shouldReceive('cancel')->never();
+
+        $order = $this->wcOrderWithMeta([
+            '_mollie_order_id'   => '',
+            '_mollie_payment_id' => '',
+        ]);
+        $order->shouldReceive('add_order_note')->never();
+
+        // When
+        $this->invokeCancel($this->buildSut(), $order);
+
+        // Then — Mockery verifies never() expectations in tearDown
+        $this->assertTrue(true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 6 — is_paid()=true → immediate ['result' => 'failure']
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When processPayment() is called and $order->is_paid() returns true
+     *           at entry, the method returns ['result' => 'failure'] immediately
+     *           without calling cancelExistingMolliePaymentIfPending(),
+     *           processPaymentForMollie(), or any Mollie API.
+     */
+    public function test_returns_failure_immediately_when_order_is_already_paid(): void
+    {
+        // Arrange — use a partial mock so we can assert processPaymentForMollie() is never called.
+        // Before phase 03: no is_paid() guard → code reaches processPaymentForMollie() → never() fails.
+        // After phase 03: is_paid() guard returns early → never() passes.
+        $gatewayId = 'mollie_wc_gateway_ideal';
+        $deprecatedGatewayHelper = $this->helperMocks->mollieGatewayBuilder('Ideal', false, false, []);
+
+        $sut = $this->getMockBuilder(PaymentProcessor::class)
+            ->setConstructorArgs([
+                $this->helperMocks->noticeMock(),
+                $this->logger,
+                $this->helperMocks->paymentFactory(),
+                $this->helperMocks->dataHelper($this->apiClientMock),
+                $this->helperMocks->apiHelper($this->apiClientMock),
+                $this->helperMocks->settingsHelper(),
+                $this->helperMocks->pluginId(),
+                $this->createMock(PaymentCheckoutRedirectService::class),
+                [$gatewayId => $deprecatedGatewayHelper],
+            ])
+            ->onlyMethods([
+                'processPaymentForMollie',
+                'processInitialOrderStatus',
+                'getUserMollieCustomerId',
+                'needsSubscriptionSwitch',
+                'paymentTypeBasedOnGateway',
+                'paymentTypeBasedOnProducts',
+            ])
+            ->getMock();
+
+        $sut->expects($this->never())->method('processPaymentForMollie');
+        $sut->method('processInitialOrderStatus')->willReturn('pending');
+        $sut->method('getUserMollieCustomerId')->willReturn(null);
+        $sut->method('needsSubscriptionSwitch')->willReturn(false);
+        $sut->method('paymentTypeBasedOnGateway')->willReturn(PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER);
+        $sut->method('paymentTypeBasedOnProducts')->willReturn(PaymentProcessor::PAYMENT_METHOD_TYPE_ORDER);
+
+        $gateway = $this->helperMocks->genericPaymentGatewayMock();
+        $gateway->id = $gatewayId;
+        $gateway->method('get_return_url')->willReturn('https://example.com/return');
+
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn(42);
+        $order->shouldReceive('is_paid')->andReturn(true);
+
+        // When
+        $result = $sut->processPayment($order, $gateway);
+
+        // Then
+        $this->assertSame(['result' => 'failure'], $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 7 — subscription switch path → cancel logic NOT reached
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When processPayment() is entered through the needsSubscriptionSwitch()
+     *           path (subscription switch with 0.00 total), cancelExistingMolliePaymentIfPending()
+     *           is NOT invoked — the cancel-before-create logic must be placed after
+     *           the subscription-switch early-return.
+     */
+    public function test_subscription_switch_path_does_not_invoke_cancel_logic(): void
+    {
+        // Arrange — cancel endpoints must never be reached when subscription switch exits early
+        $this->orderEndpointMock->shouldReceive('get')->never();
+        $this->paymentEndpointMock->shouldReceive('get')->never();
+        $this->paymentEndpointMock->shouldReceive('cancel')->never();
+
+        $gatewayId = 'mollie_wc_gateway_ideal';
+        $deprecatedGatewayHelper = $this->helperMocks->mollieGatewayBuilder('Ideal', false, false, []);
+
+        $sut = $this->getMockBuilder(PaymentProcessor::class)
+            ->setConstructorArgs([
+                $this->helperMocks->noticeMock(),
+                $this->logger,
+                $this->helperMocks->paymentFactory(),
+                $this->helperMocks->dataHelper($this->apiClientMock),
+                $this->helperMocks->apiHelper($this->apiClientMock),
+                $this->helperMocks->settingsHelper(),
+                $this->helperMocks->pluginId(),
+                $this->createMock(PaymentCheckoutRedirectService::class),
+                [$gatewayId => $deprecatedGatewayHelper],
+            ])
+            ->onlyMethods([
+                'needsSubscriptionSwitch',
+                'processSubscriptionSwitch',
+                'processInitialOrderStatus',
+                'getUserMollieCustomerId',
+            ])
+            ->getMock();
+
+        $sut->method('needsSubscriptionSwitch')->willReturn(true);
+        $sut->method('processSubscriptionSwitch')->willReturn(['result' => 'failure']);
+        $sut->method('processInitialOrderStatus')->willReturn('pending');
+        $sut->method('getUserMollieCustomerId')->willReturn(null);
+
+        $gateway = $this->helperMocks->genericPaymentGatewayMock();
+        $gateway->id = $gatewayId;
+        $gateway->method('get_return_url')->willReturn('https://example.com/return');
+
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn(99);
+        $order->shouldReceive('is_paid')->andReturn(false);
+
+        // When
+        $result = $sut->processPayment($order, $gateway);
+
+        // Then
+        $this->assertSame(['result' => 'failure'], $result);
+        // Mockery verifies never() on endpoints in tearDown
+    }
+}

--- a/tests/php/Functional/Payment/PaymentServiceTest.php
+++ b/tests/php/Functional/Payment/PaymentServiceTest.php
@@ -262,6 +262,7 @@ class PaymentServiceTest extends TestCase
                 'get_order_number' => 1,
                 'get_payment_method' => 'mollie_wc_gateway_ideal',
                 'get_currency' => 'EUR',
+                'is_paid' => false,
             ]
         );
 


### PR DESCRIPTION
What and why
  
  When a user opens the WooCommerce checkout in two browser tabs and initiates a payment in both, processPayment()
  created two independent Mollie payments for the same WC order without any idempotency check. The second call
  would overwrite _mollie_payment_id (and _mollie_order_id on the Orders API) in order meta with the newer
  transaction's ID. The first payment's webhook could then no longer locate the order — the meta-key lookup
  returned the second payment's ID, not the first — causing the webhook to either fail with HTTP 400 or silently
  complete the second payment without flagging the duplicate. The merchant's books showed the order paid once
  while Mollie had charged the customer twice. Reproducer logs from MollieWoo 8.1.5-beta confirmed the failure
  path: "No orders found for transaction ID: tr_eGy... fall back to search in meta data", "orderNeedsPayment
  check: yes, order not previously processed by Mollie gateway".

  What changed

  - src/Payment/PaymentProcessor.php — Added an $order->is_paid() early-return guard at the top of
  processPayment() and a new private method cancelExistingMolliePaymentIfPending() called after the
  subscription-switch early-return and before new-payment creation.
  
  How it works now

  When processPayment() is called, it first checks $order->is_paid() and returns ['result' => 'failure']
  immediately if the order is already settled — a safety net for the case where the first webhook has already
  completed the order before the second tab's request arrives. Before creating a new Mollie payment,
  cancelExistingMolliePaymentIfPending() reads _mollie_order_id or _mollie_payment_id from order meta; if a
  previous ord_* or tr_* is found and is still in a cancellable state (isCreated, isAuthorized, or isShipping for
  orders; isCancelable && !isCanceled && !isPaid && !isAuthorized for payments), it is cancelled via the Mollie
  API and an order note is written for the merchant audit trail. Any ApiException from the lookup or cancel is
  caught and logged at debug level without aborting the new payment attempt.

  What to verify in review

  Covered by unit tests

  - ✓ An ord_* order in a cancellable state is cancelled via the Mollie orders endpoint and an order note
  containing the order ID is added.
  - ✓ A tr_* payment with isCancelable=true, not already cancelled/paid/authorized, is cancelled via the Mollie
  payments endpoint and an order note containing the payment ID is added.
  - ✓ When the previous payment is already in a terminal state, the cancel endpoint is never called and the status
  is logged at debug level.
  - ✓ When the Mollie API throws ApiException during lookup or cancel, the exception is logged at debug level and
  does not propagate; processPayment() continues to create the new payment.
  - ✓ When the order has no _mollie_order_id and no _mollie_payment_id meta, no API call is made and no order note
  is added.
  - ✓ When $order->is_paid() returns true at entry, processPayment() returns ['result' => 'failure'] immediately
  without calling cancelExistingMolliePaymentIfPending() or touching the Mollie API.
  - ✓ When needsSubscriptionSwitch() returns true and exits early, cancelExistingMolliePaymentIfPending() is never
  reached — the cancel logic is correctly positioned after the subscription-switch early-return.

  Not covered by unit tests
  
  None — all seven acceptance criteria are covered by the test suite.

  What must not regress

  - MollieObject::setActiveMolliePayment() and related meta-write methods — canonical write path for
  _mollie_payment_id / _mollie_order_id; changes here affect every payment method.
  - MolliePayment::setActiveMolliePayment() / MollieOrder::setActiveMolliePayment() — their override logic is
  load-bearing for the Orders API vs Payments API split.
  - RestApi — webhook routing and response codes are intentionally left unchanged; the silent-discard behaviour is
  a follow-up concern scoped out of this fix.
  - WebhookHandler — all payment-status lifecycle transitions flow through this class; unplanned changes risk
  breaking payment completion.
  - MollieOrderService::doPaymentForOrder() and ::onWebhookActionFallback() — subscription renewal and webhook
  fallback paths; regressions here break recurring payments.

