### PR TITLE
Guard hide_order_lines key access with null coalescing operator

### DIFF
--- a/src/Payment/Request/Middleware/OrderLinesMiddleware.php
+++ b/src/Payment/Request/Middleware/OrderLinesMiddleware.php
@@ -46,7 +46,7 @@ class OrderLinesMiddleware implements RequestMiddlewareInterface
         if ($context === 'payment') {
             $methodId = $requestData['method'] ?? '';
             $optionName = 'mollie_wc_gateway_' . $methodId . '_settings';
-            $hideOrderLines = get_option($optionName, false)['hide_order_lines'] === 'yes';
+            $hideOrderLines = (get_option($optionName, false)['hide_order_lines'] ?? '') === 'yes';
             if ($hideOrderLines) {
                 /**
                  * Merchant has configured to hide order lines via payment method settings.

--- a/tests/php/Unit/Payment/Request/Middleware/OrderLinesMiddlewareTest.php
+++ b/tests/php/Unit/Payment/Request/Middleware/OrderLinesMiddlewareTest.php
@@ -1,0 +1,121 @@
+<?php
+// kb-active
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Payment\Request\Middleware;
+
+use Mockery;
+use Mollie\WooCommerce\Payment\LineItems\LineItemProvider;
+use Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware;
+use Mollie\WooCommerceTests\TestCase;
+use WC_Order;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware
+ */
+class OrderLinesMiddlewareTest extends TestCase
+{
+    /** @var LineItemProvider&\Mockery\MockInterface */
+    private $orderLines;
+
+    /** @var LineItemProvider&\Mockery\MockInterface */
+    private $paymentLines;
+
+    private OrderLinesMiddleware $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->orderLines = Mockery::mock(LineItemProvider::class);
+        $this->paymentLines = Mockery::mock(LineItemProvider::class);
+        $this->sut = new OrderLinesMiddleware($this->orderLines, $this->paymentLines);
+    }
+
+    /**
+     * @scenario When get_option() returns an array without a hide_order_lines key (e.g. Klarna, Billie), no PHP Warning is emitted and $hideOrderLines evaluates to false.
+     * @covers \Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware::__invoke
+     */
+    public function testInvokeWithMissingHideOrderLinesKeyIncludesPaymentLines(): void
+    {
+        when('get_option')->justReturn(['other_setting' => 'value']);
+        $order = new WC_Order();
+        $expectedLines = [['name' => 'item1']];
+        $this->paymentLines->shouldReceive('order_lines')->once()->with($order)->andReturn($expectedLines);
+
+        $warningFired = false;
+        set_error_handler(static function (int $errno) use (&$warningFired): bool {
+            if ($errno === E_WARNING) {
+                $warningFired = true;
+            }
+            return true;
+        }, E_WARNING);
+
+        $result = ($this->sut)(['method' => 'klarna'], $order, 'payment', static fn($data, $o, $c) => $data);
+
+        restore_error_handler();
+
+        self::assertFalse($warningFired, 'No PHP Warning should be emitted when hide_order_lines key is absent.');
+        self::assertSame($expectedLines, $result['lines']);
+    }
+
+    /**
+     * @scenario When get_option() returns an array with hide_order_lines set to 'yes', $hideOrderLines evaluates to true and order lines are skipped.
+     * @covers \Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware::__invoke
+     */
+    public function testInvokeWithHideOrderLinesYesSkipsPaymentLines(): void
+    {
+        when('get_option')->justReturn(['hide_order_lines' => 'yes']);
+        $order = new WC_Order();
+        $this->paymentLines->shouldNotReceive('order_lines');
+
+        $result = ($this->sut)(['method' => 'ideal'], $order, 'payment', static fn($data, $o, $c) => $data);
+
+        self::assertArrayNotHasKey('lines', $result);
+    }
+
+    /**
+     * @scenario When get_option() returns an array with hide_order_lines set to any value other than 'yes' (e.g. 'no', '0', ''), $hideOrderLines evaluates to false and order lines are included.
+     * @covers \Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware::__invoke
+     */
+    public function testInvokeWithHideOrderLinesNonYesIncludesPaymentLines(): void
+    {
+        when('get_option')->justReturn(['hide_order_lines' => 'no']);
+        $order = new WC_Order();
+        $expectedLines = [['name' => 'item1']];
+        $this->paymentLines->shouldReceive('order_lines')->once()->with($order)->andReturn($expectedLines);
+
+        $result = ($this->sut)(['method' => 'ideal'], $order, 'payment', static fn($data, $o, $c) => $data);
+
+        self::assertSame($expectedLines, $result['lines']);
+    }
+
+    /**
+     * @scenario When get_option() returns false (option does not exist at all), no PHP Warning is emitted and $hideOrderLines evaluates to false.
+     * @covers \Mollie\WooCommerce\Payment\Request\Middleware\OrderLinesMiddleware::__invoke
+     */
+    public function testInvokeWithGetOptionReturnsFalseIncludesPaymentLines(): void
+    {
+        when('get_option')->justReturn(false);
+        $order = new WC_Order();
+        $expectedLines = [['name' => 'item1']];
+        $this->paymentLines->shouldReceive('order_lines')->once()->with($order)->andReturn($expectedLines);
+
+        $warningFired = false;
+        set_error_handler(static function (int $errno) use (&$warningFired): bool {
+            if ($errno === E_WARNING) {
+                $warningFired = true;
+            }
+            return true;
+        }, E_WARNING);
+
+        $result = ($this->sut)(['method' => 'ideal'], $order, 'payment', static fn($data, $o, $c) => $data);
+
+        restore_error_handler();
+
+        self::assertFalse($warningFired, 'No PHP Warning should be emitted when get_option() returns false.');
+        self::assertSame($expectedLines, $result['lines']);
+    }
+}


### PR DESCRIPTION
What and why
  
  OrderLinesMiddleware::__invoke() reads the hide_order_lines setting from WordPress options to decide whether to
  include line items in a payment request. The code assumed this key would always be present in the option array,
  but Klarna and Billie intentionally remove the hide_order_lines field from their settings form. Because the
  field is never rendered, it is never submitted and never persisted, so get_option() returns an array that does
  not contain the key. Direct array access on a missing key emits PHP Warning: Undefined array key 
  "hide_order_lines" on every payment request through those methods.

  What changed

  - src/Payment/Request/Middleware/OrderLinesMiddleware.php — replaced direct array key access with the null
  coalescing operator (??) so a missing hide_order_lines key (or a false return from get_option()) resolves safely
  to false without emitting a PHP Warning
  - tests/php/Unit/Payment/Request/Middleware/OrderLinesMiddlewareTest.php — new unit test class covering all four
  key states: absent key, 'yes', non-'yes', and get_option() returning false

  How it works now

  OrderLinesMiddleware::__invoke() builds the option name from the payment method ID in the request data and calls
  get_option(). The result is now read as (get_option($optionName, false)['hide_order_lines'] ?? '') === 'yes':
  the null coalescing operator uses isset() semantics internally, so an absent key or a non-array value both yield
  the default empty string instead of triggering a warning. The downstream behavior is unchanged — when the key
  is absent the flag is false and line items are included as normal.

  What to verify in review

  Covered by unit tests

  - ✓ When the option array exists but has no hide_order_lines key (Klarna, Billie), no PHP Warning is emitted and
  line items are included in the request
  - ✓ When hide_order_lines is 'yes', paymentLines->order_lines() is not called and lines is absent from the
  request data passed to the next middleware
  - ✓ When hide_order_lines is any value other than 'yes' (e.g. 'no', '0', ''), line items are included
  - ✓ When get_option() returns false (option not yet stored), no PHP Warning is emitted and line items are
  included

  What must not regress
  
  - src/PaymentMethods/Klarna.php — intentionally removes hide_order_lines from form fields; this is the
  documented reason the key is absent and must remain the source of truth for that decision
  - src/PaymentMethods/Billie.php — same as Klarna; the field removal is intentional and must not be restored

