### PR TITLE
Guard gateway init against unregistered WC post types (861)

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -86,6 +86,9 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         });
 
         add_action('woocommerce_init', static function () use ($container) {
+            if (!post_type_exists('shop_order')) {
+                return;
+            }
             $gateways = WC()->payment_gateways()->payment_gateways();
             $deprecatedGatewayHelpers = $container->get('__deprecated.gateway_helpers');
             foreach ($gateways as $gateway) {


### PR DESCRIPTION
What and why
  
  When the woocommerce_init hook fires in certain admin contexts — such as generating a packing slip via the
  WooCommerce Print Invoices/Packing Lists plugin — WooCommerce's order post types are not yet registered.
  GatewayModule hooks into woocommerce_init and immediately calls WC()->payment_gateways()->payment_gateways(),
  which triggers the woocommerce_available_payment_gateways filter. WooCommerce Subscriptions hooks into that
  filter and calls wc_get_order(), which requires shop_order post types to be present. Because they aren't in this
  context, the call produces a fatal error and the packing slip cannot be generated.

  What changed

  - src/Gateway/GatewayModule.php — added an early return at the top of the woocommerce_init callback, before any
  WC gateway access, guarded by post_type_exists('shop_order')

  How it works now

  GatewayModule::run() registers a woocommerce_init callback that sets up subscription filters, payment
  instructions, and thankyou-page hooks for each Mollie gateway. That callback now checks
  post_type_exists('shop_order') as its first statement. On a normal frontend or admin checkout page load, WC has
  already registered its post types and the check passes. In admin contexts where WC boots only partially — such
  as packing slip generation — the check fails and the callback returns immediately, skipping the
  WC()->payment_gateways() call that would otherwise trigger the fatal.

  What to verify in review

  Not covered by unit tests

  - ✗ No fatal error occurs when generating a packing slip with WooCommerce Subscriptions active — depends on the
  Subscriptions plugin contributing its woocommerce_available_payment_gateways filter; requires a full WordPress +
  WooCommerce + Subscriptions + Print Invoices stack to reproduce
  - ✗ Frontend checkout continues to load Mollie gateways and subscription filters — regression; verify manually
  or via existing E2E suite
  - ✗ Mollie gateways remain visible in the Gutenberg admin checkout block preview — verify manually; the
  is_admin() approach was explicitly rejected because it would break this

  What must not regress
  
  - AssetsModule::registerBlockScripts() — this method is safe (does not call WC()->payment_gateways()); it must
  not be touched as part of any follow-up to this fix
  - AssetsModule::enqueueFrontendScripts() — already has its own is_admin() guard; no changes needed here
  - AssetsModule wp_enqueue_scripts callbacks — frontend-only enqueueing; must remain unconditional inside the
  woocommerce_init closure
  - The body of GatewayModule's woocommerce_init callback beyond the new guard — subscription filters,
  instructions, and thankyou hooks must still run on normal page loads

