### PR TITLE
Undefined array key warning in mollie pay pal button due to malformed color setting wordpress forums (869)

### DIFF
--- a/src/Buttons/PayPalButton/DataToPayPal.php
+++ b/src/Buttons/PayPalButton/DataToPayPal.php
@@ -67,7 +67,7 @@ class DataToPayPal
         $colorSetting = isset($paypalSettings['color']) ? $paypalSettings['color'] : "en-checkout-pill-golden";
         $dataArray = explode('-', $colorSetting);//[0]lang [1]folder [2]first part filename [3] second part filename
         $fixPath = 'public/images/PayPal_Buttons/';
-        $buildButtonName = sprintf('%s/%s/%s-%s.png', $dataArray[0], $dataArray[1], $dataArray[2], $dataArray[3]);
+        $buildButtonName = sprintf('%s/%s/%s-%s.png', $dataArray[0] ?? 'en', $dataArray[1] ?? 'checkout', $dataArray[2] ?? 'pill', $dataArray[3] ?? 'golden');
         $path = sprintf('%s%s', $fixPath, $buildButtonName);
         if (file_exists(M4W_PLUGIN_DIR . '/' . $path)) {
             return sprintf('%s%s', $fixPath, $buildButtonName);

--- a/tests/php/Functional/PayPalButton/DataToPayPalButtonScriptsTest.php
+++ b/tests/php/Functional/PayPalButton/DataToPayPalButtonScriptsTest.php
@@ -257,7 +257,6 @@ class DataToPayPalButtonScriptsTest extends TestCase
         when('__')->returnArg(1);
     }
 
-    // kb-active
 
     public function testWhichPaypalButtonReturnsPathForFourSegmentColor()
     {

--- a/tests/php/Functional/PayPalButton/DataToPayPalButtonScriptsTest.php
+++ b/tests/php/Functional/PayPalButton/DataToPayPalButtonScriptsTest.php
@@ -257,4 +257,117 @@ class DataToPayPalButtonScriptsTest extends TestCase
         when('__')->returnArg(1);
     }
 
+    // kb-active
+
+    public function testWhichPaypalButtonReturnsPathForFourSegmentColor()
+    {
+        /*
+         * Stubs
+         */
+        stubs([
+            'get_option' => ['color' => 'en-checkout-pill-golden'],
+        ]);
+
+        /*
+         * Sut
+         */
+        $pluginUrl = 'http://pluginUrl.com/';
+        $sut = new DataToPayPal($pluginUrl);
+
+        /*
+         * Execute Test
+         */
+        $result = $sut->selectedPaypalButtonUrl();
+        self::assertStringContainsString('en/checkout/pill-golden.png', $result);
+    }
+
+    public function testWhichPaypalButtonHandlesTwoSegmentColorWithFallbacks()
+    {
+        /*
+         * Stubs
+         */
+        stubs([
+            'get_option' => ['color' => 'en-buy'],
+        ]);
+
+        /*
+         * Sut
+         */
+        $pluginUrl = 'http://pluginUrl.com/';
+        $sut = new DataToPayPal($pluginUrl);
+
+        /*
+         * Execute Test
+         */
+        $result = $sut->selectedPaypalButtonUrl();
+        self::assertStringContainsString('en/buy/pill-golden.png', $result);
+    }
+
+    public function testWhichPaypalButtonHandlesEmptyStringColorWithoutFatalError()
+    {
+        /*
+         * Stubs
+         */
+        stubs([
+            'get_option' => ['color' => ''],
+        ]);
+
+        /*
+         * Sut
+         */
+        $pluginUrl = 'http://pluginUrl.com/';
+        $sut = new DataToPayPal($pluginUrl);
+
+        /*
+         * Execute Test
+         */
+        $result = $sut->selectedPaypalButtonUrl();
+        self::assertIsString($result);
+        self::assertNotEmpty($result);
+    }
+
+    public function testWhichPaypalButtonUsesDefaultColorWhenColorKeyAbsent()
+    {
+        /*
+         * Stubs
+         */
+        stubs([
+            'get_option' => ['enabled' => 'yes'],
+        ]);
+
+        /*
+         * Sut
+         */
+        $pluginUrl = 'http://pluginUrl.com/';
+        $sut = new DataToPayPal($pluginUrl);
+
+        /*
+         * Execute Test
+         */
+        $result = $sut->selectedPaypalButtonUrl();
+        self::assertStringContainsString('en/checkout/pill-golden.png', $result);
+    }
+
+    public function testWhichPaypalButtonReturnsFallbackWhenConstructedPathNotFound()
+    {
+        /*
+         * Stubs
+         */
+        stubs([
+            'get_option' => ['color' => 'en-checkout-rounded-purple'],
+        ]);
+
+        /*
+         * Sut
+         */
+        $pluginUrl = 'http://pluginUrl.com/';
+        $sut = new DataToPayPal($pluginUrl);
+
+        /*
+         * Execute Test
+         */
+        $result = $sut->selectedPaypalButtonUrl();
+        self::assertStringContainsString('en/checkout/pill-golden.png', $result);
+    }
+
 }


### PR DESCRIPTION
 What and why
  
  The PayPal express button in Mollie Payments for WooCommerce reads a hyphen-delimited color setting from the
  WordPress options table (mollie_wc_gateway_paypal_settings['color']) and uses explode('-', ...) to split it into
  four segments before building an image path. The code assumed the stored value would always contain exactly
  four parts, but made no attempt to validate this. If the database held a malformed or legacy value with fewer
  than four segments — for example after a plugin downgrade, a manual database edit, or an import — PHP 8 would
  emit Undefined array key warnings for indices 2 and 3 on every page load that rendered the button. The warnings
  were visible in debug logs and on product pages with WP_DEBUG enabled.

  What changed

  - src/Buttons/PayPalButton/DataToPayPal.php — replaced bare $dataArray[n] accesses in whichPayPalButton() with
  null-coalescing expressions so that each missing segment falls back to a sensible default rather than triggering
  a PHP warning
  - tests/php/Functional/PayPalButton/DataToPayPalButtonScriptsTest.php — added five test methods covering valid
  4-segment input, 2-segment input with fallbacks, empty string input, absent color key, and a color that resolves
  to a non-existent image file

  How it works now

  DataToPayPal::whichPayPalButton() still calls explode('-', $colorSetting) to split the color setting, but each
  of the four array accesses is now guarded: $dataArray[0] ?? 'en', $dataArray[1] ?? 'checkout', $dataArray[2] ?? 
  'pill', $dataArray[3] ?? 'golden'. If the stored value has fewer than four segments, the missing parts are
  replaced by these per-index defaults, producing a well-formed path like en/buy/pill-golden.png. If the
  constructed path does not exist on disk, the pre-existing file_exists() fallback already returns the static
  default image; no change was needed there.

  What to verify in review

  Covered by unit tests

  - ✓ A valid 4-segment color value (en-checkout-pill-golden) returns a URL containing en/checkout/pill-golden.png
  - ✓ A 2-segment color value (en-buy) produces a URL containing en/buy/pill-golden.png using pill and golden as
  fallbacks for the missing indices — this is the primary regression test and is red before the fix
  - ✓ An empty string color value does not crash the method and returns a non-empty string
  - ✓ Settings with no color key fall through to the hardcoded default en-checkout-pill-golden and return a URL
  containing en/checkout/pill-golden.png
  - ✓ A 4-segment color that resolves to a non-existent image file returns the static fallback URL containing
  en/checkout/pill-golden.png

  
  What must not regress

  - DataToPayPal::paypalbuttonScriptData() — orchestrates product/cart/block data; untouched by this fix
  - DataToPayPal::selectedPaypalButtonUrl() — the public entry point that wraps whichPayPalButton(); untouched
  - DataToPayPal::dataForProductPage() — product page data builder; untouched
  - DataToPayPal::dataForCartPage() — cart page data builder; untouched
  - DataToPayPal::dataForBlockCartPage() — block cart data builder; untouched

