### PR TITLE
[PIWOO-883] Improve Mollie gateway detection logic

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -147,13 +147,8 @@ function mollieWooCommerceIsDropdownEnabled($gatewaySettingsName)
 */
 function mollieWooCommerceIsMollieGateway($gateway)
 {
-    if (
-        (is_string($gateway) && strpos($gateway, 'mollie_wc_gateway_') !== false)
-        || (is_object($gateway) && strpos($gateway->id, 'mollie_wc_gateway_') !== false)
-    ) {
-        return true;
-    }
-    return false;
+    $id = is_string($gateway) ? $gateway : (is_object($gateway) ? $gateway->id : '');
+    return strpos($id, 'mollie_wc_gateway_') === 0;
 }
 
 /**

--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -89,12 +89,12 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
             $gateways = WC()->payment_gateways()->payment_gateways();
             $deprecatedGatewayHelpers = $container->get('__deprecated.gateway_helpers');
             foreach ($gateways as $gateway) {
-                $isMolliegateway = is_string($gateway) && strpos($gateway, 'mollie_wc_gateway_') !== false
-                    || is_object($gateway) && strpos($gateway->id, 'mollie_wc_gateway_') !== false;
-                if (!$isMolliegateway) {
+                if (
+                    !$gateway instanceof PaymentGateway
+                    || !array_key_exists($gateway->id, $deprecatedGatewayHelpers)
+                ) {
                     continue;
                 }
-                assert($gateway instanceof PaymentGateway);
                 // Add subscription filters after payment gateways are loaded
                 $isSubscriptiongateway = $gateway->supports('subscriptions');
                 if (


### PR DESCRIPTION
# Fix Mollie gateway ownership checks (closes #1209)

## Problem

Two issues existed in how the plugin identifies its own payment gateways in the WooCommerce gateway list:

**1. Fatal error with Germanized for WooCommerce**

`GatewayModule::run()` iterated all registered payment gateways, identified Mollie-prefixed ones, then called `assert($gateway instanceof PaymentGateway)`. Germanized for WooCommerce registers placeholder gateways that mirror Mollie gateway IDs but only extend `WC_Payment_Gateway`, not Mollie's `PaymentGateway` base class. The assertion caused a fatal error on sites with both plugins active.

**2. Fuzzy gateway ID matching**

Both `GatewayModule` and the global `mollieWooCommerceIsMollieGateway()` helper used `strpos($id, 'mollie_wc_gateway_') !== false` — a substring check that matches any string containing the prefix, not just ones that start with it. A gateway ID like `external_mollie_wc_gateway_foo` would incorrectly pass.

## Solution

Replace loose string-contains checks with stricter type-safe checks for identifying Mollie payment gateways.

In GatewayModule.php, replace the manual string/object type check and assert() with an instanceof check combined with an array_key_exists lookup against known deprecated gateway helpers, ensuring only valid registered gateways are processed.

In utils.php, simplify mollieWooCommerceIsMollieGateway() to extract the ID safely and use a prefix check (=== 0) instead of a substring match, preventing false positives from IDs that merely contain the prefix somewhere in the middle.

Fixes #1209