### PR TITLE
PIWOO-886 Update API key guidance to reflect new Mollie Dashboard flow

### DIFF
--- a/src/SDK/Api.php
+++ b/src/SDK/Api.php
@@ -53,7 +53,7 @@ class Api
                         "Invalid API key(s). Get them on the %1\$sDevelopers page in the Mollie dashboard%2\$s. The API key(s) must start with 'live_' or 'test_', be at least 30 characters and must not contain any special characters.",
                         'mollie-payments-for-woocommerce'
                     ),
-                    '<a href="https://my.mollie.com/dashboard/developers/api-keys?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner" target="_blank">',
+                    '<a href="https://my.mollie.com/dashboard/developers/api-access-tokens?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner" target="_blank">',
                     '</a>'
                 )
             );

--- a/src/Settings/Page/Section/ConnectionFields.php
+++ b/src/Settings/Page/Section/ConnectionFields.php
@@ -42,10 +42,10 @@ class ConnectionFields extends AbstractSection
                 'type' => 'text',
                 'desc' => sprintf(
                     __(
-                        "Use your <a href='%s' target='_blank'>Live API key</a> when you're ready to receive real payments.",
+                        "In the Mollie Dashboard, <a href='%s' target='_blank'>create a Standard API key access token</a> in Live mode and paste it here when you're ready to receive real payments.",
                         'mollie-payments-for-woocommerce'
                     ),
-                    'https://my.mollie.com/dashboard/developers/api-keys?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner'
+                    'https://my.mollie.com/dashboard/developers/api-access-tokens?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner'
                 ),
                 'css' => 'width: 350px',
                 'placeholder' => __(
@@ -60,10 +60,10 @@ class ConnectionFields extends AbstractSection
                 'type' => 'text',
                 'desc' => sprintf(
                     __(
-                        "Use your <a href='%s' target='_blank'>Test APl key</a> to check the connection and test transactions without a fee.",
+                        "In the Mollie Dashboard, <a href='%s' target='_blank'>create a Standard API key access token</a> in Test mode and paste it here to check the connection and test transactions without a fee.",
                         'mollie-payments-for-woocommerce'
                     ),
-                    'https://my.mollie.com/dashboard/developers/api-keys?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner'
+                    'https://my.mollie.com/dashboard/developers/api-access-tokens?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner'
                 ),
                 'css' => 'width: 350px',
                 'placeholder' => __(

--- a/src/Settings/Page/Section/InstructionsConnected.php
+++ b/src/Settings/Page/Section/InstructionsConnected.php
@@ -25,11 +25,11 @@ class InstructionsConnected extends AbstractSection
         <p>
             <?= wp_kses(sprintf(
                 __(
-                    "To start receiving payments through the Mollie plugin in your WooCommerce store, 
-                you'll need to connect it to your Mollie account using an <a href='%s' target='_blank'>API key.</a>",
+                    "To start receiving payments through the Mollie plugin in your WooCommerce store,
+                you'll need to connect it to your Mollie account using an <a href='%s' target='_blank'>API access token.</a>",
                     'mollie-payments-for-woocommerce'
                 ),
-                'https://my.mollie.com/dashboard/developers/api-keys?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner'
+                'https://my.mollie.com/dashboard/developers/api-access-tokens?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner'
             ), [
                     'a' => [
                             'target' => [],

--- a/src/Settings/Page/Section/InstructionsNotConnected.php
+++ b/src/Settings/Page/Section/InstructionsNotConnected.php
@@ -65,7 +65,7 @@ class InstructionsNotConnected extends AbstractSection
             </li>
             <li>
                 <?= wp_kses(
-                    __("Navigate to <strong>Developers > API keys.</strong>", 'mollie-payments-for-woocommerce'),
+                    __("Navigate to <strong>Developers > API access tokens.</strong>", 'mollie-payments-for-woocommerce'),
                     [
                                 'strong' => [],
                         ]
@@ -73,7 +73,7 @@ class InstructionsNotConnected extends AbstractSection
             </li>
             <li>
                 <?= wp_kses(
-                    __("Click on <strong>Copy</strong> next to your API key.", 'mollie-payments-for-woocommerce'),
+                    __("Click <strong>+ Create access token</strong>, select <strong>Standard API key</strong> as the token type, choose your payment profile and API mode (Test or Live), then click <strong>Create access token</strong>.", 'mollie-payments-for-woocommerce'),
                     [
                         'strong' => [],
                         ]


### PR DESCRIPTION
The Mollie Dashboard now exposes keys via "API access tokens" (Standard API key type) rather than the old "API keys" page. Update all in-plugin descriptions, step-by-step instructions, and error messages to point merchants to the correct URL and explain the create-access-token flow. Also fixes a pre-existing typo: "APl key" → "API key".


- Updates in-plugin descriptions for the Live and Test API key fields to explain that merchants must create a Standard API key access token (in Live or Test mode respectively) via Developers > API access tokens
- Updates the step-by-step instructions for unconnected merchants (steps 3 & 4) to match the new "+ Create access token" flow
- Updates all links from /developers/api-keys → /developers/api-access-tokens
- Fixes a pre-existing typo: "Test APl key" → "Test API key"

Fixes PIWOO-886.