### PR TITLE
Prevent duplicate Mollie payments when order is submitted twice

### DIFF
--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -872,7 +872,7 @@ class PaymentProcessor implements PaymentProcessorInterface
 
                 if ($mollieOrder->isCompleted() || $mollieOrder->isExpired()) {
                     $this->logger->debug(
-                        "Previous Mollie order {$mollieOrderId} is in a terminal state, proceeding with new payment."
+                        "Previous Mollie order {$mollieOrderId} is already completed or expired — no cancellation needed, proceeding with new payment."
                     );
                     return null;
                 }
@@ -901,7 +901,7 @@ class PaymentProcessor implements PaymentProcessorInterface
 
                 if ($payment->isPaid() || $payment->isCanceled() || $payment->isExpired() || $payment->isFailed() || $payment->isAuthorized()) {
                     $this->logger->debug(
-                        "Previous Mollie payment {$molliePaymentId} is in a terminal or authorized state, proceeding with new payment."
+                        "Previous Mollie payment {$molliePaymentId} is already paid, canceled, expired, failed, or authorized — no cancellation needed, proceeding with new payment."
                     );
                     return null;
                 }

--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -115,7 +115,10 @@ class PaymentProcessor implements PaymentProcessorInterface
             return $this->processSubscriptionSwitch($order, $orderId, $customerId, $apiKey);
         }
 
-        $this->cancelExistingMolliePaymentIfPending($order, $apiKey);
+        $earlyReturn = $this->cancelExistingMolliePaymentIfPending($order, $apiKey);
+        if ($earlyReturn !== null) {
+            return $earlyReturn;
+        }
 
         $molliePaymentType = $this->paymentTypeBasedOnGateway($paymentMethod);
         $molliePaymentType = $this->paymentTypeBasedOnProducts($order, $molliePaymentType);
@@ -836,7 +839,7 @@ class PaymentProcessor implements PaymentProcessorInterface
         );
     }
 
-    private function cancelExistingMolliePaymentIfPending(WC_Order $order, string $apiKey): void
+    private function cancelExistingMolliePaymentIfPending(WC_Order $order, string $apiKey): ?array
     {
         $mollieOrderId = $order->get_meta('_mollie_order_id', true);
 
@@ -850,7 +853,7 @@ class PaymentProcessor implements PaymentProcessorInterface
                     $this->logger->debug(
                         "Previous Mollie order {$mollieOrderId} is already canceled, skipping cancel before new payment."
                     );
-                    return;
+                    return null;
                 }
 
                 if ($mollieOrder->isCreated() || $mollieOrder->isAuthorized() || $mollieOrder->isShipping()) {
@@ -864,13 +867,17 @@ class PaymentProcessor implements PaymentProcessorInterface
                             $mollieOrderId
                         )
                     );
-                    return;
+                    return null;
                 }
 
-                $this->logger->debug(
-                    "Previous Mollie order {$mollieOrderId} is in a non-cancellable state, skipping cancel before new payment."
-                );
-                return;
+                if ($mollieOrder->isCompleted() || $mollieOrder->isExpired()) {
+                    $this->logger->debug(
+                        "Previous Mollie order {$mollieOrderId} is in a terminal state, proceeding with new payment."
+                    );
+                    return null;
+                }
+
+                return $this->buildActivePaymentResponse($mollieOrder->getCheckoutUrl(), $mollieOrderId);
             }
 
             $molliePaymentId = $order->get_meta('_mollie_payment_id', true);
@@ -889,18 +896,47 @@ class PaymentProcessor implements PaymentProcessorInterface
                             $molliePaymentId
                         )
                     );
-                    return;
+                    return null;
                 }
 
-                $this->logger->debug(
-                    "Previous Mollie payment {$molliePaymentId} is in a non-cancellable state, skipping cancel before new payment."
-                );
+                if ($payment->isPaid() || $payment->isCanceled() || $payment->isExpired() || $payment->isFailed() || $payment->isAuthorized()) {
+                    $this->logger->debug(
+                        "Previous Mollie payment {$molliePaymentId} is in a terminal or authorized state, proceeding with new payment."
+                    );
+                    return null;
+                }
+
+                return $this->buildActivePaymentResponse($payment->getCheckoutUrl(), $molliePaymentId);
             }
         } catch (ApiException $e) {
             $this->logger->debug(
                 "Failed to cancel previous Mollie payment before creating new one: " . $e->getMessage()
             );
         }
+
+        return null;
+    }
+
+    private function buildActivePaymentResponse(?string $checkoutUrl, string $paymentId): array
+    {
+        if (!empty($checkoutUrl)) {
+            $this->logger->debug(
+                "Previous Mollie payment {$paymentId} is active and non-cancellable. Redirecting customer to existing checkout URL."
+            );
+            return ['result' => 'success', 'redirect' => $checkoutUrl];
+        }
+
+        $this->notice->addNotice(
+            'error',
+            __(
+                'You already have a payment in progress for this order. Please complete it or wait for it to expire before trying again.',
+                'mollie-payments-for-woocommerce'
+            )
+        );
+        $this->logger->debug(
+            "Previous Mollie payment {$paymentId} is active and non-cancellable with no checkout URL. Blocking new payment creation."
+        );
+        return ['result' => 'failure'];
     }
 
     /**

--- a/tests/php/Functional/Payment/PaymentProcessorTest.php
+++ b/tests/php/Functional/Payment/PaymentProcessorTest.php
@@ -67,11 +67,11 @@ class PaymentProcessorTest extends TestCase
         );
     }
 
-    private function invokeCancel(PaymentProcessor $sut, object $order, string $apiKey = 'test_key'): void
+    private function invokeCancel(PaymentProcessor $sut, object $order, string $apiKey = 'test_key'): ?array
     {
         $method = new ReflectionMethod(PaymentProcessor::class, 'cancelExistingMolliePaymentIfPending');
         $method->setAccessible(true);
-        $method->invoke($sut, $order, $apiKey);
+        return $method->invoke($sut, $order, $apiKey);
     }
 
     private function wcOrderWithMeta(array $metaMap = []): object
@@ -395,5 +395,130 @@ class PaymentProcessorTest extends TestCase
         // Then
         $this->assertSame(['result' => 'failure'], $result);
         // Mockery verifies never() on endpoints in tearDown
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 8 — non-cancellable active payment WITH checkout URL → redirect
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When the existing tr_ payment is non-cancellable, not terminal, not
+     *           authorized, and Mollie returns a checkoutUrl, processPayment() must
+     *           redirect the customer to that URL instead of creating a new payment.
+     */
+    public function test_redirects_to_existing_payment_when_non_cancellable_with_checkout_url(): void
+    {
+        $paymentId = 'tr_active1';
+        $checkoutUrl = 'https://checkout.mollie.com/pay/tr_active1';
+
+        $molliePayment = Mockery::mock(MollieApiPayment::class);
+        $molliePayment->isCancelable = false;
+        $molliePayment->shouldReceive('isCanceled')->andReturn(false);
+        $molliePayment->shouldReceive('isPaid')->andReturn(false);
+        $molliePayment->shouldReceive('isExpired')->andReturn(false);
+        $molliePayment->shouldReceive('isFailed')->andReturn(false);
+        $molliePayment->shouldReceive('isAuthorized')->andReturn(false);
+        $molliePayment->shouldReceive('getCheckoutUrl')->andReturn($checkoutUrl);
+
+        $this->paymentEndpointMock->shouldReceive('get')->andReturn($molliePayment);
+        $this->paymentEndpointMock->shouldReceive('cancel')->never();
+
+        $order = $this->wcOrderWithMeta([
+            '_mollie_order_id'   => '',
+            '_mollie_payment_id' => $paymentId,
+        ]);
+        $order->shouldReceive('add_order_note')->never();
+
+        $result = $this->invokeCancel($this->buildSut(), $order);
+
+        $this->assertSame(['result' => 'success', 'redirect' => $checkoutUrl], $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 9 — non-cancellable active payment WITHOUT checkout URL → block
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When the existing tr_ payment is non-cancellable, not terminal, not
+     *           authorized, and no checkoutUrl is available (e.g. iDEAL pending at
+     *           bank), processPayment() must show an error notice and return failure.
+     */
+    public function test_blocks_with_error_notice_when_non_cancellable_no_checkout_url(): void
+    {
+        $paymentId = 'tr_pending1';
+
+        $molliePayment = Mockery::mock(MollieApiPayment::class);
+        $molliePayment->isCancelable = false;
+        $molliePayment->shouldReceive('isCanceled')->andReturn(false);
+        $molliePayment->shouldReceive('isPaid')->andReturn(false);
+        $molliePayment->shouldReceive('isExpired')->andReturn(false);
+        $molliePayment->shouldReceive('isFailed')->andReturn(false);
+        $molliePayment->shouldReceive('isAuthorized')->andReturn(false);
+        $molliePayment->shouldReceive('getCheckoutUrl')->andReturn(null);
+
+        $this->paymentEndpointMock->shouldReceive('get')->andReturn($molliePayment);
+        $this->paymentEndpointMock->shouldReceive('cancel')->never();
+
+        $order = $this->wcOrderWithMeta([
+            '_mollie_order_id'   => '',
+            '_mollie_payment_id' => $paymentId,
+        ]);
+        $order->shouldReceive('add_order_note')->never();
+
+        $noticeMock = Mockery::mock(\Mollie\WooCommerce\Notice\NoticeInterface::class);
+        $noticeMock->shouldReceive('addNotice')
+            ->once()
+            ->with('error', Mockery::type('string'));
+
+        $sut = new PaymentProcessor(
+            $noticeMock,
+            $this->logger,
+            $this->helperMocks->paymentFactory(),
+            $this->helperMocks->dataHelper($this->apiClientMock),
+            $this->helperMocks->apiHelper($this->apiClientMock),
+            $this->helperMocks->settingsHelper(),
+            $this->helperMocks->pluginId(),
+            $this->createMock(PaymentCheckoutRedirectService::class),
+            []
+        );
+
+        $result = $this->invokeCancel($sut, $order);
+
+        $this->assertSame(['result' => 'failure'], $result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Criterion 10 — tr_ payment in terminal state → null (proceed)
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When the existing tr_ payment is in a terminal state (paid, canceled,
+     *           expired, or failed), cancelExistingMolliePaymentIfPending() returns null
+     *           so processPayment() proceeds to create a new payment normally.
+     */
+    public function test_proceeds_when_tr_payment_in_terminal_state(): void
+    {
+        $paymentId = 'tr_paid1';
+
+        $molliePayment = Mockery::mock(MollieApiPayment::class);
+        $molliePayment->isCancelable = false;
+        $molliePayment->shouldReceive('isCanceled')->andReturn(false);
+        $molliePayment->shouldReceive('isPaid')->andReturn(true);
+
+        $this->paymentEndpointMock->shouldReceive('get')->andReturn($molliePayment);
+        $this->paymentEndpointMock->shouldReceive('cancel')->never();
+
+        $order = $this->wcOrderWithMeta([
+            '_mollie_order_id'   => '',
+            '_mollie_payment_id' => $paymentId,
+        ]);
+        $order->shouldReceive('add_order_note')->never();
+
+        $result = $this->invokeCancel($this->buildSut(), $order);
+
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
 Block or redirect second payment attempt if a non-cancellable active payment already exists for the order; cancel it first if still cancellable.