### PR TITLE
Fix subscription renewals

### DIFF
--- a/src/Gateway/GatewayModule.php
+++ b/src/Gateway/GatewayModule.php
@@ -85,10 +85,7 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
             return $maybeEnablegatewayHelper->maybeDisableMealVoucherGateway($gateways);
         });
 
-        add_action('woocommerce_init', static function () use ($container) {
-            if (!post_type_exists('shop_order')) {
-                return;
-            }
+        add_action('woocommerce_after_register_post_type', static function () use ($container) {
             $gateways = WC()->payment_gateways()->payment_gateways();
             $deprecatedGatewayHelpers = $container->get('__deprecated.gateway_helpers');
             foreach ($gateways as $gateway) {
@@ -155,7 +152,7 @@ class GatewayModule implements ServiceModule, ExecutableModule, ExtendingModule
         assert($surchargeService instanceof Surcharge);
         $this->gatewaySurchargeHandling($surchargeService);
 
-        add_action('woocommerce_init', function () use ($container) {
+        add_action('woocommerce_after_register_post_type', function () use ($container) {
             $this->paymentButtonsBootstrap($container);
         });
 


### PR DESCRIPTION
 GatewayModule::run() registered its gateway iteration and paymentButtonsBootstrap callbacks on woocommerce_init,
  which fires at WordPress init priority 0 — before WC_Post_Types::register_post_types() runs at priority 5. This
  meant shop_order was never registered when payment_gateways() was called, causing a fatal error in admin
  contexts like packing slip generation (where WC Subscriptions' woocommerce_available_payment_gateways filter
  calls wc_get_order() before post types exist). A previous fix attempted to guard with
  !post_type_exists('shop_order'), but since that check is always false at woocommerce_init time, it
  unconditionally blocked subscription filter registration and broke all renewal payments. This PR moves both
  callbacks to woocommerce_after_register_post_type, which fires from inside register_post_types() at priority 5 —
  at that point shop_order is registered so wc_get_order() succeeds, and subscription filters are in place before
  Action Scheduler fires renewal actions at priority 10+.