### PR TITLE
Restore left padding on credit card component fields (893)

### DIFF
--- a/resources/scss/mollie-components.scss
+++ b/resources/scss/mollie-components.scss
@@ -17,6 +17,7 @@
     0px 1px 3px 0px rgba(0, 0, 0, 0.1),
     0px 0px 0px 1px rgba(0, 0, 0, 0.05);
     border: 2px solid transparent;
+    padding: 0 .63em;
 
     iframe {
       border-radius: 6px;
@@ -167,6 +168,10 @@
 
 .mollie-component-wrapper[data-component="expiryDate"] {
     padding-right: 5%;
+}
+
+.mollie-component-wrapper[data-component="verificationCode"] {
+    padding-left: 5%;
 }
 
 /* Error notice for global component errors */

--- a/src/Settings/SettingsComponents.php
+++ b/src/Settings/SettingsComponents.php
@@ -54,7 +54,9 @@ class SettingsComponents
                 sprintf('mollie_components_%s', $key),
                 $this->defaultOptionFor($defaults, $key)
             );
-            $settings[$styleKey] = $optionValue;
+            if ($optionValue !== null) {
+                $settings[$styleKey] = $optionValue;
+            }
         }
 
         return $settings;


### PR DESCRIPTION
Add padding to .mollie-component so the Mollie iframe is inset from the
  field box border. The internal spacing was previously driven by
  styles.base.padding ('.63em') passed to Mollie's createComponent, which
  disappeared when inc/settings/mollie_components.php was deleted.

  Also add missing padding-left: 5% on the verificationCode wrapper to
  restore the gap between the expiry date and CVC fields, and filter null
  style values in SettingsComponents so Mollie falls back to its own
  defaults instead of receiving explicit nulls.
