### PR TITLE
[QA] Remove Trustly autotests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig< TestBaseExtend >( {
 	expect: {
 		timeout: 10_000,
 	},
-	timeout: 1 * 60_000,
+	timeout: 1.5 * 60_000,
 	/* Run tests in files in parallel */
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/qa/resources/gateways.ts
+++ b/tests/qa/resources/gateways.ts
@@ -435,20 +435,6 @@ const swish: MollieGateway = {
 	},
 };
 
-const trustly: MollieGateway = {
-	country: 'germany', // Europe
-	minAmount: '1.00',
-	slug: 'trustly',
-	name: 'Pay By Bank', //'Trustly',// // known bug https://mollie.atlassian.net/browse/PIWOO-683 tolerated by client
-	availableForApiMethods: [ 'order', 'payment' ],
-	settings: {
-		...defaultGatewaySettings,
-		id: 'mollie_wc_gateway_trustly',
-		title: 'Pay By Bank', //'Trustly',//
-		initial_order_status: 'on-hold',
-	},
-};
-
 const twint: MollieGateway = {
 	country: 'switzerland',
 	minAmount: '0.01',
@@ -523,7 +509,6 @@ export const gateways: {
 	riverty, // >50.00
 	satispay,
 	swish, // Sweden, currency: SEK
-	trustly,
 	twint, // currency: CHF
 	vipps, // currency: NOK
 	voucher,

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
@@ -614,38 +614,6 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 	},
 	{
 		...baseOrder,
-		testId: 'C3437842',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'paid',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437843',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'failed',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437844',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'canceled',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437845',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'expired',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C3622413',
 		payment: {
 			gateway: gateways.riverty,

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
@@ -612,38 +612,6 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 	},
 	{
 		...baseOrder,
-		testId: 'C3437846',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'paid',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437847',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'failed',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437848',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'canceled',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437849',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'expired',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C3622417',
 		payment: {
 			gateway: gateways.riverty,

--- a/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
@@ -612,38 +612,6 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 	},
 	{
 		...baseOrder,
-		testId: 'C3437850',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'paid',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437851',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'failed',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437852',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'canceled',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C3437853',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'expired',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C3622421',
 		payment: {
 			gateway: gateways.riverty,

--- a/tests/qa/tests/07-subscription/_test-data/subscription-order.data.ts
+++ b/tests/qa/tests/07-subscription/_test-data/subscription-order.data.ts
@@ -7,14 +7,6 @@ import { baseOrder } from './subscription-base-order.data';
 export const subscriptionOrderOnClassicCheckout: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
-		testId: 'C4211828',
-		payment: {
-			gateway: gateways.trustly,
-			status: 'paid',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C4237623',
 		payment: {
 			gateway: gateways.paybybank,

--- a/tests/qa/tests/07-subscription/subscription-ui.spec.ts
+++ b/tests/qa/tests/07-subscription/subscription-ui.spec.ts
@@ -31,7 +31,6 @@ test( `C3348 | Validate that only the correct payment methods (that supports a f
 		gateways.eps,
 		gateways.kbc,
 		gateways.belfius,
-		gateways.trustly,
 		gateways.paybybank,
 	];
 	await utils.fillVisitorsCart( [ products.mollieSubscription100 ] );


### PR DESCRIPTION
## Description

- Remove autotests for Trustly. See the [official Mollie report](https://help.mollie.com/hc/en-us/articles/35245827631634-Discontinued-Support-for-Trustly-Payment-Method-Frequently-Asked-Questions).
- Additional change: update test timeout since some tests (Multistep) were slower then usual.