### PR TITLE
Allow svg

### DIFF
--- a/mollie-payments-for-woocommerce.php
+++ b/mollie-payments-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mollie Payments for WooCommerce
  * Plugin URI: https://www.mollie.com
  * Description: Accept payments in WooCommerce with the official Mollie plugin
- * Version: 8.1.7-beta3
+ * Version: 8.1.7-beta4
  * Author: Mollie
  * Author URI: https://www.mollie.com
  * Requires at least: 5.0

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -697,9 +697,33 @@ class Settings
                     'size' => $file['size'],
             ];
 
+            $isSvg = strtolower(pathinfo($name, PATHINFO_EXTENSION)) === 'svg';
+            // WordPress excludes SVG from allowed MIME types by default; temporarily allow it
+            // so wp_handle_upload does not reject the file before we can sanitize it.
+            $svgMimeFilter = static function (array $mimes): array {
+                $mimes['svg'] = 'image/svg+xml';
+                return $mimes;
+            };
+            // finfo may return text/plain or text/xml for SVGs; override the filetype check
+            // so wp_handle_upload accepts the file regardless of what finfo detects.
+            $svgTypeFilter = static function (array $data, $file, string $filename): array {
+                if (strtolower(pathinfo($filename, PATHINFO_EXTENSION)) === 'svg') {
+                    $data['ext'] = 'svg';
+                    $data['type'] = 'image/svg+xml';
+                }
+                return $data;
+            };
+            if ($isSvg) {
+                add_filter('upload_mimes', $svgMimeFilter);
+                add_filter('wp_check_filetype_and_ext', $svgTypeFilter, 10, 3);
+            }
             $movefile = wp_handle_upload($file, $upload_overrides);
+            if ($isSvg) {
+                remove_filter('upload_mimes', $svgMimeFilter);
+                remove_filter('wp_check_filetype_and_ext', $svgTypeFilter);
+            }
             if ($movefile && !isset($movefile['error'])) {
-                if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) === 'svg') {
+                if ($isSvg) {
                     $svgContent = file_get_contents($movefile['file']);
                     $sanitizer = new \enshrined\svgSanitize\Sanitizer();
                     $sanitized = ($svgContent !== false) ? $sanitizer->sanitize($svgContent) : false;


### PR DESCRIPTION
### What and why
  
  WordPress excludes SVG from its allowed upload MIME types by default, causing `wp_handle_upload()` to reject SVG
  files with a permission error before the plugin's sanitizer ever runs. A prior commit had wired up
  enshrined/svg-sanitize but it was unreachable because the upload never succeeded. Any SVG a merchant tried to
  set as a custom gateway logo was silently discarded, and because no iconFileUrl was ever persisted the preview
  and remove-button UI never appeared on the settings page.
                                                                                                
  ### What changed

  - `src/Settings/Settings.php` — `Settings::processUploadedFile()` now temporarily registers two WordPress filters
  (upload_mimes, wp_check_filetype_and_ext) before calling `wp_handle_upload()` and removes them immediately after,
  allowing SVG files through WordPress's MIME gate without globally relaxing upload restrictions. The existing
  sanitization block (already present) is now reachable and the redundant extension re-check is replaced by the
  $isSvg flag computed once at the top. 