### PR TITLE
Guard update checkout trigger

### DIFF
--- a/resources/js/src/features/surcharge/__tests__/gatewaySurcharge.test.js
+++ b/resources/js/src/features/surcharge/__tests__/gatewaySurcharge.test.js
@@ -1,0 +1,72 @@
+/**
+ * Verifies the e.originalEvent guard in the payment method change listener.
+ *
+ * The listener must trigger update_checkout only when the change originates
+ * from genuine user interaction (e.originalEvent is set). Synthetic jQuery
+ * .trigger() calls — used by Fastlane and WooCommerce init_payment_methods —
+ * must not fire update_checkout, which prevents the infinite AJAX loop on
+ * /?wc-ajax=update_order_review.
+ */
+
+const triggerSpy = jest.fn();
+let capturedChangeHandler;
+
+const mockBody = {
+	on( event, selector, handler ) {
+		if (
+			event === 'change' &&
+			selector === 'input[name="payment_method"]'
+		) {
+			capturedChangeHandler = handler;
+		}
+		return this;
+	},
+	trigger( event ) {
+		triggerSpy( event );
+		return this;
+	},
+};
+
+const mockJQuery = function ( selectorOrFn ) {
+	if ( typeof selectorOrFn === 'function' ) {
+		// jQuery( function( $ ) { ... } ) — document ready, call immediately
+		selectorOrFn( mockJQuery );
+		return;
+	}
+	return mockBody;
+};
+
+beforeAll( () => {
+	global.jQuery = mockJQuery;
+	// surchargeData null keeps the IIFE in its early-return path after the
+	// change handler is registered — exactly the guest-with-no-surcharge case
+	global.surchargeData = null;
+	require( '../gatewaySurcharge' );
+} );
+
+afterEach( () => {
+	triggerSpy.mockClear();
+} );
+
+describe( 'gatewaySurcharge payment method change listener', () => {
+	it( 'does not trigger update_checkout when change has no originalEvent (synthetic / programmatic)', () => {
+		capturedChangeHandler( { originalEvent: undefined } );
+
+		expect( triggerSpy ).not.toHaveBeenCalledWith( 'update_checkout' );
+	} );
+
+	it( 'triggers update_checkout exactly once when change has originalEvent (genuine user click)', () => {
+		capturedChangeHandler( { originalEvent: new Event( 'change' ) } );
+
+		expect( triggerSpy ).toHaveBeenCalledTimes( 1 );
+		expect( triggerSpy ).toHaveBeenCalledWith( 'update_checkout' );
+	} );
+
+	it( 'does not trigger update_checkout across repeated programmatic changes (Fastlane loop scenario)', () => {
+		for ( let i = 0; i < 10; i++ ) {
+			capturedChangeHandler( { originalEvent: undefined } );
+		}
+
+		expect( triggerSpy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/resources/js/src/features/surcharge/gatewaySurcharge.js
+++ b/resources/js/src/features/surcharge/gatewaySurcharge.js
@@ -1,7 +1,9 @@
 ( function ( { jQuery, surchargeData } ) {
 	jQuery( function ( $ ) {
-		$( 'body' ).on( 'change', 'input[name="payment_method"]', function () {
-			$( 'body' ).trigger( 'update_checkout' );
+		$( 'body' ).on( 'change', 'input[name="payment_method"]', function ( e ) {
+			if ( e.originalEvent ) {
+				$( 'body' ).trigger( 'update_checkout' );
+			}
 		} );
 	} );
 	if ( ! surchargeData ) {


### PR DESCRIPTION
### What and why
  
  The Mollie surcharge script registered a jQuery change listener on `input[name="payment_method"]` that
  unconditionally called `$('body').trigger('update_checkout')` on every change event, whether it came from a real
  user click or from a programmatic script. When PayPal Payments' Fastlane module — or WooCommerce's own
  init_payment_methods — programmatically switched the selected payment radio during updated_checkout processing,
  the Mollie listener fired immediately, triggering a new update_order_review AJAX request, which in turn
  triggered updated_checkout again, creating an infinite loop that locked the Classic Checkout page for guest
  users.

  ### How it works now
  
  jQuery populates `e.originalEvent` only when the event originated from a genuine browser interaction; synthetic
  events fired via jQuery's `.trigger()` leave originalEvent undefined. The change listener now checks if 
  (e.originalEvent) before dispatching update_checkout, so programmatic payment method switches — from Fastlane
  re-initialization, WooCommerce's init_payment_methods, or any other script — no longer trigger the surcharge
  AJAX flow. Real user clicks continue to work exactly as before.

  #### Covered by unit tests
  
  - ✓ A real user clicking a payment method radio fires update_checkout exactly once
  - ✓ A programmatic jQuery('input[name="payment_method"]').trigger('change') does not fire update_checkout
  - ✓ Repeated programmatic payment method switches produce zero update_checkout calls

  #### Not covered by unit tests

  - ✗ Surcharge fee added/removed correctly in the order total after a user click — requires PHP cart calculation
  and DOM rendering; covered by the existing tests/qa/tests/03-plugin-settings/surcharge/surcharge.spec.ts
  - ✗ Script continues to load and enqueue on checkout pages — PHP-side enqueue registration; verifiable by code
  review only


