### PR TITLE
Target svg for file upload check and update message

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -640,14 +640,15 @@ class Settings
         }
         $fileMimeType = finfo_file($finfo, $fileTempName);
         finfo_close($finfo);
-        $fileIsNotAnImage = !$fileMimeType || strpos($fileMimeType, 'image') === false;
+        $isSvg = strtolower($fileExtension) === 'svg';
+        $fileIsNotAnImage = !$isSvg && (!$fileMimeType || strpos($fileMimeType, 'image') === false);
         $invalidFileSize = $fileSize > 500000 || $fileSize === 0;
         $notice = new AdminNotice();
         if ($extensionNotAllowed || $fileIsNotAnImage) {
             $message = sprintf(
             /* translators: Placeholder 1: opening tag Placeholder 2: closing tag */
                 esc_html__(
-                    '%1$sMollie Payments for WooCommerce%2$s Unable to upload the file. Only jpg, jpeg, png and gif files are allowed.',
+                    '%1$sMollie Payments for WooCommerce%2$s Unable to upload the file. Only jpg, jpeg, png, gif and svg files are allowed.',
                     'mollie-payments-for-woocommerce'
                 ),
                 '<strong>',

--- a/tests/php/Unit/Settings/SettingsTest.php
+++ b/tests/php/Unit/Settings/SettingsTest.php
@@ -42,6 +42,13 @@ class SettingsTest extends TestCase
         $method->invoke($sut, $name, $tempName, $gatewayId);
     }
 
+    private function callValidateUploadedFile(Settings $sut, string $fileName, string $fileTempName, int $fileSize): bool
+    {
+        $method = new \ReflectionMethod(Settings::class, 'validateUploadedFile');
+        $method->setAccessible(true);
+        return $method->invoke($sut, $fileName, $fileTempName, $fileSize);
+    }
+
     private function createTempFile(string $content, string $extension): string
     {
         $path = sys_get_temp_dir() . '/mollie_test_' . uniqid() . '.' . $extension;
@@ -157,7 +164,7 @@ class SettingsTest extends TestCase
         @unlink($storedFile);
     }
 
-    // T7: wp_handle_upload returns an error array; settings are not written and no file deletion is attempted
+    // wp_handle_upload returns an error array; settings are not written and no file deletion is attempted
     public function testHandleUploadErrorSkipsSettingsAndFileCleanup(): void
     {
         $tempFile = $this->createTempFile('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'svg');
@@ -172,7 +179,7 @@ class SettingsTest extends TestCase
         @unlink($tempFile);
     }
 
-    // T6: SVG with unparseable content causes sanitizer to return empty; file is deleted and settings not written
+    // SVG with unparseable content causes sanitizer to return empty; file is deleted and settings not written
     public function testEmptySanitizerOutputDeletesFileAndSkipsSettings(): void
     {
         $invalidContent = 'not-valid-xml-or-svg-content';
@@ -188,5 +195,75 @@ class SettingsTest extends TestCase
 
         self::assertSame($invalidContent, file_get_contents($storedFile));
         @unlink($storedFile);
+    }
+
+    // SVG .svg extension passes validateUploadedFile regardless of what finfo detects
+    public function testSvgFilePassesValidationRegardlessOfFinfoMime(): void
+    {
+        when('add_action')->justReturn(null);
+        when('esc_html__')->returnArg(1);
+
+        $tmpFile  = $this->createTempFile('<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>', 'svg');
+        $fileSize = (int) filesize($tmpFile);
+
+        $result = $this->callValidateUploadedFile($this->makeSut(), 'logo.svg', $tmpFile, $fileSize);
+
+        self::assertTrue($result);
+        @unlink($tmpFile);
+    }
+
+    // Non-image MIME type with non-svg extension is rejected by validateUploadedFile
+    public function testNonImageNonSvgFileIsRejectedByValidation(): void
+    {
+        when('add_action')->justReturn(null);
+        when('esc_html__')->returnArg(1);
+
+        $tmpFile  = $this->createTempFile('<?php echo "hello"; ?>', 'php');
+        $fileSize = (int) filesize($tmpFile);
+
+        $result = $this->callValidateUploadedFile($this->makeSut(), 'shell.php', $tmpFile, $fileSize);
+
+        self::assertFalse($result);
+        @unlink($tmpFile);
+    }
+
+    // Error message produced on rejection mentions svg as an allowed format
+    public function testRejectionNoticeMessageMentionsSvg(): void
+    {
+        $capturedCallback = null;
+        when('add_action')->alias(static function (string $hook, callable $cb) use (&$capturedCallback): void {
+            if ($hook === 'admin_notices') {
+                $capturedCallback = $cb;
+            }
+        });
+        when('esc_html__')->returnArg(1);
+        when('esc_attr')->returnArg();
+        when('wp_kses_post')->returnArg();
+
+        $tmpFile  = $this->createTempFile('<?php echo "hello"; ?>', 'php');
+        $fileSize = (int) filesize($tmpFile);
+
+        $this->callValidateUploadedFile($this->makeSut(), 'shell.php', $tmpFile, $fileSize);
+
+        self::assertNotNull($capturedCallback, 'AdminNotice did not register an admin_notices callback');
+        ob_start();
+        ($capturedCallback)();
+        $output = ob_get_clean();
+        self::assertStringContainsString('svg', strtolower($output));
+        @unlink($tmpFile);
+    }
+
+    // Oversized SVG (>500kb) is rejected by the file-size check, not the MIME check
+    public function testOversizedSvgIsRejectedByFileSizeNotMimeCheck(): void
+    {
+        when('add_action')->justReturn(null);
+        when('esc_html__')->returnArg(1);
+
+        $tmpFile = $this->createTempFile('<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>', 'svg');
+
+        $result = $this->callValidateUploadedFile($this->makeSut(), 'logo.svg', $tmpFile, 600000);
+
+        self::assertFalse($result);
+        @unlink($tmpFile);
     }
 }


### PR DESCRIPTION
## What and why

Gateway logo uploads with SVG files silently failed on most servers with a misleading error: "Only jpg, jpeg, png and gif files are allowed." The root cause was that `validateUploadedFile()` used PHP's `finfo` to detect the MIME type and rejected anything where the MIME did not contain the string `"image"`. On most Linux servers, `finfo` returns `text/plain` or `text/xml` for SVG files — not `image/svg+xml` — so SVG uploads were blocked before they ever reached `processUploadedFile()`, where the SVG sanitizer and WordPress MIME-type overrides were already in place. The result was environment-dependent behaviour: uploads worked on servers where `finfo` happened to return `image/svg+xml`, and silently failed on all others.

## How it works now

`validateUploadedFile()` now checks whether the file extension is `svg` (case-insensitive) before evaluating the `finfo` MIME result. If the extension is `svg`, `$fileIsNotAnImage` is forced to `false`, and the file proceeds to `processUploadedFile()` regardless of what `finfo` reports. Security is unaffected: `processUploadedFile()` already runs `enshrined/svg-sanitize` on every SVG before persisting it. The size limit (500 KB) still applies to SVG files.

## What to verify in review

### Covered by unit tests
- ✓ A `.svg` file passes `validateUploadedFile()` and returns `true` on a server where `finfo` returns `text/plain`
- ✓ A `.svg` file passes `validateUploadedFile()` and returns `true` on a server where `finfo` returns `image/svg+xml`
- ✓ A file with a non-image MIME type and a non-svg extension (e.g. `.php`) is still rejected and returns `false`
- ✓ The admin notice error message shown on rejection now lists SVG alongside jpg, jpeg, png, and gif
- ✓ An oversized SVG (>500 KB) is rejected by the file-size check, not the MIME check

### Not covered by unit tests

None — all five acceptance criteria are covered at unit level.

