### PR TITLE
Add notice when svg upload fails

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -728,6 +728,7 @@ class Settings
                     $sanitizer = new \enshrined\svgSanitize\Sanitizer();
                     $sanitized = ($svgContent !== false) ? $sanitizer->sanitize($svgContent) : false;
                     if (!$sanitized) {
+                        $this->addFileUploadErrorNotice();
                         wp_delete_file($movefile['file']);
                         return;
                     }
@@ -737,7 +738,26 @@ class Settings
                 $gatewaySettings["iconFileUrl"] = $movefile['url'];
                 $gatewaySettings["iconFilePath"] = $movefile['file'];
                 update_option(sprintf('%s_settings', $gatewayId), $gatewaySettings);
+            } else {
+                $this->addFileUploadErrorNotice();
             }
         }
+    }
+
+    private function addFileUploadErrorNotice(): void
+    {
+        $notice = new AdminNotice();
+        $notice->addNotice(
+            'notice-error is-dismissible',
+            sprintf(
+            /* translators: Placeholder 1: opening tag Placeholder 2: closing tag */
+                esc_html__(
+                    '%1$sMollie Payments for WooCommerce%2$s Unable to save the file.',
+                    'mollie-payments-for-woocommerce'
+                ),
+                '<strong>',
+                '</strong>'
+            )
+        );
     }
 }

--- a/tests/php/Unit/Settings/SettingsTest.php
+++ b/tests/php/Unit/Settings/SettingsTest.php
@@ -160,6 +160,9 @@ class SettingsTest extends TestCase
     // T7: wp_handle_upload returns an error array; settings are not written and no file deletion is attempted
     public function testHandleUploadErrorSkipsSettingsAndFileCleanup(): void
     {
+        when('add_action')->justReturn(null);
+        when('esc_html__')->returnArg(1);
+
         $tempFile = $this->createTempFile('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'svg');
         $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $tempFile);
 
@@ -175,6 +178,9 @@ class SettingsTest extends TestCase
     // T6: SVG with unparseable content causes sanitizer to return empty; file is deleted and settings not written
     public function testEmptySanitizerOutputDeletesFileAndSkipsSettings(): void
     {
+        when('add_action')->justReturn(null);
+        when('esc_html__')->returnArg(1);
+
         $invalidContent = 'not-valid-xml-or-svg-content';
         $storedFile     = $this->createTempFile($invalidContent, 'svg');
         $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $storedFile);
@@ -188,5 +194,98 @@ class SettingsTest extends TestCase
 
         self::assertSame($invalidContent, file_get_contents($storedFile));
         @unlink($storedFile);
+    }
+
+    // wp_handle_upload error array triggers an admin_notices hook registration
+    public function testHandleUploadErrorRegistersAdminNotice(): void
+    {
+        $capturedCallback = null;
+        when('add_action')->alias(static function (string $hook, callable $cb) use (&$capturedCallback): void {
+            if ($hook === 'admin_notices') {
+                $capturedCallback = $cb;
+            }
+        });
+        when('esc_html__')->returnArg(1);
+
+        $tmpFile = $this->createTempFile('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $tmpFile);
+        when('wp_handle_upload')->justReturn(['error' => 'Upload failed due to file type restriction.']);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $tmpFile, self::GATEWAY_ID);
+
+        self::assertNotNull($capturedCallback, 'Expected an admin_notices callback to be registered on wp_handle_upload error');
+        @unlink($tmpFile);
+    }
+
+    // SVG sanitizer returning falsy output triggers an admin_notices hook registration
+    public function testSanitizerRejectionRegistersAdminNotice(): void
+    {
+        $capturedCallback = null;
+        when('add_action')->alias(static function (string $hook, callable $cb) use (&$capturedCallback): void {
+            if ($hook === 'admin_notices') {
+                $capturedCallback = $cb;
+            }
+        });
+        when('esc_html__')->returnArg(1);
+
+        $tmpFile = $this->createTempFile('not-valid-xml-or-svg-content', 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $tmpFile);
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $tmpFile]);
+        when('get_option')->justReturn([]);
+        expect('wp_delete_file')->once()->with($tmpFile);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $tmpFile, self::GATEWAY_ID);
+
+        self::assertNotNull($capturedCallback, 'Expected an admin_notices callback to be registered when sanitizer rejects the file');
+        @unlink($tmpFile);
+    }
+
+    // Notice message shown on rejection contains no words revealing the cause
+    public function testRejectionNoticeMessageDoesNotRevealRejectionReason(): void
+    {
+        $capturedCallback = null;
+        when('add_action')->alias(static function (string $hook, callable $cb) use (&$capturedCallback): void {
+            if ($hook === 'admin_notices') {
+                $capturedCallback = $cb;
+            }
+        });
+        when('esc_html__')->returnArg(1);
+        when('esc_attr')->returnArg();
+        when('wp_kses_post')->returnArg();
+
+        $tmpFile = $this->createTempFile('not-valid-xml-or-svg-content', 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $tmpFile);
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $tmpFile]);
+        when('get_option')->justReturn([]);
+        expect('wp_delete_file')->once();
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $tmpFile, self::GATEWAY_ID);
+
+        self::assertNotNull($capturedCallback, 'Expected an admin_notices callback to be registered');
+        ob_start();
+        ($capturedCallback)();
+        $output = strtolower((string) ob_get_clean());
+        foreach (['sanitize', 'malicious', 'blocked', 'script', 'invalid content'] as $bannedWord) {
+            self::assertStringNotContainsString($bannedWord, $output, "Notice must not reveal rejection reason via '{$bannedWord}'");
+        }
+        @unlink($tmpFile);
+    }
+
+    // Gateway logo setting is not written when sanitizer rejects the file (notice-enabled path)
+    public function testSanitizerRejectionLeavesSettingsUnchangedAfterNotice(): void
+    {
+        when('add_action')->justReturn(null);
+        when('esc_html__')->returnArg(1);
+
+        $tmpFile = $this->createTempFile('not-valid-xml-or-svg-content', 'svg');
+        $this->setUpFilesGlobal(self::GATEWAY_ID, 'logo.svg', $tmpFile);
+        when('wp_handle_upload')->justReturn(['url' => 'https://example.com/logo.svg', 'file' => $tmpFile]);
+        when('get_option')->justReturn([]);
+        expect('update_option')->never();
+        expect('wp_delete_file')->once()->with($tmpFile);
+
+        $this->callProcessUploadedFile($this->makeSut(), 'logo.svg', $tmpFile, self::GATEWAY_ID);
+
+        @unlink($tmpFile);
     }
 }


### PR DESCRIPTION
## What and why

When an SVG uploaded as a gateway logo was rejected — either because the file could not be stored by WordPress or because the SVG sanitizer found disallowed content — `processUploadedFile()` silently deleted the file and returned without any feedback to the admin. The merchant had no way to distinguish a successful upload from a failed one, leaving the gateway logo setting silently unchanged and the merchant unable to take corrective action.

## How it works now

Both failure paths in `processUploadedFile()` now call the private `addFileUploadErrorNotice()` method before returning. That method instantiates `AdminNotice` (already used in `validateUploadedFile()`) and registers a generic "Unable to save the file." message on the `admin_notices` hook. The message is intentionally vague — it does not expose whether the rejection was caused by the sanitizer, WordPress, or any other reason.

## What to verify in review

### Covered by unit tests
- ✓ When `wp_handle_upload` returns an error array, an admin notice is registered before the method returns
- ✓ When the SVG sanitizer returns falsy output, an admin notice is registered before the uploaded file is deleted
- ✓ The notice message contains no words that reveal the reason for rejection (`sanitize`, `malicious`, `blocked`, `script`, `invalid content`)
- ✓ After a sanitizer rejection, `iconFileUrl` and `iconFilePath` in the gateway settings remain unchanged
- ✓ No PHP fatal error or uncaught exception is thrown when either failure branch is reached

### Not covered by unit tests

None — all five acceptance criteria are covered at unit level.