### PR TITLE
Add privacy policy module

### DIFF
--- a/inc/modules.php
+++ b/inc/modules.php
@@ -12,6 +12,7 @@ use Mollie\WooCommerce\Gateway\Voucher\VoucherModule;
 use Mollie\WooCommerce\Log\LogModule;
 use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
 use Mollie\WooCommerce\Notice\NoticeModule;
+use Mollie\WooCommerce\Privacy\PrivacyModule;
 use Mollie\WooCommerce\Payment\PaymentModule;
 use Mollie\WooCommerce\SDK\SDKModule;
 use Mollie\WooCommerce\Settings\SettingsModule;
@@ -41,5 +42,6 @@ return /**
             new ComponentsModule(),
             new TracksModule(),
             new UninstallModule(),
+            new PrivacyModule(),
         ];
     };

--- a/src/Privacy/PrivacyModule.php
+++ b/src/Privacy/PrivacyModule.php
@@ -1,0 +1,36 @@
+<?php
+
+# kb-active
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerce\Privacy;
+
+use Inpsyde\Modularity\Module\ExecutableModule;
+use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
+use Psr\Container\ContainerInterface;
+
+class PrivacyModule implements ExecutableModule
+{
+    use ModuleClassNameIdTrait;
+
+    public function run(ContainerInterface $container): bool
+    {
+        add_action('admin_init', [$this, 'registerPrivacyPolicyContent']);
+
+        return true;
+    }
+
+    public function registerPrivacyPolicyContent(): void
+    {
+        if (!function_exists('wp_add_privacy_policy_content')) {
+            return;
+        }
+        $content = '<div class="wp-suggested-text"><p>' . sprintf(
+            __('By using this extension, you may be processing personal data with Mollie. Please see <a href="%s">here</a> for more information.', 'mollie-payments-for-woocommerce'),
+            'https://www.mollie.com/legal/privacy'
+        ) . '</p></div>';
+
+        wp_add_privacy_policy_content('Mollie Payments for WooCommerce', $content);
+    }
+}

--- a/tests/php/Unit/Privacy/PrivacyModuleTest.php
+++ b/tests/php/Unit/Privacy/PrivacyModuleTest.php
@@ -1,0 +1,65 @@
+<?php
+# kb-active
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Privacy;
+
+use Mockery;
+use Mollie\WooCommerce\Privacy\PrivacyModule;
+use Mollie\WooCommerceTests\TestCase;
+
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Privacy\PrivacyModule::registerPrivacyPolicyContent
+ */
+class PrivacyModuleTest extends TestCase
+{
+    private PrivacyModule $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sut = new PrivacyModule();
+    }
+
+    // T3: method returns silently when wp_add_privacy_policy_content does not exist (WP < 4.9.6)
+    // Runs first so Brain\Monkey has not yet eval()-defined the function stub; function_exists() returns false.
+    public function testRegisterPrivacyPolicyContent_silentWhenFunctionMissing(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->sut->registerPrivacyPolicyContent();
+    }
+
+    // T1: admin_init callback calls wp_add_privacy_policy_content with plugin name as first arg
+    public function testRegisterPrivacyPolicyContent_callsWpAddPrivacyPolicyContentWithPluginName(): void
+    {
+        expect('wp_add_privacy_policy_content')
+            ->once()
+            ->with('Mollie Payments for WooCommerce', Mockery::type('string'));
+
+        $this->sut->registerPrivacyPolicyContent();
+
+        $this->addToAssertionCount(1);
+    }
+
+    // T2: second argument contains the exact href and anchor text "here"
+    public function testRegisterPrivacyPolicyContent_policyTextContainsExactLinkAndAnchor(): void
+    {
+        $captured = null;
+        when('wp_add_privacy_policy_content')->alias(function ($name, $text) use (&$captured): void {
+            $captured = $text;
+        });
+
+        $this->sut->registerPrivacyPolicyContent();
+
+        self::assertNotNull($captured, 'wp_add_privacy_policy_content was not called');
+        self::assertStringContainsString('https://www.mollie.com/legal/privacy', $captured);
+        self::assertRegExp(
+            '/<a\s[^>]*href=["\']https:\/\/www\.mollie\.com\/legal\/privacy["\'][^>]*>here<\/a>/i',
+            $captured
+        );
+    }
+}


### PR DESCRIPTION
## What and why

  The Mollie Payments for WooCommerce plugin collects and transmits personal data (customer details, payment
  information) to Mollie on every transaction, but had no mechanism to inform site administrators of this.
  WordPress requires plugins that handle personal data to register suggested privacy policy text via
  `wp_add_privacy_policy_content()` so administrators can include it in their site's privacy policy. Without this,
  sites using the plugin were non-compliant with the WordPress Plugin Handbook's privacy requirements, and shop
  admins had no plugin-supplied text to insert when building their privacy policy.

  ## How it works now

  A new `PrivacyModule` class in `src/Privacy/PrivacyModule.php` implements `ExecutableModule`. Its `run()` method
  hooks into `admin_init` and calls `registerPrivacyPolicyContent()`, which passes the plugin name `'Mollie
  Payments for WooCommerce'` and the prescribed policy text to `wp_add_privacy_policy_content()`. The call is
  guarded by `function_exists()` so that on WordPress installations older than 4.9.6 (where the function does not
  exist) the method returns silently and the plugin continues to operate normally. `PrivacyModule` is registered
  in `inc/modules.php` alongside all other plugin modules.

  ## What to verify in review

  ### Covered by unit tests

  - ✓ `wp_add_privacy_policy_content` is called exactly once with `'Mollie Payments for WooCommerce'` as the first
  argument and a non-empty string as the second
  - ✓ The second argument contains an `<a>` tag whose `href` is `https://www.mollie.com/legal/privacy` and whose
  anchor text is `here`
  - ✓ When `wp_add_privacy_policy_content` is not yet defined in PHP (simulating WP < 4.9.6), calling
  `registerPrivacyPolicyContent()` throws no exception

  ### Not covered by unit tests
  
  - ✗ The policy text string is wrapped in a translatable `__()` call using text domain
  `mollie-payments-for-woocommerce` — verifiable only by reading the source
  - ✗ `PrivacyModule` is registered in `inc/modules.php` and its `run()` method is invoked during bootstrap —
  requires full plugin bootstrap (integration level)
  - ✗ The WordPress Privacy Policy edit screen lists a `'Mollie Payments for WooCommerce'` suggestion section —
  observable only through the browser (e2e)
  
