### PR TITLE
Guard identifier key access and declare callerPage property in ApplePay

### DIFF
--- a/src/Buttons/ApplePayButton/ApplePayDataObjectHttp.php
+++ b/src/Buttons/ApplePayButton/ApplePayDataObjectHttp.php
@@ -55,6 +55,10 @@ class ApplePayDataObjectHttp
      * @var Logger
      */
     protected $logger;
+    /**
+     * @var string|null
+     */
+    protected $callerPage = null;
 
     /**
      * ApplePayDataObjectHttp constructor.

--- a/src/Buttons/ApplePayButton/ResponsesToApple.php
+++ b/src/Buttons/ApplePayButton/ResponsesToApple.php
@@ -116,7 +116,7 @@ class ResponsesToApple
         $reordered_methods = [];
 
         foreach ($methods as $key => $method) {
-            if ($method['identifier'] === $selectedShippingMethod['identifier']) {
+            if (($method['identifier'] ?? null) === ($selectedShippingMethod['identifier'] ?? null)) {
                 $reordered_methods[] = $method;
                 unset($methods[$key]);
                 break;

--- a/tests/php/Functional/ApplePayButton/ApplePayDataObjectTest.php
+++ b/tests/php/Functional/ApplePayButton/ApplePayDataObjectTest.php
@@ -168,6 +168,12 @@ class ApplePayDataObjectTest extends TestCase
     }
 
 
+    public function testCallerPagePropertyIsDeclaredExplicitly()
+    {
+        $reflection = new \ReflectionClass(ApplePayDataObjectHttp::class);
+        self::assertTrue($reflection->hasProperty('callerPage'));
+    }
+
     /**
      * @inheritDoc
      */

--- a/tests/php/Functional/ApplePayButton/ResponsesToAppleTest.php
+++ b/tests/php/Functional/ApplePayButton/ResponsesToAppleTest.php
@@ -151,6 +151,30 @@ class ResponsesToAppleTest extends TestCase
         self::assertEquals($response, $expectedResponse);
     }
 
+    public function testReorderShippingMethodsHandlesMissingIdentifierWithoutWarning()
+    {
+        $paymentDetails = [
+            'subtotal' => 10,
+            'shipping' => ['amount' => null, 'label' => null],
+            'shippingMethods' => [
+                ['label' => 'Standard', 'amount' => '5.00', 'identifier' => 'standard'],
+                ['label' => 'Express', 'amount' => '10.00'], // missing 'identifier'
+            ],
+            'taxes' => 1,
+            'total' => 11,
+        ];
+        $dataObject = \Mockery::mock();
+        $dataObject->shouldReceive('shippingMethod')->andReturn(['identifier' => 'standard']);
+        expect('get_bloginfo')->once()->with('name')->andReturn('Test Shop');
+
+        $logger = $this->helperMocks->loggerMock();
+        $appleGateway = $this->mollieGateway('applepay', false, true);
+        $responsesTemplate = new ResponsesToApple($logger, $appleGateway);
+        $response = $responsesTemplate->appleFormattedResponse($paymentDetails, $dataObject);
+
+        self::assertArrayHasKey('newShippingMethods', $response);
+    }
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
## What and why
  
  During the Apple Pay checkout flow, two PHP notices were being written to the error log on every request: a `PHP
  Warning` for an undefined array key `identifier` in `ResponsesToApple::reorderShippingMethods`, and a `PHP
  Deprecated` notice for dynamic property creation of `$callerPage` on `ApplePayDataObjectHttp`. Neither notice
  blocked checkout or affected the user experience, but both polluted error logs and represent
  forward-compatibility risks — dynamic property creation is deprecated in PHP 8.2 and will become a fatal error
  in a future PHP version, while undefined array key access is already an `E_WARNING` that strict error
  configurations can surface as an exception.

  ## How it works now

  In `ResponsesToApple::reorderShippingMethods`, the direct comparison `$method['identifier'] ===
  $selectedShippingMethod['identifier']` has been replaced with `($method['identifier'] ?? null) ===
  ($selectedShippingMethod['identifier'] ?? null)`, so a missing `identifier` key on either side returns `null`
  instead of raising a warning. In `ApplePayDataObjectHttp`, `$callerPage` is now declared as an explicit
  `protected` class property with a `@var string|null` docblock, which means `assignDataObjectValues` no longer
  creates it as a dynamic property when it assigns values from POST data.

  ## What to verify in review

  ### Covered by unit tests
  - ✓ The `identifier` key access in `ResponsesToApple::reorderShippingMethods` is guarded with `??` so a missing
  key does not raise a PHP Warning
  - ✓ The `$callerPage` property is explicitly declared in the `ApplePayDataObjectHttp` class body and is no
  longer assigned dynamically
  
  ### Not covered by unit tests
  - ✗ No `PHP Deprecated` notice for `$callerPage` is logged — structurally guaranteed once the property is
  creates it as a dynamic property when it assigns values from POST data.

  