### PR TITLE
Normalise decimal WC quantities to integers before sending to Mollie

### DIFF
--- a/src/Payment/LineItems/OrderLines.php
+++ b/src/Payment/LineItems/OrderLines.php
@@ -443,7 +443,7 @@ class OrderLines implements LineItemProvider
     {
         $item_subtotal = $cart_item['line_subtotal'] + $cart_item['line_subtotal_tax'];
 
-        return $item_subtotal / $cart_item['quantity'];
+        return $item_subtotal / $this->toIntegerQuantity((float) $cart_item['quantity']);
     }
 
     /**
@@ -458,7 +458,24 @@ class OrderLines implements LineItemProvider
      */
     private function get_item_quantity($cart_item)
     {
-        return $cart_item['quantity'];
+        return $this->toIntegerQuantity((float) $cart_item['quantity']);
+    }
+
+    /**
+     * Convert a fractional WooCommerce quantity to the smallest equivalent integer
+     * by finding the minimal decimal scale factor (e.g. 1.5 → ×10 → 15, 0.4 → ×10 → 4).
+     * Falls back to round()+clamp for repeating decimals that have no exact match in d=0..4.
+     */
+    private function toIntegerQuantity(float $qty): int
+    {
+        for ($d = 0; $d <= 4; $d++) {
+            $scale = (int) pow(10, $d);
+            $candidate = (int) round($qty * $scale);
+            if (abs($candidate / $scale - $qty) < 1e-9) {
+                return max(1, $candidate);
+            }
+        }
+        return max(1, (int) round($qty));
     }
 
     /**

--- a/src/Payment/LineItems/PaymentLines.php
+++ b/src/Payment/LineItems/PaymentLines.php
@@ -392,7 +392,7 @@ class PaymentLines implements LineItemProvider
     {
         $item_subtotal = $cart_item['line_subtotal'] + $cart_item['line_subtotal_tax'];
 
-        return $item_subtotal / $cart_item['quantity'];
+        return $item_subtotal / $this->toIntegerQuantity((float) $cart_item['quantity']);
     }
 
     /**
@@ -407,7 +407,24 @@ class PaymentLines implements LineItemProvider
      */
     private function get_item_quantity($cart_item)
     {
-        return $cart_item['quantity'];
+        return $this->toIntegerQuantity((float) $cart_item['quantity']);
+    }
+
+    /**
+     * Convert a fractional WooCommerce quantity to the smallest equivalent integer
+     * by finding the minimal decimal scale factor (e.g. 1.5 → ×10 → 15, 0.4 → ×10 → 4).
+     * Falls back to round()+clamp for repeating decimals that have no exact match in d=0..4.
+     */
+    private function toIntegerQuantity(float $qty): int
+    {
+        for ($d = 0; $d <= 4; $d++) {
+            $scale = (int) pow(10, $d);
+            $candidate = (int) round($qty * $scale);
+            if (abs($candidate / $scale - $qty) < 1e-9) {
+                return max(1, $candidate);
+            }
+        }
+        return max(1, (int) round($qty));
     }
 
     /**

--- a/tests/php/Functional/Payment/OrderLinesTest.php
+++ b/tests/php/Functional/Payment/OrderLinesTest.php
@@ -1,0 +1,148 @@
+<?php
+// kb-active
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Functional\Payment;
+
+use Mockery;
+use Mollie\WooCommerce\Payment\LineItems\OrderLines;
+use Mollie\WooCommerce\Payment\LineItems\PaymentLines;
+use Mollie\WooCommerce\Shared\Data;
+use Mollie\WooCommerceTests\TestCase;
+
+/**
+ * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines
+ * @covers \Mollie\WooCommerce\Payment\LineItems\PaymentLines
+ */
+class OrderLinesTest extends TestCase
+{
+    /** @var Data&\Mockery\MockInterface */
+    private $dataHelper;
+    private OrderLines $sut;
+    private PaymentLines $paymentLinesSut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dataHelper = Mockery::mock(Data::class);
+        $this->sut = new OrderLines($this->dataHelper, 'mollie-test');
+        $this->paymentLinesSut = new PaymentLines($this->dataHelper, 'mollie-test');
+    }
+
+    /**
+     * @scenario get_item_quantity() returns 15 (int) for a cart item with quantity 1.5 (scale factor 10)
+     * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines::get_item_quantity
+     */
+    public function test_get_item_quantity_scales_fractional_to_integer(): void
+    {
+        // Arrange
+        $cartItem = ['quantity' => 1.5];
+
+        // When
+        $result = $this->callPrivate($this->sut, 'get_item_quantity', $cartItem);
+
+        // Then
+        self::assertSame(15, $result);
+    }
+
+    /**
+     * @scenario get_item_price() returns line_subtotal_incl_tax / 15 for qty 1.5, so (unitPrice × 15) − discountAmount == totalAmount
+     * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines::get_item_price
+     */
+    public function test_get_item_price_divides_by_scaled_quantity(): void
+    {
+        // Arrange
+        $cartItem = [
+            'quantity' => 1.5,
+            'line_subtotal' => 10.0,
+            'line_subtotal_tax' => 2.0,
+        ];
+
+        // When
+        $result = $this->callPrivate($this->sut, 'get_item_price', $cartItem);
+
+        // Then
+        self::assertEqualsWithDelta(0.8, $result, 1e-10);
+    }
+
+    /**
+     * @scenario get_item_quantity() returns 4 (int) for a cart item with quantity 0.4 (scale factor 10)
+     * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines::get_item_quantity
+     */
+    public function test_get_item_quantity_scales_point_four_to_four(): void
+    {
+        // Arrange
+        $cartItem = ['quantity' => 0.4];
+
+        // When
+        $result = $this->callPrivate($this->sut, 'get_item_quantity', $cartItem);
+
+        // Then
+        self::assertSame(4, $result);
+    }
+
+    /**
+     * @scenario get_item_quantity() returns 1 (not 0) for a cart item with quantity below 0.5 that rounds to zero (repeating-decimal fallback path)
+     * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines::get_item_quantity
+     */
+    public function test_get_item_quantity_clamps_repeating_decimal_fallback_to_one(): void
+    {
+        // Arrange — 1/3 ≈ 0.3333… has no exact match in d=0..4; fallback round()→0 → clamped to 1
+        $cartItem = ['quantity' => (float)(1 / 3)];
+
+        // When
+        $result = $this->callPrivate($this->sut, 'get_item_quantity', $cartItem);
+
+        // Then
+        self::assertSame(1, $result);
+    }
+
+    /**
+     * @scenario get_item_quantity() returns the original integer unchanged for a cart item with integer quantity 3 (d=0 matches immediately)
+     * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines::get_item_quantity
+     */
+    public function test_get_item_quantity_preserves_integer_quantity_unchanged(): void
+    {
+        // Arrange
+        $cartItem = ['quantity' => 3];
+
+        // When
+        $result = $this->callPrivate($this->sut, 'get_item_quantity', $cartItem);
+
+        // Then
+        self::assertSame(3, $result);
+    }
+
+    /**
+     * @scenario Both OrderLines and PaymentLines exhibit identical normalisation behaviour for the same input quantity
+     * @covers \Mollie\WooCommerce\Payment\LineItems\OrderLines::get_item_quantity
+     * @covers \Mollie\WooCommerce\Payment\LineItems\PaymentLines::get_item_quantity
+     */
+    public function test_payment_lines_normalises_quantity_identically(): void
+    {
+        // Arrange
+        $cartItem = [
+            'quantity' => 1.5,
+            'line_subtotal' => 10.0,
+            'line_subtotal_tax' => 2.0,
+        ];
+
+        // When
+        $orderQty   = $this->callPrivate($this->sut, 'get_item_quantity', $cartItem);
+        $paymentQty = $this->callPrivate($this->paymentLinesSut, 'get_item_quantity', $cartItem);
+        $orderPrice   = $this->callPrivate($this->sut, 'get_item_price', $cartItem);
+        $paymentPrice = $this->callPrivate($this->paymentLinesSut, 'get_item_price', $cartItem);
+
+        // Then
+        self::assertSame(15, $orderQty);
+        self::assertSame(15, $paymentQty);
+        self::assertEqualsWithDelta(0.8, $orderPrice, 1e-10);
+        self::assertEqualsWithDelta(0.8, $paymentPrice, 1e-10);
+    }
+
+    private function callPrivate(object $obj, string $method, ...$args)
+    {
+        return (new \ReflectionMethod($obj, $method))->invoke($obj, ...$args);
+    }
+}


### PR DESCRIPTION
### What and why
  
  WooCommerce supports fractional product quantities (e.g. 1.5 metres of fabric) via third-party plugins. When a
  cart contained such a quantity, both OrderLines and PaymentLines passed the raw float directly to the Mollie API
  as the quantity field. Mollie requires quantity to be a whole number of at least 1, so any order with a
  fractional quantity was rejected with a 422 Unprocessable Entity response — making payment completely impossible
  for those customers.

  ### How it works now

  Both OrderLines and PaymentLines now include a private toIntegerQuantity() helper that converts a fractional
  WooCommerce quantity to the smallest equivalent whole number by finding the minimal decimal scale factor (e.g.
  1.5 → ×10 → 15, 0.4 → ×10 → 4). get_item_quantity() returns this scaled integer to Mollie, and get_item_price()
  divides the line subtotal by the same scaled value — preserving Mollie's required invariant unitPrice × quantity
  − discountAmount == totalAmount exactly. For repeating decimals that cannot be scaled exactly within four
  decimal places, the helper falls back to rounding and clamps to a minimum of 1.

  ### What to verify in review

  Covered by unit tests

  - ✓ A fractional quantity of 1.5 is sent to Mollie as integer 15 (scale factor ×10)
  - ✓ The unit price for quantity 1.5 is lineSubtotal / 15, keeping unitPrice × 15 − discountAmount == totalAmount
  - ✓ A fractional quantity of 0.4 is sent to Mollie as integer 4 (scale factor ×10)
  - ✓ A quantity below 0.5 that cannot be scaled exactly (e.g. 1/3) is clamped to 1 rather than 0, preventing
  division by zero
  - ✓ An integer quantity such as 3 passes through unchanged
  - ✓ OrderLines and PaymentLines produce identical quantity and price values for the same input

  Not covered by unit tests

  None — all acceptance criteria are covered by the unit test suite.
