### PR TITLE
Prevent infinite order note loop for cancelled Mollie payments

### DIFF
--- a/src/Payment/PaymentModule.php
+++ b/src/Payment/PaymentModule.php
@@ -190,7 +190,10 @@ class PaymentModule implements ServiceModule, ExecutableModule
                     $order = wc_get_order($unpaid_order);
                     $mollieOrderService = $this->container->get(MollieOrderService::class);
                     if ($mollieOrderService->checkPaymentForUnpaidOrder($order)) {
-                        continue;
+                        $order = wc_get_order($unpaid_order);
+                        if (!$order->has_status('pending')) {
+                            continue;
+                        }
                     }
                     add_filter('mollie-payments-for-woocommerce_order_status_cancelled', static function ($newOrderStatus) {
                         return SharedDataDictionary::STATUS_CANCELLED;

--- a/src/Payment/Webhooks/WebhookHandler.php
+++ b/src/Payment/Webhooks/WebhookHandler.php
@@ -266,6 +266,13 @@ class WebhookHandler
             return;
         }
 
+        if ($mollieObject->getCancelledMolliePaymentId($orderId) === $payment->id) {
+            $this->logger->debug(
+                __METHOD__ . " payment {$payment->id} already processed as cancelled for order {$orderId}, skipping."
+            );
+            return;
+        }
+
         $mollieObject->unsetActiveMolliePayment($orderId, $payment->id);
         $mollieObject->setCancelledMolliePaymentId($orderId, $payment->id);
 

--- a/tests/php/Unit/Payment/Webhooks/WebhookHandlerTest.php
+++ b/tests/php/Unit/Payment/Webhooks/WebhookHandlerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Payment\Webhooks;
+
+use Inpsyde\PaymentGateway\PaymentGateway;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mollie\WooCommerce\Payment\MolliePayment;
+use Mollie\WooCommerce\Payment\Webhooks\WebhookHandler;
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerce\Shared\Data;
+use Mollie\WooCommerceTests\TestCase;
+use Psr\Log\LoggerInterface;
+use WC_Order;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler
+ */
+class WebhookHandlerTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+    /** @var LoggerInterface&\Mockery\MockInterface */
+    private $logger;
+
+    /** @var Settings&\Mockery\MockInterface */
+    private $settings;
+
+    /** @var Data&\Mockery\MockInterface */
+    private $dataHelper;
+
+    private WebhookHandler $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger     = Mockery::mock(LoggerInterface::class);
+        $this->settings   = Mockery::mock(Settings::class);
+        $this->dataHelper = Mockery::mock(Data::class);
+
+        $this->logger->shouldReceive('debug')->zeroOrMoreTimes();
+
+        $this->sut = new WebhookHandler(
+            $this->logger,
+            $this->settings,
+            'mollie-payments-for-woocommerce',
+            $this->dataHelper
+        );
+    }
+
+    private function makePayment(string $id = 'tr_TEST123'): \stdClass
+    {
+        $payment         = new \stdClass();
+        $payment->id     = $id;
+        $payment->mode   = 'test';
+        $payment->method = 'bancontact';
+        $payment->status = 'canceled';
+
+        return $payment;
+    }
+
+    /**
+     * @scenario Given an order where '_mollie_cancelled_payment_id' already equals $payment->id,
+     *           a second call to onWebhookCanceled() adds no new WC order note and does not call
+     *           setCancelledMolliePaymentId() or updateOrderStatus() again.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCanceled
+     */
+    public function test_on_webhook_canceled_skips_all_processing_when_payment_already_tracked(): void
+    {
+        // Arrange
+        $paymentId    = 'tr_ALREADY_TRACKED';
+        $orderId      = 42;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MolliePayment::class);
+        $payment      = $this->makePayment($paymentId);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $mollieObject->shouldReceive('isFinalOrderStatus')->with($order)->andReturn(false);
+        $mollieObject->shouldReceive('getCancelledMolliePaymentId')->with($orderId)->andReturn($paymentId);
+
+        $order->shouldNotReceive('add_order_note');
+        $mollieObject->shouldNotReceive('unsetActiveMolliePayment');
+        $mollieObject->shouldNotReceive('setCancelledMolliePaymentId');
+        $mollieObject->shouldNotReceive('updateOrderStatus');
+
+        // When
+        $this->sut->onWebhookCanceled($order, $payment, 'Bancontact', $mollieObject);
+
+        // Then — Mockery verifies shouldNotReceive expectations on tearDown
+    }
+
+    /**
+     * @scenario Given an order with no '_mollie_cancelled_payment_id' meta set, the first call
+     *           to onWebhookCanceled() adds the cancellation note and writes
+     *           '_mollie_cancelled_payment_id' = $payment->id.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCanceled
+     */
+    public function test_on_webhook_canceled_processes_fully_on_first_cancellation(): void
+    {
+        // Arrange
+        $paymentId    = 'tr_FIRST';
+        $orderId      = 7;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MolliePayment::class);
+        $gateway      = Mockery::mock(PaymentGateway::class);
+        $gateway->id  = 'mollie_wc_gateway_bancontact';
+        $payment      = $this->makePayment($paymentId);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_status')->andReturn('pending');
+        $order->shouldReceive('get_payment_method')->andReturn('mollie_wc_gateway_bancontact');
+
+        $mollieObject->shouldReceive('isFinalOrderStatus')->with($order)->andReturn(false);
+        $mollieObject->shouldReceive('getCancelledMolliePaymentId')->with($orderId)->andReturn('');
+        $mollieObject->shouldReceive('unsetActiveMolliePayment')->once()->with($orderId, $paymentId);
+        $mollieObject->shouldReceive('setCancelledMolliePaymentId')->once()->with($orderId, $paymentId);
+        $mollieObject->shouldReceive('updateOrderStatus')->once();
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->once()->with($order);
+
+        $this->settings->shouldReceive('getOrderStatusCancelledPayments')->andReturn('pending');
+
+        when('wc_get_payment_gateway_by_order')->justReturn($gateway);
+        when('apply_filters')->returnArg(2);
+
+        // When
+        $order->shouldReceive('add_order_note')->once();
+
+        $this->sut->onWebhookCanceled($order, $payment, 'Bancontact', $mollieObject);
+
+        // Then — Mockery verifies call-count expectations on tearDown
+    }
+
+    /**
+     * @scenario Given an order where '_mollie_cancelled_payment_id' holds a different (older)
+     *           payment ID, calling onWebhookCanceled() with a new payment ID still processes
+     *           fully and overwrites '_mollie_cancelled_payment_id'.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCanceled
+     */
+    public function test_on_webhook_canceled_processes_new_payment_when_existing_cancelled_id_differs(): void
+    {
+        // Arrange
+        $newPaymentId = 'tr_NEW';
+        $orderId      = 99;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MolliePayment::class);
+        $gateway      = Mockery::mock(PaymentGateway::class);
+        $gateway->id  = 'mollie_wc_gateway_bancontact';
+        $payment      = $this->makePayment($newPaymentId);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_status')->andReturn('pending');
+        $order->shouldReceive('get_payment_method')->andReturn('mollie_wc_gateway_bancontact');
+
+        $mollieObject->shouldReceive('isFinalOrderStatus')->with($order)->andReturn(false);
+        $mollieObject->shouldReceive('getCancelledMolliePaymentId')->with($orderId)->andReturn('tr_OLD');
+        $mollieObject->shouldReceive('unsetActiveMolliePayment')->once()->with($orderId, $newPaymentId);
+        $mollieObject->shouldReceive('setCancelledMolliePaymentId')->once()->with($orderId, $newPaymentId);
+        $mollieObject->shouldReceive('updateOrderStatus')->once();
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->once()->with($order);
+
+        $this->settings->shouldReceive('getOrderStatusCancelledPayments')->andReturn('pending');
+
+        when('wc_get_payment_gateway_by_order')->justReturn($gateway);
+        when('apply_filters')->returnArg(2);
+
+        // When
+        $order->shouldReceive('add_order_note')->once();
+
+        $this->sut->onWebhookCanceled($order, $payment, 'Bancontact', $mollieObject);
+
+        // Then — Mockery verifies call-count expectations on tearDown
+    }
+}


### PR DESCRIPTION
## What and why
  
  When the plugin's "order status for cancelled payments" setting is configured to `pending`, a Mollie-cancelled
  payment (as occurs with Bancontact or TWINT in production) causes `onWebhookCanceled()` to resolve the
  WooCommerce order back to `pending` — the same status it already had. Because the order remains in the pending
  queue, the Mollie cron job (`mollie_woocommerce_cancel_unpaid_orders`, firing every 600 seconds) picks it up
  again on the next tick, makes a fresh API call to Mollie, and adds another "payment cancelled" order note. The bug cannot be reproduced in test mode because test-mode payments expire (`open → expired`)
  rather than sitting in `cancelled` state.

  ## How it works now

  `WebhookHandler::onWebhookCanceled()` now checks whether `MollieObject::getCancelledMolliePaymentId()` already
  returns the incoming `$payment->id` — if so, it logs and returns immediately, preventing duplicate note writes
  and redundant meta updates. In `PaymentModule::cancelOrderOnExpiryDate()`, after `checkPaymentForUnpaidOrder()`
  returns `true`, the order is refreshed via `wc_get_order()` and `has_status('pending')` is called; if the order
  is still pending (meaning the webhook handler did not move it out of the queue), execution falls through to the
  existing WooCommerce cancellation block, terminating the loop after one execution.

  ## What to verify in review

  ### Covered by unit tests
  - ✓ When `_mollie_cancelled_payment_id` already equals the incoming payment id, `onWebhookCanceled()` adds no
  order note and calls neither `setCancelledMolliePaymentId()` nor `updateOrderStatus()`.
  - ✓ When no `_mollie_cancelled_payment_id` is set, the first call to `onWebhookCanceled()` adds exactly one
  cancellation note and writes `_mollie_cancelled_payment_id`.
  - ✓ When `_mollie_cancelled_payment_id` holds a different (older) payment id, `onWebhookCanceled()` processes
  the new payment in full and overwrites the stored id.

  ### Not covered by unit tests
  - ✗ The first cron execution adds the cancellation note, sets the meta, refreshes the order, falls through to
  cancel it in WC, and the order leaves the pending queue — requires `cancelOrderOnExpiryDate()` against real WC
  order status persistence; integration level, target
  `tests/Integration/spec/webhooks/WebhooksIntegrationTest.php`.
  - ✗ A second cron execution does not find the order in `wc_get_orders(['status' => 'pending'])` because it is
  now cancelled — same integration-level reason.

 

