### PR TITLE
Identical api calls on return page cause php timeout white screen

### DIFF
--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -28,6 +28,10 @@ class MollieObject
     protected static $order;
     protected static $payment;
     protected static $shop_country;
+    /** @var array<string, Payment|null> */
+    protected static $paymentObjectCache = [];
+    /** @var array<string, Order|null> */
+    protected static $orderObjectCache = [];
     /**
      * @var Logger
      */
@@ -111,15 +115,21 @@ class MollieObject
      */
     public function getPaymentObjectPayment($payment_id, $test_mode = false, $use_cache = true)
     {
+        if ($use_cache && array_key_exists($payment_id, static::$paymentObjectCache)) {
+            return static::$paymentObjectCache[$payment_id];
+        }
+
+        $result = null;
         try {
             $test_mode = $this->settingsHelper->isTestModeEnabled();
             $apiKey = $this->settingsHelper->getApiKey();
-            return $this->apiHelper->getApiClient($apiKey)->payments->get($payment_id);
+            $result = $this->apiHelper->getApiClient($apiKey)->payments->get($payment_id);
         } catch (ApiException $apiException) {
             $this->logger->debug(__FUNCTION__ . sprintf(': Could not load payment %s (', $payment_id) . ( $test_mode ? 'test' : 'live' ) . "): " . $apiException->getMessage() . ' (' . get_class($apiException) . ')');
         }
 
-        return null;
+        static::$paymentObjectCache[$payment_id] = $result;
+        return $result;
     }
 
     /**
@@ -135,16 +145,22 @@ class MollieObject
     public function getPaymentObjectOrder($payment_id, $test_mode = false, $use_cache = true)
     {
         // TODO David: Duplicate, send to child class.
+        if ($use_cache && array_key_exists($payment_id, static::$orderObjectCache)) {
+            return static::$orderObjectCache[$payment_id];
+        }
+
+        $result = null;
         try {
             // Is test mode enabled?
             $test_mode = $this->settingsHelper->isTestModeEnabled();
             $apiKey = $this->settingsHelper->getApiKey();
-            return $this->apiHelper->getApiClient($apiKey)->orders->get($payment_id, [ "embed" => "payments" ]);
+            $result = $this->apiHelper->getApiClient($apiKey)->orders->get($payment_id, [ "embed" => "payments" ]);
         } catch (ApiException $e) {
             $this->logger->debug(__FUNCTION__ . sprintf(': Could not load order %s (', $payment_id) . ( $test_mode ? 'test' : 'live' ) . "): " . $e->getMessage() . ' (' . get_class($e) . ')');
         }
 
-        return null;
+        static::$orderObjectCache[$payment_id] = $result;
+        return $result;
     }
 
     /**

--- a/tests/php/Unit/Payment/MollieObjectTest.php
+++ b/tests/php/Unit/Payment/MollieObjectTest.php
@@ -1,5 +1,5 @@
 <?php
-# kb-active
+
 declare(strict_types=1);
 
 namespace Mollie\WooCommerceTests\Unit\Payment;

--- a/tests/php/Unit/Payment/MollieObjectTest.php
+++ b/tests/php/Unit/Payment/MollieObjectTest.php
@@ -1,0 +1,249 @@
+<?php
+# kb-active
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Payment;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mollie\Api\Endpoints\OrderEndpoint;
+use Mollie\Api\Endpoints\PaymentEndpoint;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Order as MollieApiOrder;
+use Mollie\Api\Resources\Payment as MollieApiPayment;
+use Mollie\WooCommerce\Payment\MollieObject;
+use Mollie\WooCommerce\Payment\PaymentFactory;
+use Mollie\WooCommerce\Payment\Request\RequestFactory;
+use Mollie\WooCommerce\SDK\Api;
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerceTests\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionException;
+use ReflectionProperty;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Payment\MollieObject
+ */
+class MollieObjectTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var LoggerInterface&\Mockery\MockInterface */
+    private $logger;
+
+    /** @var Settings&\Mockery\MockInterface */
+    private $settings;
+
+    /** @var Api&\Mockery\MockInterface */
+    private $apiHelper;
+
+    /** @var MollieApiClient */
+    private $apiClient;
+
+    /** @var \Mockery\MockInterface */
+    private $paymentEndpoint;
+
+    /** @var \Mockery\MockInterface */
+    private $orderEndpoint;
+
+    private MollieObject $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        when('wc_get_base_location')->justReturn(['country' => 'NL']);
+
+        $this->logger          = Mockery::mock(LoggerInterface::class);
+        $this->settings        = Mockery::mock(Settings::class);
+        $this->apiHelper       = Mockery::mock(Api::class);
+        $this->paymentEndpoint = Mockery::mock(PaymentEndpoint::class);
+        $this->orderEndpoint   = Mockery::mock(OrderEndpoint::class);
+
+        $this->logger->shouldReceive('debug')->zeroOrMoreTimes();
+        $this->settings->shouldReceive('isTestModeEnabled')->andReturn(false)->byDefault();
+        $this->settings->shouldReceive('getApiKey')->andReturn('test_api_key')->byDefault();
+
+        $this->apiClient           = $this->createMock(MollieApiClient::class);
+        $this->apiClient->payments = $this->paymentEndpoint;
+        $this->apiClient->orders   = $this->orderEndpoint;
+
+        $this->apiHelper
+            ->shouldReceive('getApiClient')
+            ->with('test_api_key')
+            ->andReturn($this->apiClient)
+            ->byDefault();
+
+        $this->resetStaticCaches();
+
+        $this->sut = new MollieObject(
+            null,
+            $this->logger,
+            Mockery::mock(PaymentFactory::class),
+            $this->apiHelper,
+            $this->settings,
+            'mollie-payments-for-woocommerce',
+            Mockery::mock(RequestFactory::class)
+        );
+    }
+
+    private function resetStaticCaches(): void
+    {
+        foreach (['paymentObjectCache', 'orderObjectCache'] as $property) {
+            try {
+                $ref = new ReflectionProperty(MollieObject::class, $property);
+                if (PHP_VERSION_ID < 80100) {
+                    $ref->setAccessible(true);
+                }
+                $ref->setValue(null, []);
+            } catch (ReflectionException $e) {
+                // Property does not exist yet — phase 03 will add it.
+            }
+        }
+    }
+
+    private function makePayment(string $id = 'tr_test123'): MollieApiPayment
+    {
+        $payment     = Mockery::mock(MollieApiPayment::class);
+        $payment->id = $id;
+        return $payment;
+    }
+
+    private function makeOrder(string $id = 'ord_test123'): MollieApiOrder
+    {
+        $order     = Mockery::mock(MollieApiOrder::class);
+        $order->id = $id;
+        return $order;
+    }
+
+    /**
+     * @scenario Within a single PHP request, calling getPaymentObjectPayment with the same
+     *           payment_id and use_cache=true more than once returns the result cached from
+     *           the first call without making additional HTTP requests to the Mollie API.
+     * @covers \Mollie\WooCommerce\Payment\MollieObject::getPaymentObjectPayment
+     */
+    public function test_cache_deduplicates_repeated_calls_for_same_payment_id(): void
+    {
+        // Arrange
+        $paymentId = 'tr_cache_test';
+        $payment   = $this->makePayment($paymentId);
+        $this->paymentEndpoint
+            ->shouldReceive('get')
+            ->with($paymentId)
+            ->once()
+            ->andReturn($payment);
+
+        // When
+        $first  = $this->sut->getPaymentObjectPayment($paymentId, false, true);
+        $second = $this->sut->getPaymentObjectPayment($paymentId, false, true);
+
+        // Then
+        $this->assertSame($payment, $first);
+        $this->assertSame($payment, $second);
+    }
+
+    /**
+     * @scenario When use_cache=false, getPaymentObjectPayment always calls the Mollie API,
+     *           updates the static cache entry for the payment_id, and the subsequent
+     *           use_cache=true call returns the fresh result without another API call.
+     * @covers \Mollie\WooCommerce\Payment\MollieObject::getPaymentObjectPayment
+     */
+    public function test_use_cache_false_bypasses_cache_and_updates_it(): void
+    {
+        // Arrange
+        $paymentId   = 'tr_bypass_test';
+        $firstResult = $this->makePayment($paymentId);
+        $freshResult = $this->makePayment($paymentId);
+        $this->paymentEndpoint
+            ->shouldReceive('get')
+            ->with($paymentId)
+            ->twice()
+            ->andReturn($firstResult, $freshResult);
+
+        // When — prime cache, then force-refresh with use_cache=false
+        $this->sut->getPaymentObjectPayment($paymentId, false, true);
+        $fromBypass = $this->sut->getPaymentObjectPayment($paymentId, false, false);
+        $fromCache  = $this->sut->getPaymentObjectPayment($paymentId, false, true);
+
+        // Then — bypass returned fresh value; cached call also got the updated fresh value
+        $this->assertSame($freshResult, $fromBypass);
+        $this->assertSame($freshResult, $fromCache);
+    }
+
+    /**
+     * @scenario When the first call throws an ApiException, null is stored in the cache;
+     *           subsequent use_cache=true calls within the same request return null without
+     *           making further API calls.
+     * @covers \Mollie\WooCommerce\Payment\MollieObject::getPaymentObjectPayment
+     */
+    public function test_null_is_cached_when_api_throws(): void
+    {
+        // Arrange
+        $paymentId = 'tr_error_test';
+        $this->paymentEndpoint
+            ->shouldReceive('get')
+            ->with($paymentId)
+            ->once()
+            ->andThrow(new ApiException('Connection error'));
+
+        // When
+        $first  = $this->sut->getPaymentObjectPayment($paymentId, false, true);
+        $second = $this->sut->getPaymentObjectPayment($paymentId, false, true);
+
+        // Then — both null; Mockery ->once() above asserts the API was not called a second time
+        $this->assertNull($first);
+        $this->assertNull($second);
+    }
+
+    /**
+     * @scenario Resetting the static cache (simulating a new PHP request) causes the next
+     *           call to hit the Mollie API again, even for a previously cached payment_id.
+     * @covers \Mollie\WooCommerce\Payment\MollieObject::getPaymentObjectPayment
+     */
+    public function test_static_cache_reset_causes_fresh_api_call(): void
+    {
+        // Arrange
+        $paymentId = 'tr_reset_test';
+        $payment   = $this->makePayment($paymentId);
+        $this->paymentEndpoint
+            ->shouldReceive('get')
+            ->with($paymentId)
+            ->twice()
+            ->andReturn($payment);
+
+        // When — first call populates cache; reset simulates new PHP request; second call must hit API
+        $this->sut->getPaymentObjectPayment($paymentId, false, true);
+        $this->resetStaticCaches();
+        $this->sut->getPaymentObjectPayment($paymentId, false, true);
+
+        // Then — Mockery ->twice() above verifies the API was called exactly twice
+    }
+
+    /**
+     * @scenario getPaymentObjectOrder deduplicates calls for the same order_id using its own
+     *           static cache, independent of the payment cache.
+     * @covers \Mollie\WooCommerce\Payment\MollieObject::getPaymentObjectOrder
+     */
+    public function test_get_payment_object_order_applies_same_caching(): void
+    {
+        // Arrange
+        $orderId = 'ord_cache_test';
+        $order   = $this->makeOrder($orderId);
+        $this->orderEndpoint
+            ->shouldReceive('get')
+            ->with($orderId, ['embed' => 'payments'])
+            ->once()
+            ->andReturn($order);
+
+        // When
+        $first  = $this->sut->getPaymentObjectOrder($orderId, false, true);
+        $second = $this->sut->getPaymentObjectOrder($orderId, false, true);
+
+        // Then
+        $this->assertSame($order, $first);
+        $this->assertSame($order, $second);
+    }
+}


### PR DESCRIPTION
## What and why

  On the Mollie return page, WordPress fires several hooks (`the_title` registered per gateway instance,
  `woocommerce_cancel_unpaid_order`, `woocommerce_thankyou`) that can each independently trigger a lookup of the
  same Mollie payment or order. `getPaymentObjectPayment` and `getPaymentObjectOrder` declared a `$use_cache`
  parameter but never honored it, so every one of these lookups made a fresh, live HTTP call to the Mollie API. The
  trigger for the multiplication is environmental and wasn't reproducible, but the absence of any request-scoped
  deduplication meant there was nothing to contain it once it started.

  ## How it works now
  
  `MollieObject` now implements the `$use_cache` parameter it already declared, using two static, per-request
  arrays — `$paymentObjectCache` and `$orderObjectCache` — keyed by `payment_id` / `order_id`.
  `getPaymentObjectPayment` and `getPaymentObjectOrder` check their respective cache first when `$use_cache` is
  true and return the cached value (including a cached `null` from a prior API failure) without calling the API
  again; when `$use_cache` is false they always hit the API and overwrite the cache entry with the fresh result.
  Because the cache is a static PHP array, it only lives for the duration of the request — a new page load or
  webhook call starts with an empty cache, so cross-request retries are completely unaffected.

  ## What to verify in review
  
  ### Covered by unit tests
  - ✓ Calling `getPaymentObjectPayment` twice with the same `payment_id` and `use_cache=true` hits the Mollie API
  only once, returning the cached result on the second call.
  - ✓ Calling with `use_cache=false` always calls the API and refreshes the cache, even when a cached value
  already exists.
  - ✓ When the first API call succeeds, the returned `Payment` object is cached and returned unchanged on
  subsequent cached calls.
  - ✓ When the first API call throws, `null` is cached and returned on subsequent cached calls without retrying.
  - ✓ Resetting the static cache (simulating a new PHP request) causes the next call to hit the API again.
  - ✓ `getPaymentObjectOrder` receives the same caching treatment, with its own cache keyed by `order_id`.

 
  
