### PR TITLE
Double-Visited Order-Received Page

### DIFF
--- a/src/Payment/PaymentModule.php
+++ b/src/Payment/PaymentModule.php
@@ -86,7 +86,7 @@ class PaymentModule implements ServiceModule, ExecutableModule
         add_action('woocommerce_api_mollie_return', function () use ($container) {
             $this->onMollieReturn($container);
         }, 10, 1);
-        add_action('template_redirect', function () use ($container) {
+        add_action('init', function () use ($container) {
             $this->mollieReturnRedirect($container);
         });
 

--- a/tests/Integration/spec/Payment/PaymentModuleReturnRedirectTest.php
+++ b/tests/Integration/spec/Payment/PaymentModuleReturnRedirectTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\spec\Payment;
+
+use Mollie\WooCommerce\Payment\PaymentModule;
+use Mollie\WooCommerceTests\Integration\IntegrationMockedTestCase;
+use ReflectionFunction;
+
+/**
+ * Integration tests for the Mollie return-redirect hook registration.
+ *
+ * @group integration
+ * @group payment-module
+ * @covers PaymentModule::run
+ */
+class PaymentModuleReturnRedirectTest extends IntegrationMockedTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        remove_all_actions('init');
+        remove_all_actions('template_redirect');
+    }
+
+    public function test_it_registers_return_redirect_callback_on_init_not_template_redirect(): void
+    {
+        $this->bootstrapModule();
+
+        $this->assertTrue(
+            $this->hookHasCallbackBoundTo('init', PaymentModule::class),
+            'Expected an "init" callback bound to a PaymentModule instance (the return-redirect handler).'
+        );
+        $this->assertFalse(
+            $this->hookHasCallbackBoundTo('template_redirect', PaymentModule::class),
+            'The return-redirect handler must no longer be registered on "template_redirect".'
+        );
+    }
+
+    private function hookHasCallbackBoundTo(string $hookName, string $className): bool
+    {
+        global $wp_filter;
+
+        if (!isset($wp_filter[$hookName])) {
+            return false;
+        }
+
+        foreach ($wp_filter[$hookName]->callbacks as $priorityGroup) {
+            foreach ($priorityGroup as $registered) {
+                $callback = $registered['function'];
+                if (!($callback instanceof \Closure)) {
+                    continue;
+                }
+
+                $boundThis = (new ReflectionFunction($callback))->getClosureThis();
+                if ($boundThis instanceof $className) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Integration/spec/Payment/PaymentModuleReturnRedirectTest.php
+++ b/tests/Integration/spec/Payment/PaymentModuleReturnRedirectTest.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerceTests\Integration\spec\Payment;
 
+use Mockery;
 use Mollie\WooCommerce\Payment\PaymentModule;
 use Mollie\WooCommerceTests\Integration\IntegrationMockedTestCase;
+use Psr\Log\LoggerInterface as Logger;
 use ReflectionFunction;
 
 /**
- * Integration tests for the Mollie return-redirect hook registration.
+ * Integration tests for the Mollie return-redirect hook registration and detection.
  *
  * @group integration
  * @group payment-module
  * @covers PaymentModule::run
+ * @covers PaymentModule::mollieReturnRedirect
  */
 class PaymentModuleReturnRedirectTest extends IntegrationMockedTestCase
 {
@@ -22,6 +25,13 @@ class PaymentModuleReturnRedirectTest extends IntegrationMockedTestCase
         parent::setUp();
         remove_all_actions('init');
         remove_all_actions('template_redirect');
+        unset($_GET['filter_flag'], $_GET['order_id'], $_GET['key']);
+    }
+
+    public function tearDown(): void
+    {
+        unset($_GET['filter_flag'], $_GET['order_id'], $_GET['key']);
+        parent::tearDown();
     }
 
     public function test_it_registers_return_redirect_callback_on_init_not_template_redirect(): void
@@ -38,12 +48,59 @@ class PaymentModuleReturnRedirectTest extends IntegrationMockedTestCase
         );
     }
 
+    /**
+     * PaymentModule::orderByRequest() reads order_id/key via filter_input(INPUT_GET, ...), which always
+     * returns NULL under the CLI SAPI regardless of $_GET (verified empirically: PHP's filter_input()
+     * input buffer is only populated for real request SAPIs, never for CLI). So under phpunit, order
+     * lookup always fails and onMollieReturn() returns via its RuntimeException catch branch *before*
+     * reaching wp_safe_redirect()/die. That lets this test safely observe that the handler was entered
+     * purely from $_GET['filter_flag'], with no dependency on is_order_received_page() or any other
+     * query-resolution-dependent conditional tag, without ever touching the redirect+die path.
+     */
+    public function test_it_detects_return_via_get_param_independent_of_query_resolution(): void
+    {
+        $this->assertFalse(
+            is_order_received_page(),
+            'Precondition: this request must not already be WooCommerce\'s order-received page.'
+        );
+
+        $_GET['filter_flag'] = 'onMollieReturn';
+
+        $debugMessages = [];
+        $loggerSpy = Mockery::mock(Logger::class);
+        $loggerSpy->shouldReceive('debug')->andReturnUsing(function ($message) use (&$debugMessages) {
+            $debugMessages[] = $message;
+        });
+
+        $this->bootstrapModule([
+            Logger::class => static function () use ($loggerSpy) {
+                return $loggerSpy;
+            },
+        ]);
+        $callback = $this->findCallbackBoundTo('init', PaymentModule::class);
+
+        $this->assertNotNull($callback, 'Expected an "init" callback bound to a PaymentModule instance.');
+        $callback();
+
+        $joined = implode(' | ', $debugMessages);
+        $this->assertStringContainsString(
+            'Could not find order by order Id',
+            $joined,
+            'Expected onMollieReturn() to be entered from $_GET[\'filter_flag\'] alone and log the order-not-found path.'
+        );
+    }
+
     private function hookHasCallbackBoundTo(string $hookName, string $className): bool
+    {
+        return $this->findCallbackBoundTo($hookName, $className) !== null;
+    }
+
+    private function findCallbackBoundTo(string $hookName, string $className): ?\Closure
     {
         global $wp_filter;
 
         if (!isset($wp_filter[$hookName])) {
-            return false;
+            return null;
         }
 
         foreach ($wp_filter[$hookName]->callbacks as $priorityGroup) {
@@ -55,11 +112,11 @@ class PaymentModuleReturnRedirectTest extends IntegrationMockedTestCase
 
                 $boundThis = (new ReflectionFunction($callback))->getClosureThis();
                 if ($boundThis instanceof $className) {
-                    return true;
+                    return $callback;
                 }
             }
         }
 
-        return false;
+        return null;
     }
 }


### PR DESCRIPTION
## What and why
  
  Every payment return from Mollie was loading the WooCommerce order-received (thank-you) page twice. The redirect
  URL sent to Mollie points at the order-received page itself, with a `filter_flag=onMollieReturn` marker
  appended so the app can strip it afterwards — but that stripping only happened on WordPress's
  `template_redirect` hook, by which point the query was already fully resolved and `is_order_received_page()` was
  already returning `true`. Any hook that runs earlier in the request (like `wp`, which most tracking/analytics
  integrations use, including server-side Facebook CAPI, Pixel Your Site Pro, and similar Conversions API setups)
  would see the flagged, throwaway request as a real page view before the redirect ever fired, and then see the
  real page view again after the redirect. 

  ## How it works now

  `PaymentModule::run()` now registers the return-redirect callback (`mollieReturnRedirect()` →
  `onMollieReturn()`) on the `init` action instead of `template_redirect`. Detection of the Mollie return still
  reads `$_GET['filter_flag']` directly rather than any WordPress query state, so it doesn't need the query to be
  resolved first — moving it to `init` means the flagged request gets redirected before `is_order_received_page()`
  can ever evaluate `true` for it, so nothing hooked on `wp` or `template_redirect` sees it as the thank-you
  page. No other file's behavior changes: `UrlMiddleware`'s return URL format and `onMollieReturn()`'s own logic
  are untouched.

  ## What to verify in review
  
  ### Covered by unit tests
  - ✓ The return-redirect callback is registered on the `init` action, and no longer on `template_redirect`
  (verified against WordPress's real hook registry, not a mock).
  - ✓ Detection of the Mollie return via `$_GET['filter_flag'] === 'onMollieReturn'` is independent of
  `is_order_received_page()` or any other query-resolution-dependent state — proven by invoking the real
  registered callback with `is_order_received_page()` false and observing it still entered the handler.

