### PR TITLE
Fix fatal error in GatewaySurchargeHandler when order item hook fires with a refund

### DIFF
--- a/src/Shared/GatewaySurchargeHandler.php
+++ b/src/Shared/GatewaySurchargeHandler.php
@@ -45,6 +45,10 @@ class GatewaySurchargeHandler
 
     public function renderHiddenOrderKeyFields($item_id, $item, $order, $bool = false)
     {
+        if (!is_callable([$order, 'get_order_key'])) {
+            return;
+        }
+
         $orderKey = $order->get_order_key();
         $nonce = wp_create_nonce('mollie_surcharge_' . $orderKey);
         ?>

--- a/tests/php/Functional/Shared/SurchargeHandlerTest.php
+++ b/tests/php/Functional/Shared/SurchargeHandlerTest.php
@@ -91,6 +91,25 @@ class SurchargeHandlerTest extends TestCase
         $testee->updateSurchargeOrderPay();
     }
 
+    /**
+     *
+     * GIVEN the woocommerce_order_item_meta_end hook fires with an object that doesn't
+     * implement get_order_key() (e.g. WC_Order_Refund during PDF credit note generation)
+     * WHEN renderHiddenOrderKeyFields is invoked with that object as $order
+     * THEN it returns without fatally erroring and without rendering any output
+     *
+     * @test
+     */
+    public function rendersNothingWhenOrderDoesNotSupportGetOrderKey()
+    {
+        $testee = new GatewaySurchargeHandler(new Surcharge());
+        $orderWithoutOrderKey = new \stdClass();
+
+        $testee->renderHiddenOrderKeyFields(1, null, $orderWithoutOrderKey, false);
+
+        $this->expectOutputString('');
+    }
+
     protected function cartMock()
     {
         return $this->createConfiguredMock(


### PR DESCRIPTION
## Summary
- `GatewaySurchargeHandler::renderHiddenOrderKeyFields()` unconditionally called `$order->get_order_key()`, but the `woocommerce_order_item_meta_end` hook can fire with a refund object (`WC_Order_Refund` / its HPOS counterpart) instead of a `WC_Order` — e.g. when a third-party plugin generates a PDF credit note.
- Since refunds don't implement `get_order_key()`, this caused a fatal error, breaking PDF credit note generation while leaving the underlying Mollie refund unaffected.
- Added a guard that bails out early when `$order` doesn't support `get_order_key()`.

Fixes #1251

## Test plan
- [x] Added a regression test (`SurchargeHandlerTest::rendersNothingWhenOrderDoesNotSupportGetOrderKey`) that reproduces the exact fatal from the issue before the fix, and passes after
- [x] Full `Functional` test suite passes (pre-existing unrelated warnings confirmed present on `dev/develop` baseline too)
- [x] `phpcs` clean on changed files