### PR TITLE
Return empty string when payment has no redirect URL in webhook fallback

### DIFF
--- a/src/Payment/MollieOrderService.php
+++ b/src/Payment/MollieOrderService.php
@@ -1022,6 +1022,6 @@ class MollieOrderService
             $this->logger->debug(__METHOD__ . ": payment $transactionID not found.", [true]);
             return '';
         }
-        return $payment->redirectUrl;
+        return $payment->redirectUrl ?? '';
     }
 }


### PR DESCRIPTION
Fixes #1255.

`getRedirectUrlFromPaymentObject()` is type-hinted `: string`, and every early-return path in it returns `''`, but the final `return $payment->redirectUrl;` is unguarded. When a matched payment has no redirect URL, `redirectUrl` is `null`, so the webhook fallback in `RestApi::callback()` throws an uncaught `TypeError` and the endpoint 500s, which makes Mollie retry for hours and leaves the order unpaid. This coalesces the return to `''` so it matches the method's other failure paths.

I could not run the suite locally since the dev setup pulls from a private Packagist repo, but the change is a one-line null guard on a single return; `php -l` passes.
