### PR TITLE
Add czech and slovak language options

### DIFF
--- a/src/Components/AcceptedLocaleValuesDictionary.php
+++ b/src/Components/AcceptedLocaleValuesDictionary.php
@@ -36,5 +36,7 @@ class AcceptedLocaleValuesDictionary
         'pl_PL',
         'lv_LV',
         'lt_LT',
+        'cs_CZ',
+        'sk_SK',
     ];
 }

--- a/src/Settings/Page/Section/Advanced.php
+++ b/src/Settings/Page/Section/Advanced.php
@@ -87,6 +87,8 @@ class Advanced extends AbstractSection
                     'pl_PL' => __('Polish', 'mollie-payments-for-woocommerce'),
                     'lv_LV' => __('Latvian', 'mollie-payments-for-woocommerce'),
                     'lt_LT' => __('Lithuanian', 'mollie-payments-for-woocommerce'),
+                    'cs_CZ' => __('Czech', 'mollie-payments-for-woocommerce'),
+                    'sk_SK' => __('Slovak', 'mollie-payments-for-woocommerce'),
                 ],
                 'desc' => sprintf(
                 /* translators: Placeholder 1: link tag Placeholder 2: closing tag */

--- a/src/Shared/SharedDataDictionary.php
+++ b/src/Shared/SharedDataDictionary.php
@@ -159,6 +159,8 @@ class SharedDataDictionary
         'pl_PL',
         'lv_LV',
         'lt_LT',
+        'cs_CZ',
+        'sk_SK',
     ];
     /**
      * @var string

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -41,7 +41,9 @@ export namespace MollieSettings {
 		| 'hu_HU'
 		| 'pl_PL'
 		| 'lv_LV'
-		| 'lt_LT';
+		| 'lt_LT'
+		| 'cs_CZ'
+		| 'sk_SK';
 
 	export type ApiMethod = 'order' | 'payment';
 


### PR DESCRIPTION
Docs at https://docs.mollie.com/reference/create-payment include cs_CZ and sk_SK as language options, but they are not provided as options in the UI Advanced settings.