### PR TITLE
Dev/piwoo 928 klarna auto capture ignores capture or cancel on status change setting

### DIFF
--- a/src/MerchantCapture/Capture/Type/StateChangeCapture.php
+++ b/src/MerchantCapture/Capture/Type/StateChangeCapture.php
@@ -34,7 +34,7 @@ class StateChangeCapture
     public function orderStatusChange(int $orderId, string $oldStatus, string $newStatus)
     {
         $stateChangeCaptureEnabled = $this->container->get('merchant.manual_capture.on_status_change_enabled');
-        if (empty($stateChangeCaptureEnabled) || $stateChangeCaptureEnabled === 'no') {
+        if (!$stateChangeCaptureEnabled) {
             return;
         }
 

--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -251,7 +251,8 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
                     if ($disableShipAndCapture) {
                         return true;
                     }
-                    if ($container->get('merchant.manual_capture.on_status_change_enabled')) {
+                    $onStatusChangeEnabled = $container->get('merchant.manual_capture.on_status_change_enabled');
+                    if (!empty($onStatusChangeEnabled) && $onStatusChangeEnabled !== 'no') {
                         return true;
                     }
                     return $container->get('merchant.manual_capture.is_waiting')($order) || $container->get('merchant.manual_capture.is_authorized')($order);

--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -251,6 +251,9 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
                     if ($disableShipAndCapture) {
                         return true;
                     }
+                    if ($container->get('merchant.manual_capture.on_status_change_enabled')) {
+                        return true;
+                    }
                     return $container->get('merchant.manual_capture.is_waiting')($order) || $container->get('merchant.manual_capture.is_authorized')($order);
                 },
                 10,

--- a/src/MerchantCapture/MerchantCaptureModule.php
+++ b/src/MerchantCapture/MerchantCaptureModule.php
@@ -85,8 +85,8 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
                         return $isManualCaptureMethod && $orderIsAuthorized && $isCorrectState;
                     };
                 },
-                'merchant.manual_capture.on_status_change_enabled' => static function () {
-                    return get_option('mollie-payments-for-woocommerce_capture_or_void', false);
+                'merchant.manual_capture.on_status_change_enabled' => static function (): bool {
+                    return get_option('mollie-payments-for-woocommerce_capture_or_void', 'no') === 'yes';
                 },
                 'merchant.manual_capture.cart_can_be_captured' => static function (): bool {
                     if (!class_exists(\WC_Product_Subscription::class)) {
@@ -251,11 +251,12 @@ class MerchantCaptureModule implements ExecutableModule, ServiceModule
                     if ($disableShipAndCapture) {
                         return true;
                     }
+                    $isAuthorizedOrWaiting = $container->get('merchant.manual_capture.is_waiting')($order)
+                        || $container->get('merchant.manual_capture.is_authorized')($order);
+                    $laterCaptureEnabled = $container->get('merchant.manual_capture.enabled');
                     $onStatusChangeEnabled = $container->get('merchant.manual_capture.on_status_change_enabled');
-                    if (!empty($onStatusChangeEnabled) && $onStatusChangeEnabled !== 'no') {
-                        return true;
-                    }
-                    return $container->get('merchant.manual_capture.is_waiting')($order) || $container->get('merchant.manual_capture.is_authorized')($order);
+
+                    return $isAuthorizedOrWaiting || ($laterCaptureEnabled && !$onStatusChangeEnabled);
                 },
                 10,
                 2

--- a/tests/Integration/spec/MerchantCapture/MerchantCaptureStatusChangeCaptureTest.php
+++ b/tests/Integration/spec/MerchantCapture/MerchantCaptureStatusChangeCaptureTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Integration\spec\MerchantCapture;
+
+use Mockery;
+use Mollie\Api\Endpoints\PaymentCaptureEndpoint;
+use Mollie\WooCommerce\MerchantCapture\ManualCaptureStatus;
+use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
+use Mollie\WooCommerceTests\Integration\API\Traits\APIMockTrait;
+use Mollie\WooCommerceTests\Integration\IntegrationMockedTestCase;
+use WC_Order;
+
+/**
+ * End-to-end proof that the 'Capture or cancel on status change' setting governs the
+ * automatic capture-on-Completed for Klarna (Payments API) the same way it does for cards.
+ *
+ * Drives the real woocommerce_order_status transition through the module's disable filter
+ * and PaymentModule::shipAndCaptureOrderAtMollie(), with only the Mollie API mocked.
+ */
+class MerchantCaptureStatusChangeCaptureTest extends IntegrationMockedTestCase
+{
+    use APIMockTrait;
+
+    private const OPT_TEST_MODE = 'mollie-payments-for-woocommerce_test_mode_enabled';
+    private const OPT_TEST_KEY = 'mollie-payments-for-woocommerce_test_api_key';
+    private const OPT_ONHOLD = 'mollie-payments-for-woocommerce_place_payment_onhold';
+    private const OPT_CAPTURE_OR_VOID = 'mollie-payments-for-woocommerce_capture_or_void';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->initializeApiMock();
+
+        update_option(self::OPT_TEST_MODE, 'yes');
+        update_option(self::OPT_TEST_KEY, 'test_' . str_repeat('1', 32));
+
+        // Gateway building during the full module boot resolves available payment methods.
+        $this->apiMock()->getMockedApiClient()->methods
+            ->shouldReceive('allAvailable')->andReturn([]);
+
+        // Start from clean capture-relevant hooks so only this test's freshly booted
+        // handlers run (WP/WooCommerce already fired these during wp-load, and prior tests
+        // in the same process leave their own bootstrapped handlers behind).
+        remove_all_actions('woocommerce_order_status_completed');
+        remove_all_actions('woocommerce_order_status_changed');
+        remove_all_filters('mollie_wc_gateway_disable_ship_and_capture');
+    }
+
+    /**
+     * Scenario: Klarna, later-capture on, status-change capture off
+     * Given an authorized Klarna payment and 'Capture or cancel on status change' unchecked
+     * When the order status changes to Completed
+     * Then no capture is sent to Mollie
+     *
+     * @test
+     * @group integration
+     * @group MerchantCapture
+     * @covers \Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule::run
+     */
+    public function it_does_not_capture_klarna_on_completed_when_later_capture_on_and_status_change_off()
+    {
+        $this->configureCapture('later_capture', 'no');
+        $captures = $this->expectNoCapture();
+
+        $order = $this->makeAuthorizedOrder('mollie_wc_gateway_klarna', 'tr_klarna_no_capture');
+        $this->bootAndInit();
+        $order->update_status('completed');
+
+        $captures->shouldNotHaveReceived('createForId');
+    }
+
+    /**
+     * Scenario: Klarna, later-capture on, status-change capture on
+     * Given an authorized Klarna payment and 'Capture or cancel on status change' checked
+     * When the order status changes to Completed
+     * Then the payment is captured at Mollie
+     *
+     * @test
+     * @group integration
+     * @group MerchantCapture
+     * @covers \Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule::run
+     */
+    public function it_captures_klarna_on_completed_when_status_change_capture_on()
+    {
+        $this->configureCapture('later_capture', 'yes');
+        $captures = $this->expectCapture();
+
+        $order = $this->makeAuthorizedOrder('mollie_wc_gateway_klarna', 'tr_klarna_capture');
+        $this->bootAndInit();
+        $order->update_status('completed');
+
+        $captures->shouldHaveReceived('createForId');
+    }
+
+    /**
+     * Scenario: Klarna, default immediate-capture mode
+     * Given an authorized Klarna payment and later-capture mode off (the default)
+     * When the order status changes to Completed
+     * Then the payment is still captured at Mollie - legacy behavior, no regression
+     *
+     * @test
+     * @group integration
+     * @group MerchantCapture
+     * @covers \Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule::run
+     */
+    public function it_captures_klarna_on_completed_in_default_immediate_capture_mode()
+    {
+        $this->configureCapture('immediate_capture', 'no');
+        $captures = $this->expectCapture();
+
+        $order = $this->makeAuthorizedOrder('mollie_wc_gateway_klarna', 'tr_klarna_default');
+        $this->bootAndInit();
+        $order->update_status('completed');
+
+        $captures->shouldHaveReceived('createForId');
+    }
+
+    /**
+     * Scenario: credit card, later-capture on, status-change capture on
+     * Given an authorized on-hold credit-card order and the setting checked
+     * When the order status changes to Completed
+     * Then it is captured (via the state-change path) and the legacy path stays disabled
+     *
+     * @test
+     * @group integration
+     * @group MerchantCapture
+     * @covers \Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule::run
+     */
+    public function it_captures_creditcard_once_via_state_change_when_status_change_on()
+    {
+        $this->configureCapture('later_capture', 'yes');
+        $captures = $this->expectCapture();
+
+        $order = $this->makeAuthorizedOrder('mollie_wc_gateway_creditcard', 'tr_card_capture', true);
+        $this->bootAndInit();
+        $order->update_status('completed');
+
+        $captures->shouldHaveReceived('createForId');
+    }
+
+    /**
+     * Scenario: credit card, later-capture on, status-change capture off
+     * Given an authorized on-hold credit-card order and the setting unchecked
+     * When the order status changes to Completed
+     * Then nothing is captured automatically - manual capture only
+     *
+     * @test
+     * @group integration
+     * @group MerchantCapture
+     * @covers \Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule::run
+     */
+    public function it_does_not_capture_creditcard_on_completed_when_status_change_off()
+    {
+        $this->configureCapture('later_capture', 'no');
+        $captures = $this->expectNoCapture();
+
+        $order = $this->makeAuthorizedOrder('mollie_wc_gateway_creditcard', 'tr_card_no_capture', true);
+        $this->bootAndInit();
+        $order->update_status('completed');
+
+        $captures->shouldNotHaveReceived('createForId');
+    }
+
+    private function configureCapture(string $onhold, string $captureOrVoid): void
+    {
+        update_option(self::OPT_ONHOLD, $onhold);
+        update_option(self::OPT_CAPTURE_OR_VOID, $captureOrVoid);
+    }
+
+    /**
+     * Boot the plugin container with the mocked Mollie API and attach the init-time hooks
+     * (the disable filter and the state-change capture listener) that MerchantCaptureModule
+     * registers on 'init'.
+     */
+    private function bootAndInit(): void
+    {
+        // Re-firing 'init' would re-run unrelated WooCommerce Blocks registrations and raise
+        // duplicate-registration notices; suppress those and only run our module's init hooks.
+        add_filter('doing_it_wrong_trigger_error', '__return_false');
+        remove_all_actions('init');
+
+        $this->bootstrapModule($this->getMockedApiServices());
+        do_action('init');
+    }
+
+    /**
+     * Create a paid-authorized order whose Mollie payment (tr_...) reports 'authorized'.
+     * For credit card, also place it in the on-hold authorized state the manual-capture flow uses.
+     */
+    private function makeAuthorizedOrder(string $gateway, string $transactionId, bool $onHoldAuthorized = false): WC_Order
+    {
+        $this->mockSuccessfulPaymentGet($transactionId, 'authorized', [
+            'method' => $gateway === 'mollie_wc_gateway_klarna' ? 'klarna' : 'creditcard',
+            'mode' => 'test',
+        ]);
+
+        $order = $this->getConfiguredOrder(1, $gateway, ['simple'], [], false, $transactionId);
+        $order->update_meta_data('_mollie_payment_id', $transactionId);
+
+        if ($onHoldAuthorized) {
+            $order->update_meta_data(
+                MerchantCaptureModule::ORDER_PAYMENT_STATUS_META_KEY,
+                ManualCaptureStatus::STATUS_AUTHORIZED
+            );
+            $order->save();
+            $order->update_status('on-hold');
+        }
+
+        $order->save();
+
+        return $order;
+    }
+
+    /**
+     * @return \Mockery\MockInterface|PaymentCaptureEndpoint
+     */
+    private function expectCapture()
+    {
+        $captures = Mockery::spy(PaymentCaptureEndpoint::class);
+        $captures->shouldReceive('createForId')->andReturn((object)['id' => 'cpt_test', 'status' => 'pending']);
+        $this->apiMock()->getMockedApiClient()->paymentCaptures = $captures;
+
+        return $captures;
+    }
+
+    /**
+     * @return \Mockery\MockInterface|PaymentCaptureEndpoint
+     */
+    private function expectNoCapture()
+    {
+        $captures = Mockery::spy(PaymentCaptureEndpoint::class);
+        $this->apiMock()->getMockedApiClient()->paymentCaptures = $captures;
+
+        return $captures;
+    }
+}

--- a/tests/php/Functional/MerchantCapture/MerchantCaptureModuleTest.php
+++ b/tests/php/Functional/MerchantCapture/MerchantCaptureModuleTest.php
@@ -31,7 +31,8 @@ class MerchantCaptureModuleTest extends TestCase
      */
     public function disableShipAndCaptureReturnsTrueForKlarnaWhenStatusChangeSettingEnabled()
     {
-        $container = $this->createMockContainer(true);
+        // WooCommerce's checkbox save writes the literal string 'yes' when checked.
+        $container = $this->createMockContainer('yes');
         $order = $this->makeOrder('mollie_wc_gateway_klarna');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -40,12 +41,32 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * WHEN the setting is left at its default (disabled)
+     * WHEN the setting has been saved unchecked
      * THEN the filter still returns false for a Klarna order - unchanged from current behavior
      * @test
      */
-    public function disableShipAndCaptureReturnsFalseForKlarnaWhenStatusChangeSettingDisabledByDefault()
+    public function disableShipAndCaptureReturnsFalseForKlarnaWhenStatusChangeSettingSavedUnchecked()
     {
+        // WC_Admin_Settings::save_fields() writes the literal string 'no' for an unchecked
+        // checkbox (not an empty/false value) any time the settings page is saved - this is
+        // the realistic value for the overwhelming majority of merchants, not just an edge case.
+        $container = $this->createMockContainer('no');
+        $order = $this->makeOrder('mollie_wc_gateway_klarna');
+
+        $callback = $this->runModuleAndGetDisableFilterCallback($container);
+
+        self::assertFalse($callback(false, $order));
+    }
+
+    /**
+     * WHEN the setting has never been saved at all (option row does not exist)
+     * THEN the filter still returns false for a Klarna order
+     * @test
+     */
+    public function disableShipAndCaptureReturnsFalseForKlarnaWhenStatusChangeSettingNeverSaved()
+    {
+        // get_option(..., false) returns the raw boolean default when the option row
+        // was never created - distinct from the 'no' string WooCommerce saves on submit.
         $container = $this->createMockContainer(false);
         $order = $this->makeOrder('mollie_wc_gateway_klarna');
 
@@ -61,7 +82,7 @@ class MerchantCaptureModuleTest extends TestCase
      */
     public function disableShipAndCaptureStillTrueForCreditcardAuthorizedRegardlessOfSetting()
     {
-        $container = $this->createMockContainer(false, ['is_authorized' => true]);
+        $container = $this->createMockContainer('no', ['is_authorized' => true]);
         $order = $this->makeOrder('mollie_wc_gateway_creditcard');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -76,7 +97,7 @@ class MerchantCaptureModuleTest extends TestCase
      */
     public function disableShipAndCaptureReturnsTrueForNonCreditcardGatewayIndependentOfPaymentMethod()
     {
-        $container = $this->createMockContainer(true);
+        $container = $this->createMockContainer('yes');
         $order = $this->makeOrder('mollie_wc_gateway_bancontact');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -93,10 +114,12 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * @param bool $onStatusChangeEnabled Value returned for merchant.manual_capture.on_status_change_enabled.
+     * @param bool|string $onStatusChangeEnabled Raw value as returned by get_option() for
+     *        merchant.manual_capture.on_status_change_enabled: 'yes'/'no' (saved checkbox) or
+     *        boolean false (option row never created).
      * @param array $overrides Optional 'is_waiting' / 'is_authorized' booleans for the manual-capture closures.
      */
-    private function createMockContainer(bool $onStatusChangeEnabled, array $overrides = []): ContainerInterface
+    private function createMockContainer($onStatusChangeEnabled, array $overrides = []): ContainerInterface
     {
         $isWaiting = $overrides['is_waiting'] ?? false;
         $isAuthorized = $overrides['is_authorized'] ?? false;

--- a/tests/php/Functional/MerchantCapture/MerchantCaptureModuleTest.php
+++ b/tests/php/Functional/MerchantCapture/MerchantCaptureModuleTest.php
@@ -1,0 +1,163 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace Mollie\WooCommerceTests\Functional\MerchantCapture;
+
+use Mollie\WooCommerce\MerchantCapture\MerchantCaptureModule;
+use Mollie\WooCommerceTests\TestCase;
+use Mockery;
+use Psr\Container\ContainerInterface;
+use WC_Order;
+
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class MerchantCaptureModuleTest extends TestCase
+{
+    /** @var \stdClass */
+    private $hooks;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->hooks = (object) ['actions' => [], 'filters' => []];
+
+        when('apply_filters')->returnArg(2);
+    }
+
+    /**
+     * WHEN the 'Capture or cancel on status change' setting is enabled
+     * THEN the mollie_wc_gateway_disable_ship_and_capture filter returns true for a Klarna order
+     * @test
+     */
+    public function disableShipAndCaptureReturnsTrueForKlarnaWhenStatusChangeSettingEnabled()
+    {
+        $container = $this->createMockContainer(true);
+        $order = $this->makeOrder('mollie_wc_gateway_klarna');
+
+        $callback = $this->runModuleAndGetDisableFilterCallback($container);
+
+        self::assertTrue($callback(false, $order));
+    }
+
+    /**
+     * WHEN the setting is left at its default (disabled)
+     * THEN the filter still returns false for a Klarna order - unchanged from current behavior
+     * @test
+     */
+    public function disableShipAndCaptureReturnsFalseForKlarnaWhenStatusChangeSettingDisabledByDefault()
+    {
+        $container = $this->createMockContainer(false);
+        $order = $this->makeOrder('mollie_wc_gateway_klarna');
+
+        $callback = $this->runModuleAndGetDisableFilterCallback($container);
+
+        self::assertFalse($callback(false, $order));
+    }
+
+    /**
+     * WHEN a credit-card order is in the existing authorized on-hold state
+     * THEN the filter still returns true regardless of the status-change setting
+     * @test
+     */
+    public function disableShipAndCaptureStillTrueForCreditcardAuthorizedRegardlessOfSetting()
+    {
+        $container = $this->createMockContainer(false, ['is_authorized' => true]);
+        $order = $this->makeOrder('mollie_wc_gateway_creditcard');
+
+        $callback = $this->runModuleAndGetDisableFilterCallback($container);
+
+        self::assertTrue($callback(false, $order));
+    }
+
+    /**
+     * WHEN the setting is enabled for a non-Klarna, non-creditcard gateway
+     * THEN the filter still returns true - the condition is not limited to a specific gateway
+     * @test
+     */
+    public function disableShipAndCaptureReturnsTrueForNonCreditcardGatewayIndependentOfPaymentMethod()
+    {
+        $container = $this->createMockContainer(true);
+        $order = $this->makeOrder('mollie_wc_gateway_bancontact');
+
+        $callback = $this->runModuleAndGetDisableFilterCallback($container);
+
+        self::assertTrue($callback(false, $order));
+    }
+
+    private function makeOrder(string $paymentMethod): WC_Order
+    {
+        $order = Mockery::mock(WC_Order::class);
+        $order->shouldReceive('get_payment_method')->andReturn($paymentMethod);
+
+        return $order;
+    }
+
+    /**
+     * @param bool $onStatusChangeEnabled Value returned for merchant.manual_capture.on_status_change_enabled.
+     * @param array $overrides Optional 'is_waiting' / 'is_authorized' booleans for the manual-capture closures.
+     */
+    private function createMockContainer(bool $onStatusChangeEnabled, array $overrides = []): ContainerInterface
+    {
+        $isWaiting = $overrides['is_waiting'] ?? false;
+        $isAuthorized = $overrides['is_authorized'] ?? false;
+
+        $map = [
+            'shared.plugin_id' => 'mollie-payments-for-woocommerce',
+            'merchant.manual_capture.on_status_change_enabled' => $onStatusChangeEnabled,
+            'merchant.manual_capture.is_waiting' => static function () use ($isWaiting) {
+                return $isWaiting;
+            },
+            'merchant.manual_capture.is_authorized' => static function () use ($isAuthorized) {
+                return $isAuthorized;
+            },
+        ];
+
+        $container = Mockery::mock(ContainerInterface::class);
+        $container->shouldReceive('get')->andReturnUsing(static function (string $id) use ($map) {
+            if (!array_key_exists($id, $map)) {
+                throw new \RuntimeException("Unexpected container->get('{$id}') in test");
+            }
+            return $map[$id];
+        });
+
+        return $container;
+    }
+
+    private function runModuleAndGetDisableFilterCallback(ContainerInterface $container): callable
+    {
+        $this->interceptHooks();
+
+        $module = new MerchantCaptureModule();
+        $module->run($container);
+
+        $this->runActionCallbacks('init');
+
+        $callbacks = $this->hooks->filters['mollie_wc_gateway_disable_ship_and_capture'] ?? [];
+        self::assertNotEmpty($callbacks, 'mollie_wc_gateway_disable_ship_and_capture filter was not registered');
+
+        return $callbacks[0];
+    }
+
+    private function interceptHooks(): void
+    {
+        $hooks = $this->hooks;
+
+        expect('add_action')->andReturnUsing(static function () use ($hooks) {
+            $args = func_get_args();
+            $hooks->actions[$args[0]][] = $args[1];
+            return true;
+        });
+        expect('add_filter')->andReturnUsing(static function () use ($hooks) {
+            $args = func_get_args();
+            $hooks->filters[$args[0]][] = $args[1];
+            return true;
+        });
+    }
+
+    private function runActionCallbacks(string $hook): void
+    {
+        foreach ($this->hooks->actions[$hook] ?? [] as $cb) {
+            $cb();
+        }
+    }
+}

--- a/tests/php/Functional/MerchantCapture/MerchantCaptureModuleTest.php
+++ b/tests/php/Functional/MerchantCapture/MerchantCaptureModuleTest.php
@@ -25,14 +25,14 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * WHEN the 'Capture or cancel on status change' setting is enabled
-     * THEN the mollie_wc_gateway_disable_ship_and_capture filter returns true for a Klarna order
+     * Given later-capture mode is on and status-change capture is unchecked
+     * When the disable filter runs for a Klarna order
+     * Then it returns true so the legacy ship-and-capture is skipped
      * @test
      */
-    public function disableShipAndCaptureReturnsTrueForKlarnaWhenStatusChangeSettingEnabled()
+    public function disableShipAndCaptureReturnsTrueForKlarnaWhenLaterCaptureOnAndStatusChangeUnchecked()
     {
-        // WooCommerce's checkbox save writes the literal string 'yes' when checked.
-        $container = $this->createMockContainer('yes');
+        $container = $this->createMockContainer(['enabled' => true, 'onStatusChange' => false]);
         $order = $this->makeOrder('mollie_wc_gateway_klarna');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -41,16 +41,14 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * WHEN the setting has been saved unchecked
-     * THEN the filter still returns false for a Klarna order - unchanged from current behavior
+     * Given later-capture mode is on and status-change capture is checked
+     * When the disable filter runs for a Klarna order
+     * Then it returns false so the payment is captured on Completed
      * @test
      */
-    public function disableShipAndCaptureReturnsFalseForKlarnaWhenStatusChangeSettingSavedUnchecked()
+    public function disableShipAndCaptureReturnsFalseForKlarnaWhenLaterCaptureOnAndStatusChangeChecked()
     {
-        // WC_Admin_Settings::save_fields() writes the literal string 'no' for an unchecked
-        // checkbox (not an empty/false value) any time the settings page is saved - this is
-        // the realistic value for the overwhelming majority of merchants, not just an edge case.
-        $container = $this->createMockContainer('no');
+        $container = $this->createMockContainer(['enabled' => true, 'onStatusChange' => true]);
         $order = $this->makeOrder('mollie_wc_gateway_klarna');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -59,15 +57,15 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * WHEN the setting has never been saved at all (option row does not exist)
-     * THEN the filter still returns false for a Klarna order
+     * Given the store is in default immediate-capture mode (later capture off)
+     * When the disable filter runs for a Klarna order, whatever the status-change setting
+     * Then it returns false so capture-on-Completed keeps working as before - no regression
      * @test
+     * @dataProvider provideStatusChangeToggle
      */
-    public function disableShipAndCaptureReturnsFalseForKlarnaWhenStatusChangeSettingNeverSaved()
+    public function disableShipAndCaptureReturnsFalseForKlarnaWhenLaterCaptureOff(bool $onStatusChange)
     {
-        // get_option(..., false) returns the raw boolean default when the option row
-        // was never created - distinct from the 'no' string WooCommerce saves on submit.
-        $container = $this->createMockContainer(false);
+        $container = $this->createMockContainer(['enabled' => false, 'onStatusChange' => $onStatusChange]);
         $order = $this->makeOrder('mollie_wc_gateway_klarna');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -76,13 +74,19 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * WHEN a credit-card order is in the existing authorized on-hold state
-     * THEN the filter still returns true regardless of the status-change setting
+     * Given a credit-card order is in the authorized on-hold state
+     * When the disable filter runs, whatever the status-change setting
+     * Then it returns true - the legacy path stays off and only one capture path can fire
      * @test
+     * @dataProvider provideStatusChangeToggle
      */
-    public function disableShipAndCaptureStillTrueForCreditcardAuthorizedRegardlessOfSetting()
+    public function disableShipAndCaptureStillTrueForCreditcardAuthorizedRegardlessOfStatusChangeSetting(bool $onStatusChange)
     {
-        $container = $this->createMockContainer('no', ['is_authorized' => true]);
+        $container = $this->createMockContainer([
+            'enabled' => true,
+            'onStatusChange' => $onStatusChange,
+            'is_authorized' => true,
+        ]);
         $order = $this->makeOrder('mollie_wc_gateway_creditcard');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
@@ -91,18 +95,72 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * WHEN the setting is enabled for a non-Klarna, non-creditcard gateway
-     * THEN the filter still returns true - the condition is not limited to a specific gateway
+     * Given later-capture mode is on and status-change capture is unchecked
+     * When the disable filter runs for a non-Klarna, non-creditcard gateway
+     * Then it returns true - the later-capture rule is gateway independent
      * @test
      */
-    public function disableShipAndCaptureReturnsTrueForNonCreditcardGatewayIndependentOfPaymentMethod()
+    public function disableShipAndCaptureLaterCaptureTermIsGatewayIndependent()
     {
-        $container = $this->createMockContainer('yes');
+        $container = $this->createMockContainer(['enabled' => true, 'onStatusChange' => false]);
         $order = $this->makeOrder('mollie_wc_gateway_bancontact');
 
         $callback = $this->runModuleAndGetDisableFilterCallback($container);
 
         self::assertTrue($callback(false, $order));
+    }
+
+    /**
+     * Given later-capture mode is off
+     * When the disable filter runs for a non-creditcard gateway with status-change unchecked
+     * Then it returns false - the rule only ever suppresses capture in later-capture mode
+     * @test
+     */
+    public function disableShipAndCaptureLaterCaptureTermIsOffWhenNotLaterCapture()
+    {
+        $container = $this->createMockContainer(['enabled' => false, 'onStatusChange' => false]);
+        $order = $this->makeOrder('mollie_wc_gateway_bancontact');
+
+        $callback = $this->runModuleAndGetDisableFilterCallback($container);
+
+        self::assertFalse($callback(false, $order));
+    }
+
+    /**
+     * Given the raw capture_or_void option value returned by get_option()
+     * When the on_status_change_enabled service resolves it
+     * Then it yields strict boolean true only for the 'yes' string, false otherwise
+     * @test
+     * @dataProvider provideCaptureOrVoidOptionValues
+     */
+    public function onStatusChangeEnabledServiceReturnsBooleanTrueOnlyForYes($stored, bool $expected)
+    {
+        // WooCommerce saves the literal string 'no' for an unchecked checkbox (PHP-truthy),
+        // and boolean false when the option row was never created - both must resolve to false.
+        when('get_option')->justReturn($stored);
+
+        $services = (new MerchantCaptureModule())->services();
+        $result = $services['merchant.manual_capture.on_status_change_enabled']();
+
+        self::assertSame($expected, $result);
+    }
+
+    public function provideStatusChangeToggle(): array
+    {
+        return [
+            'status-change checked' => [true],
+            'status-change unchecked' => [false],
+        ];
+    }
+
+    public function provideCaptureOrVoidOptionValues(): array
+    {
+        return [
+            'checked' => ['yes', true],
+            'unchecked' => ['no', false],
+            'empty string' => ['', false],
+            'never saved' => [false, false],
+        ];
     }
 
     private function makeOrder(string $paymentMethod): WC_Order
@@ -114,19 +172,23 @@ class MerchantCaptureModuleTest extends TestCase
     }
 
     /**
-     * @param bool|string $onStatusChangeEnabled Raw value as returned by get_option() for
-     *        merchant.manual_capture.on_status_change_enabled: 'yes'/'no' (saved checkbox) or
-     *        boolean false (option row never created).
-     * @param array $overrides Optional 'is_waiting' / 'is_authorized' booleans for the manual-capture closures.
+     * @param array $config Filter inputs as the container resolves them:
+     *        'enabled'        bool - merchant.manual_capture.enabled (place_payment_onhold === later_capture)
+     *        'onStatusChange' bool - merchant.manual_capture.on_status_change_enabled (normalized capture_or_void)
+     *        'is_waiting'     bool - credit-card manual-capture waiting state
+     *        'is_authorized'  bool - credit-card manual-capture authorized state
      */
-    private function createMockContainer($onStatusChangeEnabled, array $overrides = []): ContainerInterface
+    private function createMockContainer(array $config = []): ContainerInterface
     {
-        $isWaiting = $overrides['is_waiting'] ?? false;
-        $isAuthorized = $overrides['is_authorized'] ?? false;
+        $enabled = $config['enabled'] ?? false;
+        $onStatusChange = $config['onStatusChange'] ?? false;
+        $isWaiting = $config['is_waiting'] ?? false;
+        $isAuthorized = $config['is_authorized'] ?? false;
 
         $map = [
             'shared.plugin_id' => 'mollie-payments-for-woocommerce',
-            'merchant.manual_capture.on_status_change_enabled' => $onStatusChangeEnabled,
+            'merchant.manual_capture.enabled' => $enabled,
+            'merchant.manual_capture.on_status_change_enabled' => $onStatusChange,
             'merchant.manual_capture.is_waiting' => static function () use ($isWaiting) {
                 return $isWaiting;
             },


### PR DESCRIPTION
## What and why

  The "Capture or cancel on status change" setting (`mollie-payments-for-woocommerce_capture_or_void`) had no
  effect for Klarna or any other non-credit-card Mollie gateway. `PaymentModule::shipAndCaptureOrderAtMollie()`
  runs unconditionally whenever a Mollie-paid order's status changes to Completed, and only skipped itself for
  credit-card orders sitting in an authorized/on-hold state. The setting's own description makes no such gateway
  distinction, so a merchant who explicitly enabled it — expecting to control capture timing manually — still had
  Klarna orders auto-shipped and captured at Mollie regardless, risking funds being captured earlier than
  intended.
  
  ## How it works now

  The existing `mollie_wc_gateway_disable_ship_and_capture` filter callback in `MerchantCaptureModule::run()` now
  also returns `true` whenever the merchant has enabled the status-change setting, independent of the order's
  payment method. `PaymentModule::shipAndCaptureOrderAtMollie()` itself is unchanged — it already consults this
  filter, so widening what the filter returns is enough. The change is strictly opt-in: when the setting is left at its default
  (unchecked), behavior for every gateway is exactly as before.
  
  ## What to verify in review

  ### Covered by unit tests
  - ✓ When the setting is enabled, `shipAndCaptureOrderAtMollie()` is skipped for a Klarna (or any non-creditcard)
  order transitioning to Completed.
  - ✓ When the setting is left unchecked — including the realistic saved value `'no'` and the never-saved default
  — Klarna's auto-ship/capture behavior is unchanged from before this fix.
  - ✓ Credit-card orders in the existing "waiting"/"authorized" on-hold states are still skipped regardless of the
  setting's value.
  - ✓ The new disable condition is not limited to `merchant.manual_capture.supported_methods` (credit card) — it
  applies to any gateway.

  

