### PR TITLE
Dev/piwoo 920 webhook double payment complete issue

### DIFF
--- a/src/Payment/Webhooks/WebhookHandler.php
+++ b/src/Payment/Webhooks/WebhookHandler.php
@@ -207,20 +207,13 @@ class WebhookHandler
             $mollieObject->addPaypalTransactionIdToOrder($order);
         }
 
-        add_filter('woocommerce_valid_order_statuses_for_payment_complete', static function ($statuses) {
-            $statuses[] = 'processing';
-            return $statuses;
-        });
-        add_filter('woocommerce_payment_complete_order_status', static function ($status) use ($order) {
-            return $order->get_status() === 'processing' ? 'completed' : $status;
-        });
+        if ($order->get_status() === 'processing') {
+            $order->update_status('completed', '');
 
-        $order->payment_complete($payment->id);
-
-        $this->logger->debug(
-            __METHOD__ . ' WooCommerce payment_complete() processed and returned to '
-            . __METHOD__ . ' for order ' . $orderId
-        );
+            $this->logger->debug(
+                __METHOD__ . ' WooCommerce order status updated to completed for order ' . $orderId
+            );
+        }
 
         $order->add_order_note(sprintf(
                                /* translators: Placeholder 1: payment method title, placeholder 2: payment ID */

--- a/tests/php/Unit/Payment/Webhooks/WebhookHandlerTest.php
+++ b/tests/php/Unit/Payment/Webhooks/WebhookHandlerTest.php
@@ -7,6 +7,7 @@ namespace Mollie\WooCommerceTests\Unit\Payment\Webhooks;
 use Inpsyde\PaymentGateway\PaymentGateway;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mollie\WooCommerce\Payment\MollieOrder;
 use Mollie\WooCommerce\Payment\MolliePayment;
 use Mollie\WooCommerce\Payment\Webhooks\WebhookHandler;
 use Mollie\WooCommerce\Settings\Settings;
@@ -15,6 +16,7 @@ use Mollie\WooCommerceTests\TestCase;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 
+use function Brain\Monkey\Filters\expectAdded;
 use function Brain\Monkey\Functions\when;
 
 /**
@@ -59,6 +61,21 @@ class WebhookHandlerTest extends TestCase
         $payment->mode   = 'test';
         $payment->method = 'bancontact';
         $payment->status = 'canceled';
+
+        return $payment;
+    }
+
+    /**
+     * @return \Mockery\MockInterface
+     */
+    private function makeOrderApiPayment(string $id, bool $isAuthorized, bool $isCompleted)
+    {
+        $payment = Mockery::mock();
+        $payment->shouldReceive('isAuthorized')->andReturn($isAuthorized);
+        $payment->shouldReceive('isCompleted')->andReturn($isCompleted);
+        $payment->id     = $id;
+        $payment->mode   = 'test';
+        $payment->method = 'klarnapaylater';
 
         return $payment;
     }
@@ -171,6 +188,170 @@ class WebhookHandlerTest extends TestCase
         $order->shouldReceive('add_order_note')->once();
 
         $this->sut->onWebhookCanceled($order, $payment, 'Bancontact', $mollieObject);
+
+        // Then — Mockery verifies call-count expectations on tearDown
+    }
+
+    /**
+     * @scenario For an Orders API payment method (e.g. Klarna) that is not yet authorized,
+     *           onWebhookAuthorized() calls $order->payment_complete() exactly once - the
+     *           single remaining site where payment_complete() fires for such orders.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookAuthorized
+     */
+    public function test_on_webhook_authorized_calls_payment_complete_once(): void
+    {
+        // Arrange
+        $paymentId    = 'ord_AUTH1';
+        $orderId      = 15;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MollieOrder::class);
+        $payment      = $this->makeOrderApiPayment($paymentId, true, false);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_meta')->with('_mollie_authorized')->andReturn('');
+        $order->shouldReceive('add_order_note')->once();
+        $order->shouldReceive('update_meta_data')->once()->with('_mollie_authorized', '1');
+
+        $mollieObject->shouldReceive('setOrderPaidAndProcessed')->once()->with($order);
+        $mollieObject->shouldReceive('unsetCancelledMolliePaymentId')->once()->with($orderId);
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->once()->with($order);
+
+        // When
+        $order->shouldReceive('payment_complete')->once()->with($paymentId);
+
+        $this->sut->onWebhookAuthorized($order, $payment, 'Klarna', $mollieObject);
+
+        // Then — Mockery verifies call-count expectations on tearDown
+    }
+
+    /**
+     * @scenario For an Orders API payment method that was already authorized (and thus already
+     *           had payment_complete() called once), onWebhookCompleted() no longer calls
+     *           $order->payment_complete() a second time and no longer registers the
+     *           woocommerce_valid_order_statuses_for_payment_complete or
+     *           woocommerce_payment_complete_order_status filters used to force it through.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCompleted
+     */
+    public function test_on_webhook_completed_does_not_call_payment_complete_or_register_filters(): void
+    {
+        // Arrange
+        $paymentId    = 'ord_COMPLETE1';
+        $orderId      = 22;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MollieOrder::class);
+        $payment      = $this->makeOrderApiPayment($paymentId, false, true);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_status')->andReturn('processing');
+        $order->shouldReceive('update_status')->zeroOrMoreTimes();
+        $order->shouldReceive('add_order_note')->zeroOrMoreTimes();
+
+        $mollieObject->shouldReceive('setOrderPaidAndProcessed')->zeroOrMoreTimes();
+        $mollieObject->shouldReceive('unsetCancelledMolliePaymentId')->zeroOrMoreTimes();
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->zeroOrMoreTimes();
+
+        expectAdded('woocommerce_valid_order_statuses_for_payment_complete')->never();
+        expectAdded('woocommerce_payment_complete_order_status')->never();
+
+        // When
+        $order->shouldNotReceive('payment_complete');
+
+        $this->sut->onWebhookCompleted($order, $payment, 'Klarna', $mollieObject);
+
+        // Then — Mockery verifies shouldNotReceive/expectAdded expectations on tearDown
+    }
+
+    /**
+     * @scenario When onWebhookCompleted() runs and the order's current status is 'processing',
+     *           the order transitions to 'completed' via $order->update_status().
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCompleted
+     */
+    public function test_on_webhook_completed_transitions_processing_order_to_completed(): void
+    {
+        // Arrange
+        $paymentId    = 'ord_COMPLETE2';
+        $orderId      = 23;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MollieOrder::class);
+        $payment      = $this->makeOrderApiPayment($paymentId, false, true);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_status')->andReturn('processing');
+        $order->shouldReceive('add_order_note')->zeroOrMoreTimes();
+        $order->shouldReceive('payment_complete')->zeroOrMoreTimes();
+
+        $mollieObject->shouldReceive('setOrderPaidAndProcessed')->zeroOrMoreTimes();
+        $mollieObject->shouldReceive('unsetCancelledMolliePaymentId')->zeroOrMoreTimes();
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->zeroOrMoreTimes();
+
+        // When
+        $order->shouldReceive('update_status')->once()->with('completed', Mockery::type('string'));
+
+        $this->sut->onWebhookCompleted($order, $payment, 'Klarna', $mollieObject);
+
+        // Then — Mockery verifies call-count expectations on tearDown
+    }
+
+    /**
+     * @scenario The order note documenting Mollie's 'completed' status is still added by
+     *           onWebhookCompleted(), regardless of the mechanism used to change status.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCompleted
+     */
+    public function test_on_webhook_completed_adds_order_note_after_status_change(): void
+    {
+        // Arrange
+        $paymentId    = 'ord_COMPLETE3';
+        $orderId      = 24;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MollieOrder::class);
+        $payment      = $this->makeOrderApiPayment($paymentId, false, true);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_status')->andReturn('processing');
+        $order->shouldReceive('update_status')->zeroOrMoreTimes();
+        $order->shouldReceive('payment_complete')->zeroOrMoreTimes();
+
+        $mollieObject->shouldReceive('setOrderPaidAndProcessed')->zeroOrMoreTimes();
+        $mollieObject->shouldReceive('unsetCancelledMolliePaymentId')->zeroOrMoreTimes();
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->zeroOrMoreTimes();
+
+        // When
+        $order->shouldReceive('add_order_note')
+            ->once()
+            ->with(Mockery::pattern('/Order completed at Mollie/'));
+
+        $this->sut->onWebhookCompleted($order, $payment, 'Klarna', $mollieObject);
+
+        // Then — Mockery verifies call-count expectations on tearDown
+    }
+
+    /**
+     * @scenario mollieObject->setOrderPaidAndProcessed(), unsetCancelledMolliePaymentId(), and
+     *           deleteSubscriptionFromPending() still run after onWebhookCompleted() changes the
+     *           order status, unchanged from current behavior.
+     * @covers \Mollie\WooCommerce\Payment\Webhooks\WebhookHandler::onWebhookCompleted
+     */
+    public function test_on_webhook_completed_runs_mollie_object_bookkeeping_after_status_change(): void
+    {
+        // Arrange
+        $paymentId    = 'ord_COMPLETE4';
+        $orderId      = 25;
+        $order        = Mockery::mock(WC_Order::class);
+        $mollieObject = Mockery::mock(MollieOrder::class);
+        $payment      = $this->makeOrderApiPayment($paymentId, false, true);
+
+        $order->shouldReceive('get_id')->andReturn($orderId);
+        $order->shouldReceive('get_status')->andReturn('processing');
+        $order->shouldReceive('update_status')->zeroOrMoreTimes();
+        $order->shouldReceive('payment_complete')->zeroOrMoreTimes();
+        $order->shouldReceive('add_order_note')->zeroOrMoreTimes();
+
+        // When
+        $mollieObject->shouldReceive('setOrderPaidAndProcessed')->once()->with($order);
+        $mollieObject->shouldReceive('unsetCancelledMolliePaymentId')->once()->with($orderId);
+        $mollieObject->shouldReceive('deleteSubscriptionFromPending')->once()->with($order);
+
+        $this->sut->onWebhookCompleted($order, $payment, 'Klarna', $mollieObject);
 
         // Then — Mockery verifies call-count expectations on tearDown
     }


### PR DESCRIPTION
## What and why

  For orders paid through Mollie's Orders API (e.g. Klarna), WooCommerce's `woocommerce_payment_complete` action
  was firing twice for a single sale. The first fire happened correctly when Mollie authorized the order; the
  second happened later, when Mollie reported all order lines as shipped/completed, because the webhook handler
  forced a second `payment_complete()` call through by temporarily widening the valid-status and forced-status
  filters WooCommerce uses to gate that method. Any integration listening on `woocommerce_payment_complete` —
  server-side Conversions API, revenue reporting, loyalty points, etc. — had no way to tell the two fires apart
  from two separate sales, so every Orders API order was double-counted.

  ## How it works now

  `WebhookHandler::onWebhookCompleted()` no longer calls `$order->payment_complete()` a second time — the single
  `payment_complete()` call in `onWebhookAuthorized()` remains the only trigger of the
  `woocommerce_payment_complete` action for these orders. When Mollie later reports the order completed and the
  order is still `processing`, `onWebhookCompleted()` now moves it to `completed` directly via
  `$order->update_status('completed', ...)`, which fires WooCommerce's normal status-change hooks without
  re-firing `woocommerce_payment_complete`. The two `add_filter()` calls that existed only to coerce the second
  `payment_complete()` call through have been removed as unnecessary.

  ## What to verify in review

  ### Covered by unit tests
  - ✓ For an Orders API order that is first authorized then later completed, `woocommerce_payment_complete` fires
  exactly once (during authorization), not twice.
  - ✓ `onWebhookCompleted()` no longer calls `payment_complete()` and no longer registers the
  `woocommerce_valid_order_statuses_for_payment_complete` or `woocommerce_payment_complete_order_status` filters.
  - ✓ When `onWebhookCompleted()` runs and the order is `processing`, it transitions to `completed` via
  `$order->update_status()`.
  - ✓ The order note documenting Mollie's "completed" status is still added, regardless of the mechanism used to
  change status.
  - ✓ `mollieObject->setOrderPaidAndProcessed()`, `unsetCancelledMolliePaymentId()`, and
  `deleteSubscriptionFromPending()` still run after the status change, unchanged from current behavior.
