### PR TITLE
Add libphonenumber to handle phone prefix (PIWOO-925)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "psr/container": "1.1.0",
     "psr/log":"^1.1.4",
     "sniccowp/php-scoper-wordpress-excludes": "^6.6",
-    "enshrined/svg-sanitize": "^0.22.0"
+    "enshrined/svg-sanitize": "^0.22.0",
+    "giggsey/libphonenumber-for-php": "^8.12"
   },
   "require-dev": {
     "phpunit/phpunit": "^8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa9667a34f97928bf5acd6e4400e7ef3",
+    "content-hash": "eec9277e1d47fb6569c3cb22e257cc1f",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -122,6 +122,139 @@
                 "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
             },
             "time": "2025-08-12T10:13:48+00:00"
+        },
+        {
+            "name": "giggsey/libphonenumber-for-php",
+            "version": "8.13.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/libphonenumber-for-php.git",
+                "reference": "6e28b3d53cf96d7f41c83d9b80b6021ecbd00537"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/6e28b3d53cf96d7f41c83d9b80b6021ecbd00537",
+                "reference": "6e28b3d53cf96d7f41c83d9b80b6021ecbd00537",
+                "shasum": ""
+            },
+            "require": {
+                "giggsey/locale": "^2.0",
+                "php": "^7.4|^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "replace": {
+                "giggsey/libphonenumber-for-php-lite": "self.version"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "pear/pear-core-minimal": "^1.10",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "^0.7",
+                "phing/phing": "^3.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/console": "^v5.2",
+                "symfony/var-exporter": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "libphonenumber\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "/src/data/",
+                    "/src/carrier/data/",
+                    "/src/geocoding/data/",
+                    "/src/timezone/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "PHP Port of Google's libphonenumber",
+            "homepage": "https://github.com/giggsey/libphonenumber-for-php",
+            "keywords": [
+                "geocoding",
+                "geolocation",
+                "libphonenumber",
+                "mobile",
+                "phonenumber",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
+                "source": "https://github.com/giggsey/libphonenumber-for-php"
+            },
+            "time": "2025-02-14T08:14:08+00:00"
+        },
+        {
+            "name": "giggsey/locale",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/Locale.git",
+                "reference": "a5c65ea3c2630f27ccb78977990eefbee6dd8f97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/a5c65ea3c2630f27ccb78977990eefbee6dd8f97",
+                "reference": "a5c65ea3c2630f27ccb78977990eefbee6dd8f97",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "pear/pear-core-minimal": "^1.9",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "^0.5",
+                "phing/phing": "^2.7",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^8.5|^9.5",
+                "symfony/console": "^5.0|^6.0",
+                "symfony/filesystem": "^5.0|^6.0",
+                "symfony/finder": "^5.0|^6.0",
+                "symfony/process": "^5.0|^6.0",
+                "symfony/var-exporter": "^5.2|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giggsey\\Locale\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "Locale functions required by libphonenumber-for-php",
+            "support": {
+                "issues": "https://github.com/giggsey/Locale/issues",
+                "source": "https://github.com/giggsey/Locale/tree/2.7.0"
+            },
+            "time": "2024-11-04T11:18:07+00:00"
         },
         {
             "name": "inpsyde/modularity",
@@ -425,6 +558,91 @@
                 "source": "https://github.com/snicco/php-scoper-wordpress-excludes/tree/6.9.1"
             },
             "time": "2026-02-04T00:34:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
         }
     ],
     "packages-dev": [
@@ -4544,91 +4762,6 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php73",

--- a/src/Payment/Request/Middleware/AddressMiddleware.php
+++ b/src/Payment/Request/Middleware/AddressMiddleware.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\Payment\Request\Middleware;
 
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
 use Mollie\WooCommerce\Shared\FieldConstants;
 use stdClass;
 use WC_Order;
@@ -293,38 +296,60 @@ class AddressMiddleware implements RequestMiddlewareInterface
     }
 
     /**
-     * Format the phone number in E.164.
+     * Format the phone number in E.164 using libphonenumber.
+     *
+     * A number already in international form (starting with '+') is trusted as
+     * explicit intent and only normalized. A national number is parsed using the
+     * address country as the region hint and must be valid for that region.
+     * Anything that cannot be turned into a valid E.164 number returns null so no
+     * invalid number is ever sent to the Mollie API — a null phone is acceptable
+     * for payment methods that do not require one.
      *
      * @param string $phone The phone number.
-     * @return string|null The formatted phone number.
+     * @param string|null $countryCode The ISO 3166-1 alpha-2 region hint.
+     * @return string|null The E.164 formatted phone number, or null.
      */
     protected function getFormatedPhoneNumber(string $phone, $countryCode): ?string
     {
-        //remove whitespaces and all non numerical characters except +
-        $phone = preg_replace('/[^0-9+]+/', '', $phone);
-        if (!is_string($phone) || strlen($phone) < 9) {
+        $phone = trim($phone);
+        if ($phone === '') {
             return null;
         }
 
-        if (strpos($phone, '00') === 0) {
-            $phone = '+' . substr($phone, 2);
-        }
-        if (strpos($phone, '0') === 0) {
-            $prefix = $this->countryCodeToPhonePrefix($countryCode);
-            if ($prefix) {
-                $phone = '+' . $prefix . substr($phone, 1);
-            }
+        $region = is_string($countryCode) && $countryCode !== '' ? strtoupper($countryCode) : null;
+        $isInternational = strpos($phone, '+') === 0;
+
+        $phoneUtil = PhoneNumberUtil::getInstance();
+        try {
+            $parsed = $phoneUtil->parse($phone, $region);
+        } catch (NumberParseException $exception) {
+            return null;
         }
 
-        if (strlen($phone) <= 16) {
-            return $phone;
+        // National numbers must be valid for the region hint; an international
+        // number is trusted as long as it parses.
+        if (!$isInternational && !$phoneUtil->isValidNumber($parsed)) {
+            return null;
         }
-        return null;
+
+        return $phoneUtil->format($parsed, PhoneNumberFormat::E164);
     }
 
-    private function isPhoneValid($billing_phone)
+    /**
+     * Loose pre-filter used only to pick a usable phone source (billing, shipping
+     * or POST). Authoritative validation happens in getFormatedPhoneNumber() via
+     * libphonenumber, so this must not drop formattable national numbers.
+     *
+     * @param mixed $billing_phone
+     * @return bool
+     */
+    private function isPhoneValid($billing_phone): bool
     {
-        return preg_match('/^\+[1-9]\d{10,13}$|^[1-9]\d{9,13}$|^06\d{9,13}$/', $billing_phone);
+        if (!is_string($billing_phone) || $billing_phone === '') {
+            return false;
+        }
+        $digits = preg_replace('/\D+/', '', $billing_phone);
+        return is_string($digits) && strlen($digits) >= 8;
     }
 
     /**
@@ -386,259 +411,6 @@ class AddressMiddleware implements RequestMiddlewareInterface
         }
 
         return $field;
-    }
-
-    /**
-     * Converts a country code to its corresponding phone prefix.
-     *
-     * @param string $countryCode The ISO 3166-1 alpha-2 country code.
-     * @return string|null The phone prefix associated with the country code, or null if not found.
-     */
-    private function countryCodeToPhonePrefix($countryCode): ?string
-    {
-        $phoneCodes = [
-            'AF' => '93',
-            'AL' => '355',
-            'DZ' => '213',
-            'AS' => '1684',
-            'AD' => '376',
-            'AO' => '244',
-            'AI' => '1264',
-            'AQ' => '672',
-            'AG' => '1268',
-            'AR' => '54',
-            'AM' => '374',
-            'AW' => '297',
-            'AU' => '61',
-            'AT' => '43',
-            'AZ' => '994',
-            'BS' => '1242',
-            'BH' => '973',
-            'BD' => '880',
-            'BB' => '1246',
-            'BY' => '375',
-            'BE' => '32',
-            'BZ' => '501',
-            'BJ' => '229',
-            'BM' => '1441',
-            'BT' => '975',
-            'BO' => '591',
-            'BA' => '387',
-            'BW' => '267',
-            'BR' => '55',
-            'IO' => '246',
-            'VG' => '1284',
-            'BN' => '673',
-            'BG' => '359',
-            'BF' => '226',
-            'BI' => '257',
-            'KH' => '855',
-            'CM' => '237',
-            'CA' => '1',
-            'CV' => '238',
-            'KY' => '1345',
-            'CF' => '236',
-            'TD' => '235',
-            'CL' => '56',
-            'CN' => '86',
-            'CX' => '61',
-            'CC' => '61',
-            'CO' => '57',
-            'KM' => '269',
-            'CK' => '682',
-            'CR' => '506',
-            'HR' => '385',
-            'CU' => '53',
-            'CW' => '599',
-            'CY' => '357',
-            'CZ' => '420',
-            'CD' => '243',
-            'DK' => '45',
-            'DJ' => '253',
-            'DM' => '1767',
-            'DO' => '1809',
-            'TL' => '670',
-            'EC' => '593',
-            'EG' => '20',
-            'SV' => '503',
-            'GQ' => '240',
-            'ER' => '291',
-            'EE' => '372',
-            'ET' => '251',
-            'FK' => '500',
-            'FO' => '298',
-            'FJ' => '679',
-            'FI' => '358',
-            'FR' => '33',
-            'PF' => '689',
-            'GA' => '241',
-            'GM' => '220',
-            'GE' => '995',
-            'DE' => '49',
-            'GH' => '233',
-            'GI' => '350',
-            'GR' => '30',
-            'GL' => '299',
-            'GD' => '1473',
-            'GU' => '1671',
-            'GT' => '502',
-            'GG' => '441481',
-            'GN' => '224',
-            'GW' => '245',
-            'GY' => '592',
-            'HT' => '509',
-            'HN' => '504',
-            'HK' => '852',
-            'HU' => '36',
-            'IS' => '354',
-            'IN' => '91',
-            'ID' => '62',
-            'IR' => '98',
-            'IQ' => '964',
-            'IE' => '353',
-            'IM' => '441624',
-            'IL' => '972',
-            'IT' => '39',
-            'CI' => '225',
-            'JM' => '1876',
-            'JP' => '81',
-            'JE' => '441534',
-            'JO' => '962',
-            'KZ' => '7',
-            'KE' => '254',
-            'KI' => '686',
-            'XK' => '383',
-            'KW' => '965',
-            'KG' => '996',
-            'LA' => '856',
-            'LV' => '371',
-            'LB' => '961',
-            'LS' => '266',
-            'LR' => '231',
-            'LY' => '218',
-            'LI' => '423',
-            'LT' => '370',
-            'LU' => '352',
-            'MO' => '853',
-            'MK' => '389',
-            'MG' => '261',
-            'MW' => '265',
-            'MY' => '60',
-            'MV' => '960',
-            'ML' => '223',
-            'MT' => '356',
-            'MH' => '692',
-            'MR' => '222',
-            'MU' => '230',
-            'YT' => '262',
-            'MX' => '52',
-            'FM' => '691',
-            'MD' => '373',
-            'MC' => '377',
-            'MN' => '976',
-            'ME' => '382',
-            'MS' => '1664',
-            'MA' => '212',
-            'MZ' => '258',
-            'MM' => '95',
-            'NA' => '264',
-            'NR' => '674',
-            'NP' => '977',
-            'NL' => '31',
-            'AN' => '599',
-            'NC' => '687',
-            'NZ' => '64',
-            'NI' => '505',
-            'NE' => '227',
-            'NG' => '234',
-            'NU' => '683',
-            'KP' => '850',
-            'MP' => '1670',
-            'NO' => '47',
-            'OM' => '968',
-            'PK' => '92',
-            'PW' => '680',
-            'PS' => '970',
-            'PA' => '507',
-            'PG' => '675',
-            'PY' => '595',
-            'PE' => '51',
-            'PH' => '63',
-            'PN' => '64',
-            'PL' => '48',
-            'PT' => '351',
-            'PR' => '1787',
-            'QA' => '974',
-            'CG' => '242',
-            'RE' => '262',
-            'RO' => '40',
-            'RU' => '7',
-            'RW' => '250',
-            'BL' => '590',
-            'SH' => '290',
-            'KN' => '1869',
-            'LC' => '1758',
-            'MF' => '590',
-            'PM' => '508',
-            'VC' => '1784',
-            'WS' => '685',
-            'SM' => '378',
-            'ST' => '239',
-            'SA' => '966',
-            'SN' => '221',
-            'RS' => '381',
-            'SC' => '248',
-            'SL' => '232',
-            'SG' => '65',
-            'SX' => '1721',
-            'SK' => '421',
-            'SI' => '386',
-            'SB' => '677',
-            'SO' => '252',
-            'ZA' => '27',
-            'KR' => '82',
-            'SS' => '211',
-            'ES' => '34',
-            'LK' => '94',
-            'SD' => '249',
-            'SR' => '597',
-            'SJ' => '47',
-            'SZ' => '268',
-            'SE' => '46',
-            'CH' => '41',
-            'SY' => '963',
-            'TW' => '886',
-            'TJ' => '992',
-            'TZ' => '255',
-            'TH' => '66',
-            'TG' => '228',
-            'TK' => '690',
-            'TO' => '676',
-            'TT' => '1868',
-            'TN' => '216',
-            'TR' => '90',
-            'TM' => '993',
-            'TC' => '1649',
-            'TV' => '688',
-            'VI' => '1340',
-            'UG' => '256',
-            'UA' => '380',
-            'AE' => '971',
-            'GB' => '44',
-            'US' => '1',
-            'UY' => '598',
-            'UZ' => '998',
-            'VU' => '678',
-            'VA' => '379',
-            'VE' => '58',
-            'VN' => '84',
-            'WF' => '681',
-            'EH' => '212',
-            'YE' => '967',
-            'ZM' => '260',
-            'ZW' => '263',
-        ];
-        return $phoneCodes[$countryCode] ?? null;
     }
 
     /**

--- a/tests/Integration/spec/Payment/Request/Middleware/AddressMiddlewarePhoneTest.php
+++ b/tests/Integration/spec/Payment/Request/Middleware/AddressMiddlewarePhoneTest.php
@@ -30,7 +30,8 @@ class AddressMiddlewarePhoneTest extends IntegrationMockedTestCase
             ['+31 6 1234-5678', 'NL', '+31612345678'],        // With formatting
             ['0201234567', 'DE', '+49201234567'],             // German
 
-        // Invalid cases -> null
+        // Unformattable inputs -> null (never sent to the API, never throw).
+        // A null phone is valid for methods that do not require a phone.
             ['12345678', 'NL', null],                         // Too short
             ['invalid', 'NL', null],                          // Non-numeric
             ['', 'NL', null],                                 // Empty
@@ -89,8 +90,8 @@ class AddressMiddlewarePhoneTest extends IntegrationMockedTestCase
             'DE' => ['0301234567', '+49301234567'],
             'FR' => ['0123456789', '+33123456789'],
             'GB' => ['07123456789', '+447123456789'],
-            // Unknown country - no prefix added
-            'XX' => ['0612345678', '0612345678'],
+            // Unknown region - cannot be formatted to a valid E.164 number -> null
+            'XX' => ['0612345678', null],
         ];
 
         foreach ($countryTests as $country => [$input, $expected]) {
@@ -132,6 +133,102 @@ class AddressMiddlewarePhoneTest extends IntegrationMockedTestCase
         $this->assertNull($result['billingAddress']);
     }
 
+    /**
+     * @scenario Given the Italian national number 3887403368 and region hint IT,
+     *           getFormatedPhoneNumber() returns +393887403368 and never a value beginning with +388.
+     *
+     */
+    public function test_italian_national_number_gets_e164_country_code()
+    {
+        $order = $this->createOrderWithPhone('3887403368', 'IT');
+
+        $result = $this->middleware->__invoke([], $order, 'order', fn($data) => $data);
+        $phone = $result['billingAddress']->phone ?? null;
+
+        $this->assertSame('+393887403368', $phone);
+        $this->assertStringStartsNotWith('+388', (string) $phone);
+    }
+
+    /**
+     * @scenario Given an already E.164-formatted number such as +49152123456,
+     *           getFormatedPhoneNumber() validates it and returns it unchanged.
+     *
+     */
+    public function test_already_e164_number_is_validated_and_unchanged()
+    {
+        $order = $this->createOrderWithPhone('+49152123456', 'DE');
+
+        $result = $this->middleware->__invoke([], $order, 'order', fn($data) => $data);
+
+        $this->assertSame('+49152123456', $result['billingAddress']->phone ?? null);
+    }
+
+    /**
+     * @scenario Given a non-E.164 national number and a region hint from the address country,
+     *           getFormatedPhoneNumber() returns that number reformatted to E.164 for that region.
+     *
+     */
+    public function test_non_e164_national_numbers_reformat_via_region_hint()
+    {
+        $phoneTests = [
+            // [national number, region hint (address country), expected E.164]
+            ['3887403368', 'IT', '+393887403368'],  // Italian mobile, no trunk 0
+            ['0612345678', 'NL', '+31612345678'],   // Dutch mobile, trunk 0
+            ['0301234567', 'DE', '+49301234567'],   // German, trunk 0
+        ];
+
+        foreach ($phoneTests as [$inputPhone, $country, $expected]) {
+            $order = $this->createOrderWithPhone($inputPhone, $country);
+            $result = $this->middleware->__invoke([], $order, 'order', fn($data) => $data);
+
+            $this->assertSame(
+                $expected,
+                $result['billingAddress']->phone ?? null,
+                "Phone '$inputPhone' with region hint '$country' should become '$expected'"
+            );
+        }
+    }
+
+    /**
+     * @scenario Both the billing phone and the shipping phone are normalized exclusively
+     *           through getFormatedPhoneNumber(); both reach the API in E.164.
+     *
+     */
+    public function test_shipping_and_billing_phone_both_normalized_to_e164()
+    {
+        $order = $this->createOrderWithPhone('3887403368', 'IT');
+        $order->set_shipping_phone('3479411234');
+        $this->setRequiredShippingFields($order, 'IT');
+
+        $result = $this->middleware->__invoke([], $order, 'order', fn($data) => $data);
+
+        $this->assertSame('+393887403368', $result['billingAddress']->phone ?? null);
+        $this->assertSame('+393479411234', $result['shippingAddress']->phone ?? null);
+    }
+
+    /**
+     * @scenario When a provided phone cannot be parsed/formatted into valid E.164 for the target
+     *           region (we could not fix it by guessing), the middleware returns a null phone and
+     *           does NOT throw — so the invalid number is never sent to the Mollie API and methods
+     *           that do not require a phone still complete. A notice for methods that DO require a
+     *           phone is handled reactively by PaymentProcessor when the API rejects it, which is
+     *           outside this middleware and out of scope here.
+     *
+     */
+    public function test_unformattable_phone_returns_null_without_throwing()
+    {
+        // A digit string that libphonenumber cannot validate for the region hint
+        // (not a real number) cannot be formatted into valid E.164.
+        $order = $this->createOrderWithPhone('00000000', 'DE');
+
+        $result = $this->middleware->__invoke([], $order, 'order', fn($data) => $data);
+
+        $this->assertNull(
+            $result['billingAddress']->phone ?? null,
+            'An unformattable phone must resolve to null, not be sent to the API'
+        );
+    }
+
     // Helper methods
     private function createOrderWithPhone(string $phone, string $country): WC_Order
     {
@@ -164,5 +261,15 @@ class AddressMiddlewarePhoneTest extends IntegrationMockedTestCase
         $order->set_billing_address_1('Test Street 123');
         $order->set_billing_postcode('1234AB');
         $order->set_billing_city('Test City');
+    }
+
+    private function setRequiredShippingFields(WC_Order $order, string $country): void
+    {
+        $order->set_shipping_first_name('John');
+        $order->set_shipping_last_name('Doe');
+        $order->set_shipping_address_1('Test Street 123');
+        $order->set_shipping_postcode('1234AB');
+        $order->set_shipping_city('Test City');
+        $order->set_shipping_country($country);
     }
 }


### PR DESCRIPTION
## What and why

  `getFormatedPhoneNumber()` only prepended a country calling code when a phone number started with a leading `0`
  (or `00`), using a hand-maintained country-to-prefix map. Numbers that don't start with a trunk `0` — such as
  the Italian mobile `3887403368` — were sent to Mollie unprefixed. Mollie then interpreted the bare national
  number as if it were already E.164, reading `3887403368` as a `+388...` number, which is not a valid country
  calling code. The result was a 422 from the Mollie API and a failed payment for any customer whose phone number
  didn't happen to start with `0`.

  ## How it works now

  `AddressMiddleware::getFormatedPhoneNumber()` now delegates to `libphonenumber\PhoneNumberUtil` instead of the
  leading-zero heuristic. A number already starting with `+` is parsed and trusted as explicit international
  input; everything else is parsed using the address country (billing or shipping) as a region hint and
  reformatted to `PhoneNumberFormat::E164`. If the number can't be parsed or isn't valid for that region, the
  method returns `null` instead of guessing, so no invalid number is ever submitted to Mollie. The old
  `countryCodeToPhonePrefix()` map has been removed entirely.

  ## What to verify in review

  ### Covered by unit tests
  - ✓ The Italian national number `3887403368` with region hint `IT` becomes `+393887403368`, and never a value
  starting with `+388`.
  - ✓ An already E.164 number like `+49152123456` is validated and returned unchanged, not reprefixed or altered.
  - ✓ Non-E.164 national numbers are reformatted to E.164 using the address country as the region hint (checked
  across IT/NL/DE).
  - ✓ A phone that can't be formatted into a valid E.164 number for its region hint resolves to `null`, and
  `AddressMiddleware` does not throw — payment methods that don't require a phone still complete successfully.
  - ✓ Both the billing phone and the shipping phone are normalized exclusively through `getFormatedPhoneNumber()`,
  with no other method in `AddressMiddleware` prepending a country calling code directly.

