### PR TITLE
Decouple paypal button visibility in cart and checkout (PIWOO-901)

### DIFF
--- a/src/PaymentMethods/Paypal.php
+++ b/src/PaymentMethods/Paypal.php
@@ -66,6 +66,18 @@ class Paypal extends AbstractPaymentMethod implements PaymentMethodI
                 ),
                 'default' => 'no',
             ],
+            'mollie_paypal_button_enabled_checkout' => [
+                'type' => 'checkbox',
+                'title' => __(
+                    'Display on checkout page',
+                    'mollie-payments-for-woocommerce'
+                ),
+                'description' => __(
+                    'Enable the PayPal button to be used in the Express Buttons section of the checkout page.',
+                    'mollie-payments-for-woocommerce'
+                ),
+                'default' => 'no',
+            ],
             'color' => [
                 'type' => 'select',
                 'id' => 'mollie_paypal_button_color',
@@ -98,7 +110,13 @@ class Paypal extends AbstractPaymentMethod implements PaymentMethodI
 
     public function isExpressCheckoutEnabled(): bool
     {
-        return $this->getProperty('mollie_paypal_button_enabled_cart') === 'yes';
+        if (is_cart()) {
+            return $this->getProperty('mollie_paypal_button_enabled_cart') === 'yes';
+        }
+        if (is_checkout()) {
+            return $this->getProperty('mollie_paypal_button_enabled_checkout') === 'yes';
+        }
+        return false;
     }
 
     protected function blocksExpressData(ContainerInterface $container): ?array

--- a/tests/php/Unit/PaymentMethods/PaypalTest.php
+++ b/tests/php/Unit/PaymentMethods/PaypalTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\PaymentMethods;
+
+use Mollie\WooCommerce\PaymentMethods\Paypal;
+use Mollie\WooCommerceTests\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\PaymentMethods\Paypal::getFormFields
+ * @covers \Mollie\WooCommerce\PaymentMethods\Paypal::isExpressCheckoutEnabled
+ */
+class PaypalTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // buttonOptions() runs unconditionally inside getFormFields() and calls _x() for every color option.
+        when('_x')->returnArg(1);
+    }
+
+    private function makeSut(array $storedSettings): Paypal
+    {
+        when('get_option')->justReturn($storedSettings);
+        return new Paypal();
+    }
+
+    private function stubCurrentPage(bool $isCart, bool $isCheckout): void
+    {
+        when('is_cart')->justReturn($isCart);
+        when('is_checkout')->justReturn($isCheckout);
+    }
+
+    /** @scenario Paypal::getFormFields() includes a 'mollie_paypal_button_enabled_checkout' field of type 'checkbox' with default 'no', distinct from 'mollie_paypal_button_enabled_cart'. */
+    public function test_form_fields_include_dedicated_checkout_checkbox(): void
+    {
+        // Arrange
+        $sut = $this->makeSut([]);
+
+        // When
+        $fields = $sut->getFormFields([]);
+
+        // Then
+        self::assertArrayHasKey('mollie_paypal_button_enabled_checkout', $fields);
+        self::assertSame('checkbox', $fields['mollie_paypal_button_enabled_checkout']['type']);
+        self::assertSame('no', $fields['mollie_paypal_button_enabled_checkout']['default']);
+        self::assertArrayHasKey('mollie_paypal_button_enabled_cart', $fields);
+        self::assertNotSame(
+            $fields['mollie_paypal_button_enabled_cart'],
+            $fields['mollie_paypal_button_enabled_checkout']
+        );
+    }
+
+    /** @scenario On the Cart page, isExpressCheckoutEnabled() reflects only mollie_paypal_button_enabled_cart. */
+    public function test_is_express_checkout_enabled_on_cart_page_reads_cart_setting(): void
+    {
+        // Arrange
+        $this->stubCurrentPage(true, false);
+
+        // When / Then — cart setting enabled
+        $sutEnabled = $this->makeSut(['mollie_paypal_button_enabled_cart' => 'yes']);
+        self::assertTrue($sutEnabled->isExpressCheckoutEnabled());
+
+        // When / Then — cart setting disabled
+        $sutDisabled = $this->makeSut(['mollie_paypal_button_enabled_cart' => 'no']);
+        self::assertFalse($sutDisabled->isExpressCheckoutEnabled());
+    }
+
+    /** @scenario On the Checkout page, isExpressCheckoutEnabled() reflects only mollie_paypal_button_enabled_checkout. */
+    public function test_is_express_checkout_enabled_on_checkout_page_reads_checkout_setting(): void
+    {
+        // Arrange
+        $this->stubCurrentPage(false, true);
+
+        // When / Then — checkout setting enabled
+        $sutEnabled = $this->makeSut(['mollie_paypal_button_enabled_checkout' => 'yes']);
+        self::assertTrue($sutEnabled->isExpressCheckoutEnabled());
+
+        // When / Then — checkout setting disabled
+        $sutDisabled = $this->makeSut(['mollie_paypal_button_enabled_checkout' => 'no']);
+        self::assertFalse($sutDisabled->isExpressCheckoutEnabled());
+    }
+
+    /** @scenario Enabling one page's setting must not enable the express button on the other page — the cart and checkout settings are fully independent. */
+    public function test_is_express_checkout_enabled_settings_do_not_leak_across_pages(): void
+    {
+        // Cart page: checkout is enabled but cart is not — must stay hidden on cart
+        $this->stubCurrentPage(true, false);
+        $sutOnCart = $this->makeSut([
+            'mollie_paypal_button_enabled_cart' => 'no',
+            'mollie_paypal_button_enabled_checkout' => 'yes',
+        ]);
+        self::assertFalse($sutOnCart->isExpressCheckoutEnabled());
+
+        // Checkout page: cart is enabled but checkout is not — must stay hidden on checkout
+        $this->stubCurrentPage(false, true);
+        $sutOnCheckout = $this->makeSut([
+            'mollie_paypal_button_enabled_cart' => 'yes',
+            'mollie_paypal_button_enabled_checkout' => 'no',
+        ]);
+        self::assertFalse($sutOnCheckout->isExpressCheckoutEnabled());
+    }
+
+    /** @scenario Outside the Cart and Checkout pages, isExpressCheckoutEnabled() is always false regardless of stored settings. */
+    public function test_is_express_checkout_enabled_false_outside_cart_and_checkout_pages(): void
+    {
+        // Arrange
+        $this->stubCurrentPage(false, false);
+
+        // When
+        $sut = $this->makeSut([
+            'mollie_paypal_button_enabled_cart' => 'yes',
+            'mollie_paypal_button_enabled_checkout' => 'yes',
+        ]);
+
+        // Then
+        self::assertFalse($sut->isExpressCheckoutEnabled());
+    }
+}


### PR DESCRIPTION
## What and why

  PayPal's "Display on cart page" setting was the only flag `Paypal::isExpressCheckoutEnabled()` read, but that
  same flag also controlled whether the PayPal button registers in the WooCommerce Blocks Express Payment area — a
  single registration mechanism shared by both the Cart block and the Checkout block. As a result, enabling the
  cart-only checkbox unintentionally showed the PayPal express button on the Checkout page as well, contradicting
  the setting's own label and description, which mention only the cart page. This diverged from the intended Apple
  Pay-like model where cart and checkout visibility should be controlled independently.

  ## How it works now
  
  `Paypal::getFormFields()` gains a new `mollie_paypal_button_enabled_checkout` checkbox setting (default `no`),
  distinct from the existing `mollie_paypal_button_enabled_cart`. `Paypal::isExpressCheckoutEnabled()` is now
  page-aware: it uses WooCommerce's `is_cart()`/`is_checkout()` conditional tags (the same pattern already used by
  `DataToPayPal::paypalbuttonScriptData()`) to read `mollie_paypal_button_enabled_cart` on the Cart page,
  `mollie_paypal_button_enabled_checkout` on the Checkout page, and returns `false` on any other page.

  ## What to verify in review
  
  ### Covered by unit tests
  - ✓ `Paypal::getFormFields()` includes a `mollie_paypal_button_enabled_checkout` field of type checkbox,
  defaulting to `no`, distinct from `mollie_paypal_button_enabled_cart`.
  - ✓ On the Cart page, `isExpressCheckoutEnabled()` reflects only `mollie_paypal_button_enabled_cart`, regardless
  of the checkout setting's value.
  - ✓ On the Checkout page, `isExpressCheckoutEnabled()` reflects only `mollie_paypal_button_enabled_checkout`,
  regardless of the cart setting's value.
  - ✓ Enabling one page's setting does not enable the express button on the other page, in either direction.

  ### Not covered by unit tests
  - ✗ Enabling `mollie_paypal_button_enabled_cart` alone still results in
  `mollieWooCommerceIsPayPalButtonEnabled('cart')` returning `true`, leaving the classic (non-blocks) cart-page
  PayPal button unaffected — this exercises `mollieWooCommerceIsPayPalButtonEnabled()` in `inc/utils.php`, which
  is out of scope for this change and untouched, so there is no new behavior to unit test here.

  ## Contracts introduced or changed

  (none — no constructor, hook signature, or other contract changes in this fix)

