### PR TITLE
Move nonce one level up (PIWOO-921)

### DIFF
--- a/src/Buttons/ApplePayButton/AppleAjaxRequests.php
+++ b/src/Buttons/ApplePayButton/AppleAjaxRequests.php
@@ -206,6 +206,9 @@ class AppleAjaxRequests
      */
     public function createWcOrder()
     {
+        if (!$this->isNonceValid()) {
+            return;
+        }
         $this->responseAfterSuccessfulResult();
         $cart = WC()->cart;
         $this->oldCartContents = WC()->cart->get_cart_contents();
@@ -237,6 +240,9 @@ class AppleAjaxRequests
      */
     public function createWcOrderFromCart()
     {
+        if (!$this->isNonceValid()) {
+            return;
+        }
         $this->responseAfterSuccessfulResult();
         $applePayRequestDataObject = $this->applePayDataObjectHttp();
         $applePayRequestDataObject->orderData('cart');

--- a/tests/php/Functional/ApplePayButton/AjaxRequestsTest.php
+++ b/tests/php/Functional/ApplePayButton/AjaxRequestsTest.php
@@ -308,6 +308,68 @@ class AjaxRequestsTest extends TestCase
 
     /**
      *
+     * GIVEN a request to createWcOrder with an invalid/missing checkout nonce
+     * WHEN createWcOrder() is invoked
+     * THEN it returns early before touching the cart or processing the checkout
+     */
+    public function testCreateWcOrderReturnsEarlyOnInvalidNonce()
+    {
+        list($logger, $responsesTemplate) = $this->responsesToApple();
+        $apiClientMock = $this->createConfiguredMock(MollieApiClient::class, []);
+
+        $testee = $this->buildTesteeMock(
+            AppleAjaxRequests::class,
+            [
+                $responsesTemplate,
+                $this->helperMocks->noticeMock(),
+                $logger,
+                $this->helperMocks->apiHelper($apiClientMock),
+                $this->helperMocks->settingsHelper(),
+            ],
+            ['isNonceValid', 'responseAfterSuccessfulResult', 'applePayDataObjectHttp', 'addAddressesToOrder']
+        )->getMock();
+
+        $testee->expects($this->once())->method('isNonceValid')->willReturn(false);
+        $testee->expects($this->never())->method('responseAfterSuccessfulResult');
+        $testee->expects($this->never())->method('applePayDataObjectHttp');
+        $testee->expects($this->never())->method('addAddressesToOrder');
+
+        $testee->createWcOrder();
+    }
+
+    /**
+     *
+     * GIVEN a request to createWcOrderFromCart with an invalid/missing checkout nonce
+     * WHEN createWcOrderFromCart() is invoked
+     * THEN it returns early before adding addresses or processing the checkout
+     */
+    public function testCreateWcOrderFromCartReturnsEarlyOnInvalidNonce()
+    {
+        list($logger, $responsesTemplate) = $this->responsesToApple();
+        $apiClientMock = $this->createConfiguredMock(MollieApiClient::class, []);
+
+        $testee = $this->buildTesteeMock(
+            AppleAjaxRequests::class,
+            [
+                $responsesTemplate,
+                $this->helperMocks->noticeMock(),
+                $logger,
+                $this->helperMocks->apiHelper($apiClientMock),
+                $this->helperMocks->settingsHelper(),
+            ],
+            ['isNonceValid', 'responseAfterSuccessfulResult', 'applePayDataObjectHttp', 'addAddressesToOrder']
+        )->getMock();
+
+        $testee->expects($this->once())->method('isNonceValid')->willReturn(false);
+        $testee->expects($this->never())->method('responseAfterSuccessfulResult');
+        $testee->expects($this->never())->method('applePayDataObjectHttp');
+        $testee->expects($this->never())->method('addAddressesToOrder');
+
+        $testee->createWcOrderFromCart();
+    }
+
+    /**
+     *
      * GIVEN WPML String Translation is active and a translation exists for the gateway fee label
      * WHEN cartCalculationResults() builds the ApplePay surcharge fee line
      * THEN the fee label in the result is the WPML-translated label, not the raw stored option


### PR DESCRIPTION
## What and why

  The Apple Pay AJAX handlers `createWcOrder()` and `createWcOrderFromCart()` began mutating the WooCommerce cart
  and registering order-address callbacks before any nonce was verified. The only nonce check happened deep inside
  `WC()->checkout()->process_checkout()`, by which point cart side effects had already occurred. This was
  inconsistent with the other handlers in the same class (`validateMerchant`, `updateShippingContact`,
  `updateShippingMethod`), which all verify the nonce before doing any work.

  ## How it works now
  
  Both `createWcOrder()` and `createWcOrderFromCart()` in `AppleAjaxRequests` now call the existing
  `isNonceValid()` accessor as their first statement and return immediately if it's falsy. `isNonceValid()`
  already validates the `woocommerce-process-checkout-nonce` against both the `woocommerce-process_checkout` and
  `mollie_apple_pay_blocks` actions, so no new nonce logic was introduced — this just applies the same guard the
  sibling handlers already use, before any cart or order side effects can run.

  ## What to verify in review
  
  ### Covered by unit tests
  - ✓ `createWcOrder()` returns early and never touches the cart or calls checkout processing when the nonce is
  invalid or missing.
  - ✓ `createWcOrderFromCart()` returns early and never adds addresses to the order or calls checkout processing
  when the nonce is invalid or missing.
  - ✓ The nonce check happens before any cart mutation or address-callback registration, via `isNonceValid()`
  rather than an inline `wp_verify_nonce()` call.

  ### Not covered by unit tests
  - ✗ Behavior with a valid nonce (matching `woocommerce-process_checkout` or `mollie_apple_pay_blocks`)
  proceeding through checkout unchanged — not exercised by a new test; relies on existing checkout-processing
  tests/behavior remaining unaffected since the guard only adds an early-return path.

