### PR TITLE
PIWOO-933 Fix fatal error in Apple Pay Express Checkout on shipping contact update

### DIFF
--- a/src/Buttons/ApplePayButton/AppleAjaxRequests.php
+++ b/src/Buttons/ApplePayButton/AppleAjaxRequests.php
@@ -274,7 +274,7 @@ class AppleAjaxRequests
         $applePayRequestDataObject
     ) {
 
-        if ($applePayRequestDataObject->callerPage === 'productDetail') {
+        if ($applePayRequestDataObject->callerPage() === 'productDetail') {
             return $this->calculateTotalsSingleProduct(
                 $applePayRequestDataObject->productId(),
                 $applePayRequestDataObject->productQuantity(),
@@ -282,7 +282,7 @@ class AppleAjaxRequests
                 $applePayRequestDataObject->shippingMethod()
             );
         }
-        if ($applePayRequestDataObject->callerPage === 'cart') {
+        if ($applePayRequestDataObject->callerPage() === 'cart') {
             return $this->calculateTotalsCartPage(
                 $applePayRequestDataObject->simplifiedContact(),
                 $applePayRequestDataObject->shippingMethod()

--- a/src/Buttons/ApplePayButton/ApplePayDataObjectHttp.php
+++ b/src/Buttons/ApplePayButton/ApplePayDataObjectHttp.php
@@ -461,6 +461,11 @@ class ApplePayDataObjectHttp
         return $this->simplifiedContact;
     }
 
+    public function callerPage()
+    {
+        return $this->callerPage;
+    }
+
     public function isNonceValid()
     {
         $nonce = filter_input(INPUT_POST, 'woocommerce-process-checkout-nonce', FILTER_SANITIZE_SPECIAL_CHARS);

--- a/tests/php/Functional/ApplePayButton/AjaxRequestsTest.php
+++ b/tests/php/Functional/ApplePayButton/AjaxRequestsTest.php
@@ -369,6 +369,48 @@ class AjaxRequestsTest extends TestCase
         $this->assertSame('Kosten betaalmethode', $result['fee']['label']);
     }
 
+    /**
+     * GIVEN an ApplePayDataObjectHttp with callerPage set to 'productDetail'
+     * WHEN whichCalculateTotals() reads callerPage from AppleAjaxRequests (a different class)
+     * THEN it must not fatal on accessing the protected property directly
+     */
+    public function testWhichCalculateTotalsDoesNotFatalOnProtectedCallerPageAccess()
+    {
+        $logger = $this->helperMocks->loggerMock();
+        $dataObject = $this->createPartialMock(
+            ApplePayDataObjectHttp::class,
+            ['productId', 'productQuantity', 'simplifiedContact', 'shippingMethod']
+        );
+        $dataObject->method('productId')->willReturn('123');
+        $dataObject->method('productQuantity')->willReturn('1');
+        $dataObject->method('simplifiedContact')->willReturn(['country' => 'NL']);
+        $dataObject->method('shippingMethod')->willReturn([]);
+        $reflection = new \ReflectionProperty(ApplePayDataObjectHttp::class, 'callerPage');
+        $reflection->setAccessible(true);
+        $reflection->setValue($dataObject, 'productDetail');
+
+        list(, $responsesTemplate) = $this->responsesToApple();
+        $apiClientMock = $this->createConfiguredMock(MollieApiClient::class, []);
+        $testee = $this->buildTesteeMock(
+            AppleAjaxRequests::class,
+            [
+                $responsesTemplate,
+                $this->helperMocks->noticeMock(),
+                $logger,
+                $this->helperMocks->apiHelper($apiClientMock),
+                $this->helperMocks->settingsHelper(),
+            ],
+            ['calculateTotalsSingleProduct']
+        )->getMock();
+        $testee->expects($this->once())
+            ->method('calculateTotalsSingleProduct')
+            ->willReturn(['total' => 10]);
+
+        $result = $this->invokeProtectedMethod($testee, 'whichCalculateTotals', [$dataObject]);
+
+        $this->assertSame(['total' => 10], $result);
+    }
+
     private function invokeProtectedMethod($object, string $method, array $args = [])
     {
         $reflection = new \ReflectionMethod($object, $method);


### PR DESCRIPTION
## Summary

Fixes [PIWOO-933](https://mollie.atlassian.net/browse/PIWOO-933): a PHP fatal error was reported (via wordpress.org support) when Apple Pay Express Checkout processes the `updateShippingContact` AJAX request:

```
PHP Fatal error: Uncaught Error: Cannot access protected property
Mollie\WooCommerce\Buttons\ApplePayButton\ApplePayDataObjectHttp::$callerPage
in .../AppleAjaxRequests.php:223
```

## Root cause

`AppleAjaxRequests::whichCalculateTotals()` read `ApplePayDataObjectHttp::$callerPage` directly from outside the declaring class. This worked while `$callerPage` was an undeclared dynamic property (implicitly public). Commit `9ca9b21d` later declared it `protected` (to silence a PHP 8.2 dynamic-property deprecation notice), which turned the pre-existing external access into a fatal error.

This affects both `updateShippingContact()` and `updateShippingMethod()`, since both call `whichCalculateTotals()`. Existing tests didn't catch it because they return early on address-validation errors, before reaching that code path.

## Fix

- Added a `callerPage()` getter to `ApplePayDataObjectHttp`, matching the existing getter convention used for every other property on the class (`productId()`, `needShipping()`, etc.).
- Updated the two direct `->callerPage` reads in `AppleAjaxRequests::whichCalculateTotals()` to use the getter.

## Test plan

- [x] Added a regression test (`AjaxRequestsTest::testWhichCalculateTotalsDoesNotFatalOnProtectedCallerPageAccess`) that reproduces the fatal error pre-fix and passes post-fix.
- [x] Full `tests/php/Functional/ApplePayButton/` suite passes (one pre-existing, unrelated failure due to a missing `overrides/wpml.php` test fixture, present before this change too).
- [x] PHPStan clean on both changed source files.

[PIWOO-933]: https://mollie.atlassian.net/browse/PIWOO-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ