### PR TITLE
Add wordpress.org release workflow

### DIFF
--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -37,7 +37,7 @@ jobs:
       PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
       GIT_REF: ${{ inputs.GIT_REF }}
       UPDATE_TRUNK_ONLY: ${{ inputs.UPDATE_TRUNK_ONLY }}
-      DRY_RUN: ${{ inputs.DRY_RUN }}
+      DRY_RUN: true #Always set to true while testing this action. Replace with the following when ready to use it: ${{ inputs.DRY_RUN }}
     secrets:
       SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
       SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -1,0 +1,33 @@
+name: Publish to WordPress.org
+
+on:
+  workflow_dispatch:
+    inputs:
+      PLUGIN_VERSION:
+        description: 'Plugin version to publish (MAJOR.MINOR.PATCH)'
+        required: true
+      GIT_REF:
+        description: 'Git tag, branch, or commit to publish'
+        required: true
+      UPDATE_TRUNK_ONLY:
+        description: 'Only sync trunk, skip creating an SVN tag'
+        type: boolean
+        default: true
+      DRY_RUN:
+        description: 'Upload trunk as an artifact instead of committing to SVN'
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@feature/pre-release-mode
+    with:
+      SVN_PLUGIN_SLUG: mollie-payments-for-woocommerce
+      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
+      GIT_REF: ${{ inputs.GIT_REF }}
+      UPDATE_TRUNK_ONLY: ${{ inputs.UPDATE_TRUNK_ONLY }}
+      DRY_RUN: ${{ inputs.DRY_RUN }}
+    secrets:
+      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -19,7 +19,18 @@ on:
         default: true
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject dev/* refs
+        run: |
+          if [[ "${{ inputs.GIT_REF }}" == dev/* ]]; then
+            echo "::error::GIT_REF '${{ inputs.GIT_REF }}' looks like a source branch, not a release ref. Publish from the branch/tag that carries the built release (e.g. a version tag or 'develop'), not a 'dev/' branch. Aborting."
+            exit 1
+          fi
+
   publish:
+    needs: validate
     uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@chore/remove-extra-env-var
     with:
       SVN_PLUGIN_SLUG: mollie-payments-for-woocommerce

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@feature/pre-release-mode
+    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@chore/remove-extra-env-var
     with:
       SVN_PLUGIN_SLUG: mollie-payments-for-woocommerce
       PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -7,7 +7,7 @@ on:
         description: 'Plugin version to publish (MAJOR.MINOR.PATCH)'
         required: true
       GIT_REF:
-        description: 'Git tag, branch, or commit to publish'
+        description: 'Release branch to publish from, must be release/MAJOR.MINOR.PATCH (e.g. release/1.2.3)'
         required: true
       UPDATE_TRUNK_ONLY:
         description: 'Only sync trunk, skip creating an SVN tag'
@@ -22,10 +22,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - name: Reject dev/* refs
+      - name: Require release/MAJOR.MINOR.PATCH ref
         run: |
-          if [[ "${{ inputs.GIT_REF }}" == dev/* ]]; then
-            echo "::error::GIT_REF '${{ inputs.GIT_REF }}' looks like a source branch, not a release ref. Publish from the branch/tag that carries the built release (e.g. a version tag or 'develop'), not a 'dev/' branch. Aborting."
+          if [[ ! "${{ inputs.GIT_REF }}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::GIT_REF '${{ inputs.GIT_REF }}' is not a release branch. Publish from a 'release/MAJOR.MINOR.PATCH' branch (e.g. 'release/1.2.3'). Aborting."
             exit 1
           fi
 

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -31,7 +31,7 @@ jobs:
 
   publish:
     needs: validate
-    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@chore/remove-extra-env-var
+    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@fix/wporg-combined-commit
     with:
       SVN_PLUGIN_SLUG: mollie-payments-for-woocommerce
       PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,12 @@ and then run tests using `yarn playwright test`
 
 Note: Local installation might fail if the playwright install script does not recognize your OS/distribution
 
+## Releasing to WordPress.org
+
+Publishing to the WordPress.org SVN repository is done via the `Publish to WordPress.org` GitHub Actions workflow (`.github/workflows/wordpress-org-release.yml`), triggered manually (`workflow_dispatch`).
+
+The workflow only accepts a release branch named `release/MAJOR.MINOR.PATCH` (e.g. `release/1.2.3`) as `GIT_REF` — any other ref (a `dev/*` branch, a tag, `develop`, a commit SHA) is rejected before publishing runs.
+
 ## Debugging GHA
 
 If you need to debug the GitHub Actions, you can do so by installing the [ACT tool](https://github.com/nektos/act). This is an example command to run the workflow locally:


### PR DESCRIPTION
A GitHub action for publishing the plugin at WordPress.org.

It doesn't include any build process and is meant to be executed on the already built branch or tag (like the one after Build & Distribute workflow).