### PR TITLE
Mollie customer is created even when "Store customer details at Mollie" is disabled (PIWOO-932)

### DIFF
--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -601,9 +601,7 @@ class MollieObject
             ) {
                 $order->update_meta_data('_mollie_mandate_id', $payment->mandateId);
                 $order->save();
-                // A mandate can't exist without a Mollie Customer, so this is exempt from the
-                // "store customer details" setting.
-                $customerId = $this->getUserMollieCustomerId($order, true);
+                $customerId = $this->getUserMollieCustomerId($order);
                 do_action($this->pluginId . '_after_mandate_created', $payment, $order, $customerId, $payment->mandateId);
 
                 $subscriptions = wcs_get_subscriptions_for_order($order);
@@ -634,15 +632,14 @@ class MollieObject
 
     /**
      * @param $order
-     * @param bool $allowCreate Whether creating a new Mollie Customer is permitted for this call.
      * @return null|string
      */
-    protected function getUserMollieCustomerId($order, bool $allowCreate)
+    protected function getUserMollieCustomerId($order)
     {
         $order_customer_id = $order->get_customer_id();
         $apiKey = $this->settingsHelper->getApiKey();
 
-        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey, $allowCreate);
+        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey, $order->get_id());
     }
     /**
      * @param $order

--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -601,7 +601,9 @@ class MollieObject
             ) {
                 $order->update_meta_data('_mollie_mandate_id', $payment->mandateId);
                 $order->save();
-                $customerId = $this->getUserMollieCustomerId($order);
+                // A mandate can't exist without a Mollie Customer, so this is exempt from the
+                // "store customer details" setting.
+                $customerId = $this->getUserMollieCustomerId($order, true);
                 do_action($this->pluginId . '_after_mandate_created', $payment, $order, $customerId, $payment->mandateId);
 
                 $subscriptions = wcs_get_subscriptions_for_order($order);

--- a/src/Payment/MollieObject.php
+++ b/src/Payment/MollieObject.php
@@ -632,15 +632,15 @@ class MollieObject
 
     /**
      * @param $order
-     * @param $test_mode
+     * @param bool $allowCreate Whether creating a new Mollie Customer is permitted for this call.
      * @return null|string
      */
-    protected function getUserMollieCustomerId($order)
+    protected function getUserMollieCustomerId($order, bool $allowCreate)
     {
         $order_customer_id = $order->get_customer_id();
         $apiKey = $this->settingsHelper->getApiKey();
 
-        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey);
+        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey, $allowCreate);
     }
     /**
      * @param $order

--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -187,10 +187,15 @@ class PaymentProcessor implements PaymentProcessorInterface
      */
     protected function getUserMollieCustomerId($order)
     {
+        $orderId = $order->get_id();
+        $allowCreate = $this->settingsHelper->shouldStoreCustomer()
+            || $this->dataHelper->isSubscription($orderId)
+            || $this->dataHelper->isWcSubscription($orderId);
+
         $order_customer_id = $order->get_customer_id();
         $apiKey = $this->settingsHelper->getApiKey();
 
-        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey);
+        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey, $allowCreate);
     }
 
     protected function paymentTypeBasedOnGateway($paymentMethod)

--- a/src/Payment/PaymentProcessor.php
+++ b/src/Payment/PaymentProcessor.php
@@ -187,15 +187,10 @@ class PaymentProcessor implements PaymentProcessorInterface
      */
     protected function getUserMollieCustomerId($order)
     {
-        $orderId = $order->get_id();
-        $allowCreate = $this->settingsHelper->shouldStoreCustomer()
-            || $this->dataHelper->isSubscription($orderId)
-            || $this->dataHelper->isWcSubscription($orderId);
-
         $order_customer_id = $order->get_customer_id();
         $apiKey = $this->settingsHelper->getApiKey();
 
-        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey, $allowCreate);
+        return $this->dataHelper->getUserMollieCustomerId($order_customer_id, $apiKey, $order->get_id());
     }
 
     protected function paymentTypeBasedOnGateway($paymentMethod)

--- a/src/Payment/Request/Middleware/StoreCustomerMiddleware.php
+++ b/src/Payment/Request/Middleware/StoreCustomerMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mollie\WooCommerce\Payment\Request\Middleware;
 
-use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerce\Shared\Data;
 use WC_Order;
 
 /**
@@ -17,18 +17,18 @@ use WC_Order;
 class StoreCustomerMiddleware implements RequestMiddlewareInterface
 {
     /**
-     * @var Settings The settings helper instance.
+     * @var Data The data helper instance.
      */
-    private Settings $settingsHelper;
+    private Data $dataHelper;
 
     /**
      * StoreCustomerMiddleware constructor.
      *
-     * @param Settings $settingsHelper The settings helper instance.
+     * @param Data $dataHelper The data helper instance.
      */
-    public function __construct(Settings $settingsHelper)
+    public function __construct(Data $dataHelper)
     {
-        $this->settingsHelper = $settingsHelper;
+        $this->dataHelper = $dataHelper;
     }
 
     /**
@@ -42,8 +42,8 @@ class StoreCustomerMiddleware implements RequestMiddlewareInterface
      */
     public function __invoke(array $requestData, WC_Order $order, string $context, callable $next): array
     {
-        $storeCustomer = $this->settingsHelper->shouldStoreCustomer();
-        if (!$storeCustomer) {
+        $allowCustomer = $this->dataHelper->isMollieCustomerAllowedForOrder($order->get_id());
+        if (!$allowCustomer) {
             if ($context === 'order') {
                 unset($requestData['payment']['customerId']);
             } elseif ($context === 'payment') {

--- a/src/Payment/inc/services.php
+++ b/src/Payment/inc/services.php
@@ -108,7 +108,7 @@ return static function (): array {
             return new CardTokenMiddleware();
         },
         StoreCustomerMiddleware::class => static function (ContainerInterface $container): StoreCustomerMiddleware {
-            return new StoreCustomerMiddleware($container->get('settings.settings_helper'));
+            return new StoreCustomerMiddleware($container->get('settings.data_helper'));
         },
         AddSequenceTypeForSubscriptionsMiddleware::class => static function (ContainerInterface $container): AddSequenceTypeForSubscriptionsMiddleware {
             $dataHelper = $container->get('settings.data_helper');

--- a/src/Settings/Page/Section/Advanced.php
+++ b/src/Settings/Page/Section/Advanced.php
@@ -104,7 +104,7 @@ class Advanced extends AbstractSection
                 'desc' => sprintf(
                 /* translators: Placeholder 1: enabled or disabled Placeholder 2: translated string */
                     __(
-                        'Should Mollie store customers name and email address for Single Click Payments? Default <code>%1$s</code>. Required if WooCommerce Subscriptions is being used! Read more about <a href=\'https://help.mollie.com/hc/en-us/articles/115000671249-What-are-single-click-payments-and-how-does-it-work-\'>%2$s</a> and how it improves your conversion.',
+                        'Should Mollie store customers name and email address for Single Click Payments? Default <code>%1$s</code>. Required if WooCommerce Subscriptions is being used! Read more about <a href=\'https://help.mollie.com/hc/en-us/articles/115000671249-What-are-single-click-payments-and-how-does-it-work-\'>%2$s</a> and how it improves your conversion. Note: this setting does not apply to WooCommerce Subscriptions orders — a Mollie Customer is always created for those, since Mollie\'s recurring-payment/mandate feature requires one.',
                         'mollie-payments-for-woocommerce'
                     ),
                     strtolower(__('Enabled', 'mollie-payments-for-woocommerce')),

--- a/src/Shared/Data.php
+++ b/src/Shared/Data.php
@@ -562,9 +562,10 @@ class Data
     /**
      * @param int $userId
      * @param string $apiKey
+     * @param bool $allowCreate Whether creating a new Mollie Customer is permitted for this call.
      * @return null|string
      */
-    public function getUserMollieCustomerId($userId, $apiKey)
+    public function getUserMollieCustomerId($userId, $apiKey, bool $allowCreate)
     {
         // Guest users can't buy subscriptions and don't need a Mollie customer ID
         // https://github.com/mollie/WooCommerce/issues/132
@@ -605,6 +606,9 @@ class Data
 
         // If there is no Mollie Customer ID set, try to create a new Mollie Customer
         if (empty($customerId)) {
+            if (!$allowCreate) {
+                return null;
+            }
             try {
                 $userdata = get_userdata($userId);
 

--- a/src/Shared/Data.php
+++ b/src/Shared/Data.php
@@ -562,10 +562,11 @@ class Data
     /**
      * @param int $userId
      * @param string $apiKey
-     * @param bool $allowCreate Whether creating a new Mollie Customer is permitted for this call.
+     * @param int $orderId Order this customer ID lookup is for, used to decide whether creating
+     *                      a new Mollie Customer is permitted (see isMollieCustomerAllowedForOrder()).
      * @return null|string
      */
-    public function getUserMollieCustomerId($userId, $apiKey, bool $allowCreate)
+    public function getUserMollieCustomerId($userId, $apiKey, $orderId)
     {
         // Guest users can't buy subscriptions and don't need a Mollie customer ID
         // https://github.com/mollie/WooCommerce/issues/132
@@ -606,7 +607,7 @@ class Data
 
         // If there is no Mollie Customer ID set, try to create a new Mollie Customer
         if (empty($customerId)) {
-            if (!$allowCreate) {
+            if (!$this->isMollieCustomerAllowedForOrder($orderId)) {
                 return null;
             }
             try {
@@ -717,6 +718,21 @@ class Data
     {
         $isSubscription = false;
         return apply_filters($this->pluginId . '_is_subscription_payment', $isSubscription, $orderId);
+    }
+
+    /**
+     * Single source of truth for whether a Mollie Customer may be associated with an order:
+     * either the merchant opted in to storing customer details, or Mollie's recurring-payment/
+     * mandate model requires a Customer to exist regardless of that setting (subscriptions).
+     *
+     * @param int $orderId
+     * @return bool
+     */
+    public function isMollieCustomerAllowedForOrder($orderId): bool
+    {
+        return $this->settingsHelper->shouldStoreCustomer()
+            || $this->isSubscription($orderId)
+            || $this->isWcSubscription($orderId);
     }
 
     public function getAllAvailablePaymentMethods($useCache = true)

--- a/tests/overrides/woocommerce.php
+++ b/tests/overrides/woocommerce.php
@@ -364,6 +364,23 @@ class WooCommerce
 
 class WC_Customer
 {
+    public function __construct($userId = 0)
+    {
+    }
+
+    public function get_meta($key)
+    {
+        return '';
+    }
+
+    public function update_meta_data($key, $value)
+    {
+    }
+
+    public function save()
+    {
+    }
+
     public function set_shipping_country()
     {
     }

--- a/tests/php/Functional/Payment/PaymentProcessorTest.php
+++ b/tests/php/Functional/Payment/PaymentProcessorTest.php
@@ -13,6 +13,8 @@ use Mollie\Api\Resources\Order as MollieApiOrder;
 use Mollie\Api\Resources\Payment as MollieApiPayment;
 use Mollie\WooCommerce\Payment\PaymentCheckoutRedirectService;
 use Mollie\WooCommerce\Payment\PaymentProcessor;
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerce\Shared\Data;
 use Mollie\WooCommerceTests\Functional\HelperMocks;
 use Mollie\WooCommerceTests\TestCase;
 use Psr\Log\LoggerInterface;
@@ -520,5 +522,58 @@ class PaymentProcessorTest extends TestCase
         $result = $this->invokeCancel($this->buildSut(), $order);
 
         $this->assertNull($result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // getUserMollieCustomerId() — passthrough to Data
+    // ──────────────────────────────────────────────────────────────────────
+
+    private function invokeGetUserMollieCustomerId(PaymentProcessor $sut, object $order)
+    {
+        $method = new ReflectionMethod(PaymentProcessor::class, 'getUserMollieCustomerId');
+        $method->setAccessible(true);
+        return $method->invoke($sut, $order);
+    }
+
+    /**
+     * @test
+     * @scenario getUserMollieCustomerId() delegates entirely to Data::getUserMollieCustomerId(),
+     *           passing the order's customer id, the API key, and the order id. Whether creating
+     *           a Mollie Customer is actually allowed is decided solely inside Data, not here.
+     */
+    public function test_delegates_to_data_helper_with_customer_id_api_key_and_order_id(): void
+    {
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn(42);
+        $order->shouldReceive('get_customer_id')->andReturn(7);
+
+        $dataMock = $this->getMockBuilder(Data::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getUserMollieCustomerId'])
+            ->getMock();
+        $dataMock->expects($this->once())
+            ->method('getUserMollieCustomerId')
+            ->with(7, 'test_key', 42)
+            ->willReturn('cst_123');
+
+        $settings = $this->createConfiguredMock(Settings::class, [
+            'getApiKey' => 'test_key',
+        ]);
+
+        $sut = new PaymentProcessor(
+            $this->helperMocks->noticeMock(),
+            $this->logger,
+            $this->helperMocks->paymentFactory(),
+            $dataMock,
+            $this->helperMocks->apiHelper($this->apiClientMock),
+            $settings,
+            $this->helperMocks->pluginId(),
+            $this->createMock(PaymentCheckoutRedirectService::class),
+            []
+        );
+
+        $result = $this->invokeGetUserMollieCustomerId($sut, $order);
+
+        $this->assertSame('cst_123', $result);
     }
 }

--- a/tests/php/Functional/Shared/DataTest.php
+++ b/tests/php/Functional/Shared/DataTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Functional\Shared;
+
+use Mockery;
+use Mollie\Api\Endpoints\CustomerEndpoint;
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerceTests\Functional\HelperMocks;
+use Mollie\WooCommerceTests\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Shared\Data::getUserMollieCustomerId
+ */
+class DataTest extends TestCase
+{
+    private HelperMocks $helperMocks;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->helperMocks = new HelperMocks();
+    }
+
+    private function makeUserData(): object
+    {
+        return (object) [
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'display_name' => 'Jane Doe',
+            'user_email' => 'jane@example.com',
+        ];
+    }
+
+    private function dataHelperWithShouldStoreCustomer(bool $shouldStoreCustomer, $apiClientMock)
+    {
+        $settings = $this->createConfiguredMock(Settings::class, [
+            'isTestModeEnabled' => true,
+            'getApiKey' => 'test_SOME_API_KEY',
+            'shouldStoreCustomer' => $shouldStoreCustomer,
+        ]);
+
+        return new \Mollie\WooCommerce\Shared\Data(
+            $this->helperMocks->apiHelper($apiClientMock),
+            $this->helperMocks->loggerMock(),
+            $this->helperMocks->pluginId(),
+            $settings,
+            $this->helperMocks->pluginPath()
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // getUserMollieCustomerId() — creation gating driven by isMollieCustomerAllowedForOrder()
+    // (see tests/php/Unit/Shared/DataTest.php for that policy's own tests)
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When a Mollie Customer isn't allowed for this order and the user has no
+     *           stored/derivable Mollie customer ID, getUserMollieCustomerId() must not call
+     *           the Mollie API's customers->create() endpoint and must return null.
+     */
+    public function doesNotCreateCustomerWhenNotAllowedForOrder(): void
+    {
+        when('wc_get_orders')->justReturn([]);
+
+        $customerEndpointMock = Mockery::mock(CustomerEndpoint::class);
+        $customerEndpointMock->shouldReceive('create')->never();
+
+        $apiClientMock = $this->helperMocks->apiClient();
+        $apiClientMock->customers = $customerEndpointMock;
+
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(false, $apiClientMock);
+
+        $result = $dataHelper->getUserMollieCustomerId(42, 'test_key', 999);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     * @scenario When a Mollie Customer is allowed for this order (setting enabled), a missing
+     *           Mollie customer ID is still created via the API as before.
+     */
+    public function createsCustomerWhenAllowedViaSetting(): void
+    {
+        when('wc_get_orders')->justReturn([]);
+        when('get_userdata')->justReturn($this->makeUserData());
+
+        $mollieCustomer = (object) ['id' => 'cst_new123'];
+
+        $customerEndpointMock = Mockery::mock(CustomerEndpoint::class);
+        $customerEndpointMock->shouldReceive('create')->once()->andReturn($mollieCustomer);
+
+        $apiClientMock = $this->helperMocks->apiClient();
+        $apiClientMock->customers = $customerEndpointMock;
+
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(true, $apiClientMock);
+
+        $result = $dataHelper->getUserMollieCustomerId(42, 'test_key', 999);
+
+        $this->assertSame('cst_new123', $result);
+    }
+
+    /**
+     * @test
+     * @scenario A subscription order is allowed to create a Mollie Customer even when the
+     *           "store customer details" setting is disabled.
+     */
+    public function createsCustomerWhenOrderIsSubscriptionEvenWhenSettingDisabled(): void
+    {
+        when('wc_get_orders')->justReturn([]);
+        when('apply_filters')->justReturn(true); // simulates Data::isSubscription($orderId) === true
+        when('get_userdata')->justReturn($this->makeUserData());
+
+        $mollieCustomer = (object) ['id' => 'cst_new456'];
+
+        $customerEndpointMock = Mockery::mock(CustomerEndpoint::class);
+        $customerEndpointMock->shouldReceive('create')->once()->andReturn($mollieCustomer);
+
+        $apiClientMock = $this->helperMocks->apiClient();
+        $apiClientMock->customers = $customerEndpointMock;
+
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(false, $apiClientMock);
+
+        $result = $dataHelper->getUserMollieCustomerId(42, 'test_key', 999);
+
+        $this->assertSame('cst_new456', $result);
+    }
+
+    /**
+     * @test
+     * @scenario An already-known Mollie customer ID (derived here from an active subscription
+     *           order) is reused as-is, without ever calling customers->create(), even when a
+     *           Mollie Customer would not otherwise be allowed for this order.
+     */
+    public function reusesExistingCustomerIdEvenWhenNotAllowedForOrder(): void
+    {
+        $subscriptionOrder = Mockery::mock('WC_Order');
+        $subscriptionOrder->shouldReceive('get_id')->andReturn(555);
+
+        when('wc_get_orders')->justReturn([$subscriptionOrder]);
+        when('get_post_meta')->justReturn('cst_existing123');
+
+        $customerEndpointMock = Mockery::mock(CustomerEndpoint::class);
+        $customerEndpointMock->shouldReceive('get')
+            ->with('cst_existing123')
+            ->once()
+            ->andReturn((object) ['id' => 'cst_existing123']);
+        $customerEndpointMock->shouldReceive('create')->never();
+
+        $apiClientMock = $this->helperMocks->apiClient();
+        $apiClientMock->customers = $customerEndpointMock;
+
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(false, $apiClientMock);
+
+        $result = $dataHelper->getUserMollieCustomerId(42, 'test_key', 999);
+
+        $this->assertSame('cst_existing123', $result);
+    }
+}

--- a/tests/php/Functional/Shared/DataTest.php
+++ b/tests/php/Functional/Shared/DataTest.php
@@ -83,7 +83,7 @@ class DataTest extends TestCase
     /**
      * @test
      * @scenario When a Mollie Customer is allowed for this order (setting enabled), a missing
-     *           Mollie customer ID is still created via the API as before.
+     *           Mollie customer ID is created via the API.
      */
     public function createsCustomerWhenAllowedViaSetting(): void
     {

--- a/tests/php/Unit/Payment/Request/Middleware/StoreCustomerMiddlewareTest.php
+++ b/tests/php/Unit/Payment/Request/Middleware/StoreCustomerMiddlewareTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Payment\Request\Middleware;
+
+use Mockery;
+use Mollie\WooCommerce\Payment\Request\Middleware\StoreCustomerMiddleware;
+use Mollie\WooCommerce\Shared\Data;
+use Mollie\WooCommerceTests\TestCase;
+
+/**
+ * @covers \Mollie\WooCommerce\Payment\Request\Middleware\StoreCustomerMiddleware
+ */
+class StoreCustomerMiddlewareTest extends TestCase
+{
+    private function callMiddleware(bool $allowed, array $requestData, string $context): array
+    {
+        $orderId = 42;
+
+        $dataHelper = Mockery::mock(Data::class);
+        $dataHelper->shouldReceive('isMollieCustomerAllowedForOrder')->with($orderId)->andReturn($allowed);
+
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn($orderId);
+
+        $sut = new StoreCustomerMiddleware($dataHelper);
+
+        return $sut($requestData, $order, $context, static function (array $data) {
+            return $data;
+        });
+    }
+
+    /**
+     * @test
+     * @scenario When a Mollie Customer is not allowed for the order (setting disabled and not
+     *           a subscription), customerId is stripped from the 'order' context payload.
+     */
+    public function stripsCustomerIdFromOrderContextWhenNotAllowed(): void
+    {
+        $result = $this->callMiddleware(false, ['payment' => ['customerId' => 'cst_123']], 'order');
+
+        $this->assertArrayNotHasKey('customerId', $result['payment']);
+    }
+
+    /**
+     * @test
+     * @scenario When a Mollie Customer is not allowed for the order, customerId is stripped
+     *           from the 'payment' context payload.
+     */
+    public function stripsCustomerIdFromPaymentContextWhenNotAllowed(): void
+    {
+        $result = $this->callMiddleware(false, ['customerId' => 'cst_123'], 'payment');
+
+        $this->assertArrayNotHasKey('customerId', $result);
+    }
+
+    /**
+     * @test
+     * @scenario When a Mollie Customer is allowed for the order (setting enabled, or the order
+     *           is subscription-related), customerId is left untouched.
+     */
+    public function keepsCustomerIdWhenAllowed(): void
+    {
+        $result = $this->callMiddleware(true, ['customerId' => 'cst_123'], 'payment');
+
+        $this->assertSame('cst_123', $result['customerId']);
+    }
+}

--- a/tests/php/Unit/Shared/DataTest.php
+++ b/tests/php/Unit/Shared/DataTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\WooCommerceTests\Unit\Shared;
+
+use Mollie\WooCommerce\Settings\Settings;
+use Mollie\WooCommerceTests\Functional\HelperMocks;
+use Mollie\WooCommerceTests\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \Mollie\WooCommerce\Shared\Data::isMollieCustomerAllowedForOrder
+ */
+class DataTest extends TestCase
+{
+    private HelperMocks $helperMocks;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->helperMocks = new HelperMocks();
+    }
+
+    private function dataHelperWithShouldStoreCustomer(bool $shouldStoreCustomer, $apiClientMock)
+    {
+        $settings = $this->createConfiguredMock(Settings::class, [
+            'isTestModeEnabled' => true,
+            'getApiKey' => 'test_SOME_API_KEY',
+            'shouldStoreCustomer' => $shouldStoreCustomer,
+        ]);
+
+        return new \Mollie\WooCommerce\Shared\Data(
+            $this->helperMocks->apiHelper($apiClientMock),
+            $this->helperMocks->loggerMock(),
+            $this->helperMocks->pluginId(),
+            $settings,
+            $this->helperMocks->pluginPath()
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // isMollieCustomerAllowedForOrder() — the single source of truth
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @test
+     * @scenario When "store customer details" is disabled and the order is not
+     *           subscription-related, a Mollie Customer is not allowed.
+     */
+    public function isFalseWhenSettingDisabledAndNotSubscription(): void
+    {
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(false, $this->helperMocks->apiClient());
+
+        $this->assertFalse($dataHelper->isMollieCustomerAllowedForOrder(999));
+    }
+
+    /**
+     * @test
+     * @scenario When "store customer details" is enabled, a Mollie Customer is allowed
+     *           regardless of subscription status.
+     */
+    public function isTrueWhenSettingEnabled(): void
+    {
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(true, $this->helperMocks->apiClient());
+
+        $this->assertTrue($dataHelper->isMollieCustomerAllowedForOrder(999));
+    }
+
+    /**
+     * @test
+     * @scenario Even when "store customer details" is disabled, a subscription order is
+     *           exempt — Mollie's recurring-payment/mandate model requires a Customer
+     *           regardless of the setting.
+     */
+    public function isTrueForSubscriptionOrderEvenWhenSettingDisabled(): void
+    {
+        when('apply_filters')->justReturn(true); // simulates Data::isSubscription($orderId) === true
+
+        $dataHelper = $this->dataHelperWithShouldStoreCustomer(false, $this->helperMocks->apiClient());
+
+        $this->assertTrue($dataHelper->isMollieCustomerAllowedForOrder(999));
+    }
+}


### PR DESCRIPTION
## What and why

When "Store customer details at Mollie" was disabled in Advanced settings, the plugin still
created a Mollie Customer at Mollie for logged-in checkouts, and persisted a
`mollie_customer_id` to WordPress usermeta.

`Data::getUserMollieCustomerId()` called `->customers->create()` unconditionally whenever no customer ID was already known, without ever checking `Settings::shouldStoreCustomer()`. The setting was only consulted later, in `StoreCustomerMiddleware`. It stripped `customerId` from the outgoing payment/order request, but it was too late. By then, the Customer had already been created at Mollie, and the ID had already been written to usermeta.

Naively gating creation on the setting would have broken subscriptions: Mollie's recurring-payment/mandate model
requires a Customer to exist regardless of the setting, so `PaymentProcessor::processSubscriptionSwitch()` (mandate lookups) and first-payment mandate creation both depend on a real customer ID being available. Investigating that also surfaced that `StoreCustomerMiddleware` had the same blind spot in the other direction — it stripped `customerId` from subscription first-payment requests too, with no subscription exception — which independently risked leaving subscription mandates never established even before this fix.

## How it works now

`Data::isMollieCustomerAllowedForOrder(int $orderId): bool` is the single source of truth for whether a Mollie
Customer may be associated with an order: `shouldStoreCustomer() || isSubscription($orderId) || isWcSubscription($orderId)`.

`Data::getUserMollieCustomerId($userId, $apiKey, $orderId)` consults that method itself before ever calling
`->customers->create()`. Reusing an already-known customer ID is untouched, and only new creation is gated.

`PaymentProcessor::getUserMollieCustomerId()` and `MollieObject::getUserMollieCustomerId()` are now plain
passthroughs that supply `$order->get_id()`; neither computes the decision itself anymore.

`StoreCustomerMiddleware` now depends on `Data` instead of `Settings` and asks the same `isMollieCustomerAllowedForOrder()` before stripping `customerId` from the outgoing request, so the request-attachment decision and the creation decision can no longer diverge.

The `customer_details` checkbox description in Advanced settings now discloses that subscription orders are exempt from the setting.

### Important
_The "Store customer details at Mollie" setting is always ignored for subscription orders. I also updated the setting description to make it clear._

Please let me know if you want it working in some other way._\

## What to verify in review

### Covered by unit tests
- ✓ Setting disabled + non-subscription order: `Data::getUserMollieCustomerId()` never calls `->customers->create()`
  and returns `null`.
- ✓ Setting enabled: a missing customer ID is still created via the API (regression guard).
- ✓ Subscription order (`isSubscription`): a customer is still created even when the setting is disabled.
- ✓ An already-known customer ID (derived from an active subscription order's meta) is reused as-is, without ever
  calling `->customers->create()`, regardless of what `isMollieCustomerAllowedForOrder()` would otherwise return.
- ✓ `isMollieCustomerAllowedForOrder()` itself: `false` when disabled and not a subscription, `true` when enabled,
  `true` for a subscription order even when disabled.
- ✓ `StoreCustomerMiddleware` strips `customerId` from both the `order`- and `payment`-context payloads when not allowed, and leaves it untouched when allowed.
- ✓ `PaymentProcessor::getUserMollieCustomerId()` passes the order's customer id, API key, and order id straight
  through to `Data`, making no decision of its own.

### Not covered by unit tests
- ✗ `MollieObject::getUserMollieCustomerId()`'s passthrough (used only from
  `addMandateIdMetaToFirstPaymentSubscriptionOrder()`, reached only after Mollie has already created a mandate for the payment) has no dedicated test. It is a two-line passthrough identical in shape to `PaymentProcessor`'s, which is covered; standing up a full subscription-mandate `MollieObject`/`MollieOrder` fixture to re-test the same
  passthrough didn't seem worth the setup cost.
- ✗ No live/integration test confirms Mollie's actual API behavior for a `sequenceType: 'first'` payment sent without
  `customerId` (silently no mandate established, rather than a hard error) — that documented historical failure mode is what motivated exempting subscriptions here, established by tracing the code against Mollie's published API docs, not by a live call against Mollie.

## Contracts introduced or changed

### Constructor signature changed
- `StoreCustomerMiddleware::__construct()` now takes `Mollie\WooCommerce\Shared\Data $dataHelper` instead of
  `Mollie\WooCommerce\Settings\Settings $settingsHelper`. DI wiring updated in `src/Payment/inc/services.php`.

### Method contract changed
- `Data::getUserMollieCustomerId($userId, $apiKey, $orderId)` — third parameter is now a required `$orderId` (used
  internally to consult `isMollieCustomerAllowedForOrder()`), replacing an earlier, since-superseded
`bool $allowCreate` parameter. Both call sites (`PaymentProcessor`, `MollieObject`) pass `$order->get_id()`.
- New public method `Data::isMollieCustomerAllowedForOrder(int $orderId): bool`.
