### PR TITLE
Fix broken Mollie Components help link in Credit card settings

### DIFF
--- a/src/PaymentMethods/Creditcard.php
+++ b/src/PaymentMethods/Creditcard.php
@@ -79,7 +79,7 @@ class Creditcard extends AbstractPaymentMethod implements PaymentMethodI
                 'description' => sprintf(
                 /* translators: Placeholder 1: Mollie Components.*/
                     __(
-                        'Use the Mollie Components for this Gateway. Read more about <a href=\'https://www.mollie.com/en/news/post/better-checkout-flows-with-mollie-components?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner\'>%s</a> and how it improves your conversion.',
+                        'Use the Mollie Components for this Gateway. Read more about <a href=\'https://www.mollie.com/growth/better-checkout-flows-with-mollie-components?utm_source=woocommerce&utm_medium=plugin&utm_campaign=partner\'>%s</a> and how it improves your conversion.',
                         'mollie-payments-for-woocommerce'
                     ),
                     __('Mollie Components', 'mollie-payments-for-woocommerce')


### PR DESCRIPTION
## Summary
The "Read more about Mollie Components" link on the Credit card gateway settings page 404s. The article moved from `mollie.com/en/news/post/better-checkout-flows-with-mollie-components` to `mollie.com/growth/better-checkout-flows-with-mollie-components`.

## Change
Updated the URL in `src/PaymentMethods/Creditcard.php` to point to the current live location of the same article, keeping the existing UTM params.

No Jira ticket — trivial link correction.

## Test plan
- [x] Verified old URL returns 404
- [x] Verified new URL resolves to the same article