### PR TITLE
[QA] Updates for 8.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.6.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@inpsyde/playwright-utils": "^5.1.0",
+        "@inpsyde/playwright-utils": "^5.1.1",
         "@playwright/test": "^1.59.0",
         "@types/node": "^20.8.4",
         "@woocommerce/dependency-extraction-webpack-plugin": "3.0.1",
@@ -2570,9 +2570,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inpsyde/playwright-utils": {
-      "version": "5.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.1.0/352e0a83c72bd7e62793c5d8b55b469cff37f40d",
-      "integrity": "sha512-nqbelr1rodaibIkyGrium77BnZxq8ksX9LZvMqjUt5wZhWGvxvLbjutRdUF3bOV+kS1nXgFz6urF7NWObL062A==",
+      "version": "5.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.1.1/afe7d8593b6eada858a353119c66e6106209bf1f",
+      "integrity": "sha512-QApRv8oyxhnjmFN/f/oYigG+nynRaZReKuffW1X+1FL9SCnGrKjxNp51uUU/AR5EKzXTKRWWWD9o3E4fh6Xncw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.6.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@inpsyde/playwright-utils": "^5.1.1",
+        "@inpsyde/playwright-utils": "^5.2.0",
         "@playwright/test": "^1.59.0",
         "@types/node": "^20.8.4",
         "@woocommerce/dependency-extraction-webpack-plugin": "3.0.1",
@@ -2570,24 +2570,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inpsyde/playwright-utils": {
-      "version": "5.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.1.1/afe7d8593b6eada858a353119c66e6106209bf1f",
-      "integrity": "sha512-QApRv8oyxhnjmFN/f/oYigG+nynRaZReKuffW1X+1FL9SCnGrKjxNp51uUU/AR5EKzXTKRWWWD9o3E4fh6Xncw==",
+      "version": "5.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.2.0/2986ad3e90353eea12359717501d2d7441911610",
+      "integrity": "sha512-DJA6XLLKSB4J0umsK3hK4VV/gOsk7qE+MShpuDdUv68B8hFRmplLnxet7S2XPi3HusvOaEoFhK1oML3JhJrZUg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@axe-core/playwright": "^4.10.1",
         "@percy/cli": "^1.30.6",
         "@percy/playwright": "^1.0.6",
-        "@playwright/test": "^1.45.0",
+        "@playwright/test": "^1.59.0",
         "@types/woocommerce__woocommerce-rest-api": "^1.0.5",
         "@woocommerce/woocommerce-rest-api": "^1.0.1",
         "@wordpress/e2e-test-utils-playwright": "^1.0.0",
         "axe-core": "^4.10.2",
         "axe-html-reporter": "^2.2.11",
         "lighthouse": "^12.0.0",
-        "playwright": "^1.49.0",
-        "playwright-core": "^1.49.0",
+        "playwright": "^1.59.0",
+        "playwright-core": "^1.59.0",
         "playwright-lighthouse": "^4.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -56,10 +56,12 @@
     "env:reset": "npx playwright test --grep=\"env:reset;\"",
     "env:reset:wc": "npx playwright test --grep=\"env:reset;|setup:wc;\"",
     "env:reset:mollie": "npm run env:reset:wc && npm run env:setup:mollie",
+    "env:reset:mollie:nl": "npm run env:reset:wc && npm run env:setup:mollie:nl",
     "env:reset:mollie:multistep": "npm run env:reset:mollie && npm run env:setup:multistep",
 
     "env:setup:wc": "npx playwright test --grep=\"setup:wc;\"",
     "env:setup:mollie": "npx playwright test --project=setup-mollie --grep=\"setup:mollie;\"",
+    "env:setup:mollie:nl": "npx playwright test --project=setup-mollie-nl --grep=\"setup:mollie:nl;\"",
     "env:setup:payment-api": "npx playwright test --grep=\"setup:payment-api;\"",
     "env:setup:order-api": "npx playwright test --grep=\"setup:order-api;\"",
     "env:setup:multistep": "npx playwright test --grep=\"setup:multistep:checkout;\"",
@@ -73,6 +75,8 @@
     "e2e:test:payment-api:refund": "npx playwright test --project=refund-payment-api --workers=4",
     "e2e:test:payment-api:multistep": "npx playwright test --project=multistep-payment-api --workers=1",
     "e2e:test:payment-api:multistep:smoke": "npx playwright test --project=multistep-payment-api --workers=1 --grep \"@Critical\"",
+    "e2e:test:payment-api:nl": "npx playwright test --project=nl-payment-api --workers=1",
+    "e2e:test:payment-api:nl:smoke": "npx playwright test --project=nl-payment-api --workers=1 --grep \"@Critical\"",
 
     "e2e:test:order-api": "npx playwright test --project=order-api --workers=1",
     "e2e:test:order-api:smoke": "npx playwright test --project=order-api --workers=1 --grep \"@Critical\"",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git@github.com:mollie/WooCommerce.git"
   },
   "devDependencies": {
-    "@inpsyde/playwright-utils": "^5.1.0",
+    "@inpsyde/playwright-utils": "^5.1.1",
     "@playwright/test": "^1.59.0",
     "@woocommerce/dependency-extraction-webpack-plugin": "3.0.1",
     "@wordpress/scripts": "^30.24.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git@github.com:mollie/WooCommerce.git"
   },
   "devDependencies": {
-    "@inpsyde/playwright-utils": "^5.1.1",
+    "@inpsyde/playwright-utils": "^5.2.0",
     "@playwright/test": "^1.59.0",
     "@woocommerce/dependency-extraction-webpack-plugin": "3.0.1",
     "@wordpress/scripts": "^30.24.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -134,6 +134,13 @@ export default defineConfig< TestBaseExtend >( {
 			},
 		},
 		{
+			name: 'setup-mollie-nl',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /mollie\.setup\.ts/,
+			grep: /setup:mollie:nl;/,
+			fullyParallel: false,
+		},
+		{
 			name: 'setup-multistep',
 			testMatch: /multistep\.setup\.ts/,
 			fullyParallel: false,
@@ -148,16 +155,24 @@ export default defineConfig< TestBaseExtend >( {
 			name: 'payment-api',
 			dependencies: [ 'setup-woocommerce' ],
 			fullyParallel: false,
-			testIgnore: /refund\.spec\.ts/,
+			testIgnore:
+				/refund\.spec\.ts|nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,
 		},
 		{
 			name: 'order-api',
 			dependencies: [ 'setup-woocommerce' ],
 			fullyParallel: false,
-			testIgnore: /refund\.spec\.ts/,
+			testIgnore:
+				/refund\.spec\.ts|nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,
 			use: {
 				mollieApiMethod: 'order',
 			},
+		},
+		{
+			name: 'nl-payment-api',
+			dependencies: [ 'setup-mollie-nl' ],
+			fullyParallel: false,
+			testMatch: /nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,
 		},
 		{
 			name: 'refund-payment-api',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -194,7 +194,8 @@ export default defineConfig< TestBaseExtend >( {
 			name: 'multistep-payment-api',
 			dependencies: [ 'setup-multistep-tests' ],
 			fullyParallel: false,
-			testIgnore: /refund\.spec\.ts/,
+			testIgnore:
+				/refund\.spec\.ts|nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,
 			// grep: /Transaction - (Classic checkout|Checkout) - (iDEAL -|PayPal|Card|KBC)|Transaction - Checkout - (iDEAL Pay in 3|Przelewy24|MyBank)/,
 			grep: /Transaction/,
 			grepInvert: /Transaction - Pay for order/,
@@ -206,7 +207,8 @@ export default defineConfig< TestBaseExtend >( {
 			name: 'multistep-order-api',
 			dependencies: [ 'setup-multistep-tests' ],
 			fullyParallel: false,
-			testIgnore: /refund\.spec\.ts/,
+			testIgnore:
+				/refund\.spec\.ts|nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,
 			// grep: /Transaction - (Classic checkout|Checkout) - (iDEAL -|PayPal|Card|KBC)|Transaction - Checkout - (iDEAL Pay in 3|Przelewy24|MyBank)/,
 			grep: /Transaction/,
 			grepInvert: /Transaction - Pay for order/,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -153,14 +153,14 @@ export default defineConfig< TestBaseExtend >( {
 		},
 		{
 			name: 'payment-api',
-			dependencies: [ 'setup-woocommerce' ],
+			dependencies: [ 'setup-mollie-payment-api' ],
 			fullyParallel: false,
 			testIgnore:
 				/refund\.spec\.ts|nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,
 		},
 		{
 			name: 'order-api',
-			dependencies: [ 'setup-woocommerce' ],
+			dependencies: [ 'setup-mollie-order-api' ],
 			fullyParallel: false,
 			testIgnore:
 				/refund\.spec\.ts|nl-(checkout|classic-checkout|pay-for-order)\.spec\.ts/,

--- a/tests/qa/resources/gateways.ts
+++ b/tests/qa/resources/gateways.ts
@@ -122,6 +122,20 @@ const billie: MollieGateway = {
 	},
 };
 
+const billink: MollieGateway = {
+	country: 'netherlands', // Netherlands, Belgium also supported (Germany on request)
+	minAmount: '0.01',
+	maxAmount: '2500.00', // B2C limit; B2B is 10000.00
+	slug: 'billink',
+	name: 'Billink',
+	availableForApiMethods: [ 'payment' ], // Payments API only
+	settings: {
+		...defaultGatewaySettings,
+		id: 'mollie_wc_gateway_billink',
+		title: 'Billink',
+	},
+};
+
 const blik: MollieGateway = {
 	country: 'poland',
 	minAmount: '1.00',
@@ -478,6 +492,20 @@ const voucher: MollieGateway = {
 	},
 };
 
+const wero: MollieGateway = {
+	country: 'germany', // Belgium, France, Luxembourg also supported
+	minAmount: '0.01',
+	maxAmount: '10000.00', // default; scheme max is 99999.00, bank-dependent
+	slug: 'wero',
+	name: 'Wero',
+	availableForApiMethods: [ 'payment' ], // Payments API only
+	settings: {
+		...defaultGatewaySettings,
+		id: 'mollie_wc_gateway_wero',
+		title: 'Wero',
+	},
+};
+
 export const gateways: {
 	[ key: string ]: MollieGateway;
 } = {
@@ -488,6 +516,7 @@ export const gateways: {
 	banktransfer,
 	belfius,
 	billie, // >100.00
+	billink,
 	blik, // currency: PLN
 	bizum,
 	creditcard,
@@ -512,4 +541,5 @@ export const gateways: {
 	twint, // currency: CHF
 	vipps, // currency: NOK
 	voucher,
+	wero,
 };

--- a/tests/qa/resources/gateways.ts
+++ b/tests/qa/resources/gateways.ts
@@ -115,6 +115,7 @@ const billie: MollieGateway = {
 	slug: 'billie',
 	name: 'Pay by Invoice for Businesses - Billie',
 	availableForApiMethods: [ 'order', 'payment' ],
+	isCaptureRequired: true,
 	settings: {
 		...defaultGatewaySettings,
 		id: 'mollie_wc_gateway_billie',
@@ -129,6 +130,7 @@ const billink: MollieGateway = {
 	slug: 'billink',
 	name: 'Billink',
 	availableForApiMethods: [ 'payment' ], // Payments API only
+	isCaptureRequired: true,
 	settings: {
 		...defaultGatewaySettings,
 		id: 'mollie_wc_gateway_billink',
@@ -284,6 +286,7 @@ const klarna: MollieGateway = {
 	slug: 'klarna',
 	name: 'Pay with Klarna',
 	availableForApiMethods: [ 'order', 'payment' ],
+	isCaptureRequired: true,
 	settings: {
 		...defaultGatewaySettings,
 		id: 'mollie_wc_gateway_klarna',
@@ -414,6 +417,7 @@ const riverty: MollieGateway = {
 	slug: 'riverty',
 	name: 'Buy now, pay later with Riverty',
 	availableForApiMethods: [ 'order', 'payment' ],
+	isCaptureRequired: true,
 	settings: {
 		...defaultGatewaySettings,
 		id: 'mollie_wc_gateway_riverty',

--- a/tests/qa/resources/gateways.ts
+++ b/tests/qa/resources/gateways.ts
@@ -378,6 +378,7 @@ const paypal: MollieGateway = {
 		title: 'PayPal',
 		mollie_paypal_button_enabled_cart: 'no',
 		mollie_paypal_button_enabled_product: 'no',
+		mollie_paypal_button_enabled_checkout: 'no',
 		paypal_color: 'en-buy-pill-blue',
 		mollie_paypal_button_minimum_amount: '0',
 	},

--- a/tests/qa/resources/mollie-config.ts
+++ b/tests/qa/resources/mollie-config.ts
@@ -16,7 +16,6 @@ export const mollieApiKeys: {
 		liveApiKey: process.env.MOLLIE_LIVE_API_KEY,
 		testApiKey: process.env.MOLLIE_TEST_API_KEY,
 	},
-	// Billink only works with an NL merchant profile - separate Mollie account/keys.
 	nl: {
 		testModeEnabled: 'yes',
 		liveApiKey: process.env.MOLLIE_LIVE_API_KEY_NL,

--- a/tests/qa/resources/mollie-config.ts
+++ b/tests/qa/resources/mollie-config.ts
@@ -16,4 +16,10 @@ export const mollieApiKeys: {
 		liveApiKey: process.env.MOLLIE_LIVE_API_KEY,
 		testApiKey: process.env.MOLLIE_TEST_API_KEY,
 	},
+	// Billink only works with an NL merchant profile - separate Mollie account/keys.
+	nl: {
+		testModeEnabled: 'yes',
+		liveApiKey: process.env.MOLLIE_LIVE_API_KEY_NL,
+		testApiKey: process.env.MOLLIE_TEST_API_KEY_NL,
+	},
 };

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -204,6 +204,7 @@ export type MollieGateway = {
 	maxAmount?: string;
 	availableForApiMethods?: MollieSettings.ApiMethod[];
 	settings?: MollieSettings.Gateway;
+	isCaptureRequired?: boolean; // Mirrors `paymentCaptureMode: 'manual'` in the gateway's PHP config
 };
 
 export type MolliePaymentStatus =

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -273,4 +273,10 @@ export namespace MollieTestData {
 		refundOrderStatus?: WooCommerce.OrderStatus; // WooCommerce refunded order status
 		refundPaymentStatus?: string; // Payment status obtained from PayPal Payment
 	};
+	
+	export type OrderTransition = 'onHoldToFinal' | 'authorizedToVoided';
+
+	export type ShopOrderTransition = ShopOrder & {
+		transition: OrderTransition;
+	};
 }

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -179,6 +179,7 @@ export namespace MollieSettings {
 
 		mollie_paypal_button_enabled_cart?: 'yes' | 'no'; // paypal
 		mollie_paypal_button_enabled_product?: 'yes' | 'no'; // paypal
+		mollie_paypal_button_enabled_checkout?: 'yes' | 'no'; // paypal
 		paypal_color?: PaypalButtonTextLanguageAndColor; // paypal
 		mollie_paypal_button_minimum_amount?: string; // paypal
 

--- a/tests/qa/resources/woocommerce-config.ts
+++ b/tests/qa/resources/woocommerce-config.ts
@@ -16,3 +16,16 @@ export const shopConfigClassic: ShopConfig = {
 	...shopConfigDefault,
 	enableClassicPages: true,
 };
+
+// Billink only works with an NL merchant, so its shop must run under NL general
+// settings/customer too, not the default German ones.
+export const shopConfigNetherlands: ShopConfig = {
+	...shopConfigDefault,
+	settings: shopSettings.netherlands,
+	customer: customers.netherlands,
+};
+
+export const shopConfigNetherlandsClassic: ShopConfig = {
+	...shopConfigNetherlands,
+	enableClassicPages: true,
+};

--- a/tests/qa/resources/woocommerce-config.ts
+++ b/tests/qa/resources/woocommerce-config.ts
@@ -17,8 +17,7 @@ export const shopConfigClassic: ShopConfig = {
 	enableClassicPages: true,
 };
 
-// Billink only works with an NL merchant, so its shop must run under NL general
-// settings/customer too, not the default German ones.
+// Billink only works with an NL merchant, so its shop must run under NL general/settings/customer settings
 export const shopConfigNetherlands: ShopConfig = {
 	...shopConfigDefault,
 	settings: shopSettings.netherlands,

--- a/tests/qa/tests/04-frontend-ui/_test-data/index.ts
+++ b/tests/qa/tests/04-frontend-ui/_test-data/index.ts
@@ -1,0 +1,1 @@
+export * from './phone-validation.data';

--- a/tests/qa/tests/04-frontend-ui/_test-data/phone-validation.data.ts
+++ b/tests/qa/tests/04-frontend-ui/_test-data/phone-validation.data.ts
@@ -1,0 +1,78 @@
+/**
+ * Internal dependencies
+ */
+import {
+	orders,
+	MollieTestData,
+	gateways,
+	guests,
+	products,
+} from '../../../resources';
+
+const baseOrder: MollieTestData.ShopOrder = {
+	...orders.default,
+	products: [ products.mollieSimple100 ],
+};
+
+export const phoneValidationData: MollieTestData.ShopOrder[] = [
+	// Baseline: phone already in the gateway's local format - must keep working.
+	{
+		...baseOrder,
+		testId: 'C4567605',
+		testLabel: '@Critical',
+		customer: guests.germany,
+		payment: {
+			gateway: gateways.riverty,
+			status: 'authorized',
+		},
+	},
+	// Local mobile number with no leading zero and no country code (e.g. Italian
+	// mobile "3887403368"). Region hint comes from the billing address, so this must
+	// now be reformatted to a valid E.164 number instead of failing at Mollie with a 422.
+	{
+		...baseOrder,
+		testId: 'C4567606',
+		testLabel: '@Critical',
+		customer: {
+			...guests.italy,
+			billing: { ...guests.italy.billing, phone: '3887403368' },
+			shipping: { ...guests.italy.shipping, phone: '3887403368' },
+		},
+		payment: {
+			gateway: gateways.riverty,
+			status: 'authorized',
+		},
+	},
+	// Phone already E.164-formatted ("+" prefix) must be left as-is and still work.
+	{
+		...baseOrder,
+		testId: 'C4567607',
+		customer: {
+			...guests.germany,
+			billing: { ...guests.germany.billing, phone: '+4917612345678' },
+			shipping: { ...guests.germany.shipping, phone: '+4917612345678' },
+		},
+		payment: {
+			gateway: gateways.riverty,
+			status: 'authorized',
+		},
+	},
+	// iDEAL doesn't require a phone number, so checkout must still complete even
+	// though this value can't be formatted into any valid E.164 number.
+	{
+		...baseOrder,
+		testId: 'C4567608',
+		customer: {
+			...guests.netherlands,
+			billing: { ...guests.netherlands.billing, phone: '99999999999999' },
+			shipping: {
+				...guests.netherlands.shipping,
+				phone: '99999999999999',
+			},
+		},
+		payment: {
+			gateway: gateways.ideal,
+			status: 'open',
+		},
+	},
+];

--- a/tests/qa/tests/04-frontend-ui/_test-data/phone-validation.data.ts
+++ b/tests/qa/tests/04-frontend-ui/_test-data/phone-validation.data.ts
@@ -14,20 +14,27 @@ const baseOrder: MollieTestData.ShopOrder = {
 	products: [ products.mollieSimple100 ],
 };
 
+// The E.164 reformatting (AddressMiddleware::getPhoneNumber()) reads the general
+// WooCommerce billing/shipping phone field first, for every gateway - it's checked
+// before any gateway-specific field is even looked at. So no phone-required gateway
+// (In3/Riverty/Vipps/MobilePay) is needed here, and using one would only add a
+// country/gateway-availability constraint with no test-value payoff. MyBank is
+// Italy-native and phone-optional, so it lets the billing country genuinely be Italy
+// (needed for the region hint) without the payment option itself being filtered out.
 export const phoneValidationData: MollieTestData.ShopOrder[] = [
 	// Baseline: phone already in the gateway's local format - must keep working.
 	{
 		...baseOrder,
 		testId: 'C4567605',
 		testLabel: '@Critical',
-		customer: guests.germany,
+		customer: guests.italy,
 		payment: {
-			gateway: gateways.riverty,
-			status: 'authorized',
+			gateway: gateways.mybank,
+			status: 'paid',
 		},
 	},
-	// Local mobile number with no leading zero and no country code (e.g. Italian
-	// mobile "3887403368"). Region hint comes from the billing address, so this must
+	// Local mobile number with no leading zero and no country code (the exact
+	// PIWOO-925 repro case). Region hint comes from the billing address, so this must
 	// now be reformatted to a valid E.164 number instead of failing at Mollie with a 422.
 	{
 		...baseOrder,
@@ -39,8 +46,8 @@ export const phoneValidationData: MollieTestData.ShopOrder[] = [
 			shipping: { ...guests.italy.shipping, phone: '3887403368' },
 		},
 		payment: {
-			gateway: gateways.riverty,
-			status: 'authorized',
+			gateway: gateways.mybank,
+			status: 'paid',
 		},
 	},
 	// Phone already E.164-formatted ("+" prefix) must be left as-is and still work.
@@ -48,13 +55,13 @@ export const phoneValidationData: MollieTestData.ShopOrder[] = [
 		...baseOrder,
 		testId: 'C4567607',
 		customer: {
-			...guests.germany,
-			billing: { ...guests.germany.billing, phone: '+4917612345678' },
-			shipping: { ...guests.germany.shipping, phone: '+4917612345678' },
+			...guests.italy,
+			billing: { ...guests.italy.billing, phone: '+393887403368' },
+			shipping: { ...guests.italy.shipping, phone: '+393887403368' },
 		},
 		payment: {
-			gateway: gateways.riverty,
-			status: 'authorized',
+			gateway: gateways.mybank,
+			status: 'paid',
 		},
 	},
 	// iDEAL doesn't require a phone number, so checkout must still complete even

--- a/tests/qa/tests/04-frontend-ui/_test-scenarios/index.ts
+++ b/tests/qa/tests/04-frontend-ui/_test-scenarios/index.ts
@@ -1,0 +1,1 @@
+export * from './phone-validation.scenario';

--- a/tests/qa/tests/04-frontend-ui/_test-scenarios/phone-validation.scenario.ts
+++ b/tests/qa/tests/04-frontend-ui/_test-scenarios/phone-validation.scenario.ts
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { test, buildMollieGatewayLabel } from '../../../utils';
+import { MollieTestData } from '../../../resources';
+
+/**
+ * Checks out with the given phone number and stops as soon as the order has
+ * reached Mollie's hosted checkout page - the phone number's E.164 formatting
+ * is verified at integration level, so this only needs to confirm checkout
+ * isn't blocked before the payment itself. No payment is completed.
+ *
+ * @param testData
+ */
+export const testReachesMollieHostedCheckout = (
+	testData: MollieTestData.ShopOrder
+) => {
+	const { testId, testLabel, payment, customer } = testData;
+	const { gateway } = payment;
+	const gatewayLabel = buildMollieGatewayLabel( gateway );
+	const label = testLabel ? ` ${ testLabel }` : '';
+
+	test( `${ testId } | Phone validation - ${ gatewayLabel } - checkout with phone "${ customer.billing.phone }" reaches Mollie hosted checkout${ label }`, async ( {
+		utils,
+		checkout,
+		mollieHostedCheckout,
+		isMultistepCheckout,
+		mollieApiMethod,
+	} ) => {
+		// exclude tests for payment methods if not available for tested API
+		test.skip(
+			! gateway.availableForApiMethods.includes( mollieApiMethod ),
+			`Test is not eligible for ${ mollieApiMethod } API method.`
+		);
+
+		await utils.fillVisitorsCart( testData.products );
+
+		await ( isMultistepCheckout
+			? checkout.makeMultistepOrder( testData )
+			: checkout.makeOrder( testData ) );
+
+		await mollieHostedCheckout.assertUrl();
+	} );
+};

--- a/tests/qa/tests/04-frontend-ui/phone-validation.spec.ts
+++ b/tests/qa/tests/04-frontend-ui/phone-validation.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { shopConfigDefault } from '../../resources';
+import { testReachesMollieHostedCheckout } from './_test-scenarios';
+import { phoneValidationData } from './_test-data';
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( shopConfigDefault );
+	await utils.installAndActivateMollie();
+	await utils.cleanReconnectMollie();
+} );
+
+test.describe( () => {
+	for ( const testData of phoneValidationData ) {
+		testReachesMollieHostedCheckout( testData );
+	}
+} );

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
@@ -72,6 +72,7 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3731',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'paid',
@@ -80,6 +81,7 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3732',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'failed',
@@ -88,6 +90,7 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3733',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'canceled',
@@ -96,6 +99,7 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3734',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'expired',

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
@@ -519,6 +519,7 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3007255',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.klarna,
 			status: 'authorized',

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
@@ -708,4 +708,68 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
                         status: 'expired',
                 },
         },
+	{
+		...baseOrder,
+		testId: 'C4567617',
+		payment: {
+			gateway: gateways.billink,
+			status: 'authorized',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567618',
+		payment: {
+			gateway: gateways.billink,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567619',
+		payment: {
+			gateway: gateways.billink,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567620',
+		payment: {
+			gateway: gateways.billink,
+			status: 'expired',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567621',
+		payment: {
+			gateway: gateways.wero,
+			status: 'paid',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567622',
+		payment: {
+			gateway: gateways.wero,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567623',
+		payment: {
+			gateway: gateways.wero,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567624',
+		payment: {
+			gateway: gateways.wero,
+			status: 'expired',
+		},
+	},
 ];

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout-classic.data.ts
@@ -710,38 +710,6 @@ export const classicCheckoutEur: MollieTestData.ShopOrder[] = [
         },
 	{
 		...baseOrder,
-		testId: 'C4567617',
-		payment: {
-			gateway: gateways.billink,
-			status: 'authorized',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567618',
-		payment: {
-			gateway: gateways.billink,
-			status: 'failed',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567619',
-		payment: {
-			gateway: gateways.billink,
-			status: 'canceled',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567620',
-		payment: {
-			gateway: gateways.billink,
-			status: 'expired',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C4567621',
 		payment: {
 			gateway: gateways.wero,

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
@@ -517,6 +517,7 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3007259',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.klarna,
 			status: 'authorized',

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
@@ -72,6 +72,7 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420219',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'paid',
@@ -80,6 +81,7 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420220',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'failed',
@@ -88,6 +90,7 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420221',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'canceled',
@@ -96,6 +99,7 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420222',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'expired',

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
@@ -706,4 +706,68 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
                         status: 'expired',
                 },
         },
+	{
+		...baseOrder,
+		testId: 'C4567609',
+		payment: {
+			gateway: gateways.billink,
+			status: 'authorized',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567610',
+		payment: {
+			gateway: gateways.billink,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567611',
+		payment: {
+			gateway: gateways.billink,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567612',
+		payment: {
+			gateway: gateways.billink,
+			status: 'expired',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567613',
+		payment: {
+			gateway: gateways.wero,
+			status: 'paid',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567614',
+		payment: {
+			gateway: gateways.wero,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567615',
+		payment: {
+			gateway: gateways.wero,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567616',
+		payment: {
+			gateway: gateways.wero,
+			status: 'expired',
+		},
+	},
 ];

--- a/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-checkout.data.ts
@@ -708,38 +708,6 @@ export const checkoutEur: MollieTestData.ShopOrder[] = [
         },
 	{
 		...baseOrder,
-		testId: 'C4567609',
-		payment: {
-			gateway: gateways.billink,
-			status: 'authorized',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567610',
-		payment: {
-			gateway: gateways.billink,
-			status: 'failed',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567611',
-		payment: {
-			gateway: gateways.billink,
-			status: 'canceled',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567612',
-		payment: {
-			gateway: gateways.billink,
-			status: 'expired',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C4567613',
 		payment: {
 			gateway: gateways.wero,

--- a/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
@@ -517,6 +517,7 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C3007283',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.klarna,
 			status: 'authorized',

--- a/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
@@ -708,38 +708,6 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
         },
 	{
 		...baseOrder,
-		testId: 'C4567625',
-		payment: {
-			gateway: gateways.billink,
-			status: 'authorized',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567626',
-		payment: {
-			gateway: gateways.billink,
-			status: 'failed',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567627',
-		payment: {
-			gateway: gateways.billink,
-			status: 'canceled',
-		},
-	},
-	{
-		...baseOrder,
-		testId: 'C4567628',
-		payment: {
-			gateway: gateways.billink,
-			status: 'expired',
-		},
-	},
-	{
-		...baseOrder,
 		testId: 'C4567629',
 		payment: {
 			gateway: gateways.wero,

--- a/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
@@ -706,4 +706,68 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
                         status: 'expired',
                 },
         },
+	{
+		...baseOrder,
+		testId: 'C4567625',
+		payment: {
+			gateway: gateways.billink,
+			status: 'authorized',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567626',
+		payment: {
+			gateway: gateways.billink,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567627',
+		payment: {
+			gateway: gateways.billink,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567628',
+		payment: {
+			gateway: gateways.billink,
+			status: 'expired',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567629',
+		payment: {
+			gateway: gateways.wero,
+			status: 'paid',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567630',
+		payment: {
+			gateway: gateways.wero,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567631',
+		payment: {
+			gateway: gateways.wero,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567632',
+		payment: {
+			gateway: gateways.wero,
+			status: 'expired',
+		},
+	},
 ];

--- a/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/eur-pay-for-order.data.ts
@@ -72,6 +72,7 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420334',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'paid',
@@ -80,6 +81,7 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420335',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'failed',
@@ -88,6 +90,7 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420336',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'canceled',
@@ -96,6 +99,7 @@ export const payForOrderEur: MollieTestData.ShopOrder[] = [
 	{
 		...baseOrder,
 		testId: 'C420337',
+		testLabel: '@Critical',
 		payment: {
 			gateway: gateways.in3,
 			status: 'expired',

--- a/tests/qa/tests/05-transaction/_test-data/index.ts
+++ b/tests/qa/tests/05-transaction/_test-data/index.ts
@@ -1,4 +1,7 @@
 export * from './transaction-base-order.data';
+export * from './nl-checkout.data';
+export * from './nl-classic-checkout.data';
+export * from './nl-pay-for-order.data';
 export * from './eur-checkout-classic.data';
 export * from './eur-checkout.data';
 export * from './eur-pay-for-order.data';

--- a/tests/qa/tests/05-transaction/_test-data/index.ts
+++ b/tests/qa/tests/05-transaction/_test-data/index.ts
@@ -9,3 +9,4 @@ export * from './eur-credit-card-disabled-mollie-components.data';
 export * from './non-eur-checkout-classic.data';
 export * from './non-eur-checkout.data';
 export * from './non-eur-pay-for-order.data';
+export * from './paypal-express.data';

--- a/tests/qa/tests/05-transaction/_test-data/nl-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/nl-checkout.data.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { MollieTestData, gateways } from '../../../resources';
+import { baseOrder } from './transaction-base-order.data';
+
+// Billink only works with an NL merchant profile (see nl-checkout.spec.ts's
+// dedicated beforeAll and project), so it's kept separate from the other EUR gateways here.
+export const checkoutNl: MollieTestData.ShopOrder[] = [
+	{
+		...baseOrder,
+		testId: 'C4567609',
+		testLabel: '@Critical',
+		payment: {
+			gateway: gateways.billink,
+			status: 'authorized',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567610',
+		payment: {
+			gateway: gateways.billink,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567611',
+		payment: {
+			gateway: gateways.billink,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567612',
+		payment: {
+			gateway: gateways.billink,
+			status: 'expired',
+		},
+	},
+];

--- a/tests/qa/tests/05-transaction/_test-data/nl-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/nl-classic-checkout.data.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { MollieTestData, gateways } from '../../../resources';
+import { baseOrder } from './transaction-base-order.data';
+
+// Billink only works with an NL merchant profile (see nl-classic-checkout.spec.ts's
+// dedicated beforeAll and project), so it's kept separate from the other EUR gateways here.
+export const classicCheckoutNl: MollieTestData.ShopOrder[] = [
+	{
+		...baseOrder,
+		testId: 'C4567617',
+		testLabel: '@Critical',
+		payment: {
+			gateway: gateways.billink,
+			status: 'authorized',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567618',
+		payment: {
+			gateway: gateways.billink,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567619',
+		payment: {
+			gateway: gateways.billink,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567620',
+		payment: {
+			gateway: gateways.billink,
+			status: 'expired',
+		},
+	},
+];

--- a/tests/qa/tests/05-transaction/_test-data/nl-pay-for-order.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/nl-pay-for-order.data.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { MollieTestData, gateways } from '../../../resources';
+import { baseOrder } from './transaction-base-order.data';
+
+// Billink only works with an NL merchant profile (see nl-pay-for-order.spec.ts's
+// dedicated beforeAll and project), so it's kept separate from the other EUR gateways here.
+export const payForOrderNl: MollieTestData.ShopOrder[] = [
+	{
+		...baseOrder,
+		testId: 'C4567625',
+		testLabel: '@Critical',
+		payment: {
+			gateway: gateways.billink,
+			status: 'authorized',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567626',
+		payment: {
+			gateway: gateways.billink,
+			status: 'failed',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567627',
+		payment: {
+			gateway: gateways.billink,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567628',
+		payment: {
+			gateway: gateways.billink,
+			status: 'expired',
+		},
+	},
+];

--- a/tests/qa/tests/05-transaction/_test-data/paypal-express.data.ts
+++ b/tests/qa/tests/05-transaction/_test-data/paypal-express.data.ts
@@ -1,0 +1,176 @@
+/**
+ * Internal dependencies
+ */
+import {
+	MollieTestData,
+	gateways,
+	products,
+	freeShipping,
+} from '../../../resources';
+import { baseOrder } from './transaction-base-order.data';
+
+// PayPal Express only renders when every product involved is virtual (see
+// PayPalExpressButton::isVirtualProduct() / registerCartPageHook() in
+// src/Buttons/PayPalButton/PayPalExpressButton.php), so all three page
+// variants below use the virtual product instead of baseOrder's default.
+//
+// The Express flow never calls selectShippingMethod() (it bypasses normal
+// checkout entirely) and a virtual product needs no shipping, so the real
+// order never gets a shipping line - confirmed via the order-edit page
+// ("No shipping address set", Order Total = Items Subtotal + tax only).
+// Override baseOrder's flatRate shipping with freeShipping so countTotals()
+// expects the same zero-shipping total the real order actually has.
+const virtualOrder: MollieTestData.ShopOrder = {
+	...baseOrder,
+	products: [ products.mollieVirtual100 ],
+	shipping: freeShipping,
+};
+
+// orderStatus is set explicitly here instead of relying on getOrderStatusFromMollieStatus()
+
+export const payPalExpressProduct: MollieTestData.ShopOrder[] = [
+	{
+		...virtualOrder,
+		testId: 'C4567643',
+		testLabel: '@Critical',
+		orderStatus: 'completed',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'paid',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567644',
+		orderStatus: 'pending',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'pending',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567645',
+		orderStatus: 'failed',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'failed',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567646',
+		orderStatus: 'pending',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'canceled',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567647',
+		orderStatus: 'cancelled',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'expired',
+		},
+	},
+];
+
+export const payPalExpressCart: MollieTestData.ShopOrder[] = [
+	{
+		...virtualOrder,
+		testId: 'C4567648',
+		testLabel: '@Critical',
+		orderStatus: 'completed',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'paid',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567649',
+		orderStatus: 'pending',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'pending',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567650',
+		orderStatus: 'failed',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'failed',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567651',
+		orderStatus: 'pending',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'canceled',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567652',
+		orderStatus: 'cancelled',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'expired',
+		},
+	},
+];
+
+export const payPalExpressCheckout: MollieTestData.ShopOrder[] = [
+	{
+		...virtualOrder,
+		testId: 'C4567653',
+		testLabel: '@Critical',
+		orderStatus: 'completed',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'paid',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567654',
+		orderStatus: 'pending',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'pending',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567655',
+		orderStatus: 'failed',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'failed',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567656',
+		orderStatus: 'pending',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'canceled',
+		},
+	},
+	{
+		...virtualOrder,
+		testId: 'C4567657',
+		orderStatus: 'cancelled',
+		payment: {
+			gateway: gateways.paypal,
+			status: 'expired',
+		},
+	},
+];

--- a/tests/qa/tests/05-transaction/_test-scenarios/index.ts
+++ b/tests/qa/tests/05-transaction/_test-scenarios/index.ts
@@ -1,3 +1,4 @@
 export * from './checkout-classic.scenario';
 export * from './checkout.scenario';
 export * from './pay-for-order.scenario';
+export * from './paypal-express.scenario';

--- a/tests/qa/tests/05-transaction/_test-scenarios/paypal-express.scenario.ts
+++ b/tests/qa/tests/05-transaction/_test-scenarios/paypal-express.scenario.ts
@@ -1,0 +1,231 @@
+/**
+ * External dependencies
+ */
+import { countTotals, expect } from '@inpsyde/playwright-utils/build';
+/**
+ * Internal dependencies
+ */
+import {
+	test,
+	processMolliePaymentStatus,
+	updateCurrencyIfNeeded,
+	getOrderStatusFromMollieStatus,
+	assertOrderNotes,
+	TestBaseExtend,
+} from '../../../utils';
+import { MollieTestData, guests } from '../../../resources';
+
+/**
+ * Shared setup: resolves order status/currency/totals and skips the test if
+ * the current Mollie API method doesn't support the gateway - identical
+ * groundwork the regular gateway transaction scenarios do before checkout.
+ */
+const preparePayPalExpressOrder = async (
+	testData: MollieTestData.ShopOrder,
+	wooCommerceApi: TestBaseExtend[ 'wooCommerceApi' ],
+	mollieApiMethod: TestBaseExtend[ 'mollieApiMethod' ]
+) => {
+	const { payment } = testData;
+	const { gateway } = payment;
+
+	test.skip(
+		! gateway.availableForApiMethods.includes( mollieApiMethod ),
+		`Test is not eligible for ${ mollieApiMethod } API method.`
+	);
+
+	const customer = guests[ gateway.country ];
+	Object.assign( testData, { customer, currency: gateway.currency } );
+
+	if ( ! testData.orderStatus ) {
+		testData.orderStatus = await getOrderStatusFromMollieStatus(
+			payment.status,
+			mollieApiMethod
+		);
+	}
+
+	await updateCurrencyIfNeeded( wooCommerceApi, gateway.currency );
+
+	const orderTotals = await countTotals( testData );
+	payment.amount = orderTotals.order;
+};
+
+/**
+ * Shared tail: pays at Mollie for the order the Express button just created,
+ * then asserts order status/transaction id/notes - identical to the regular
+ * gateway transaction scenarios, since the Express button hands off to the
+ * exact same order-processing code path once redirected to Mollie.
+ */
+const completePayPalExpressOrder = async (
+	{
+		wooCommerceApi,
+		mollieHostedCheckout,
+		orderReceived,
+		payForOrder,
+		wooCommerceOrderEdit,
+	}: Pick<
+		TestBaseExtend,
+		| 'wooCommerceApi'
+		| 'mollieHostedCheckout'
+		| 'orderReceived'
+		| 'payForOrder'
+		| 'wooCommerceOrderEdit'
+	>,
+	testData: MollieTestData.ShopOrder
+) => {
+	const { payment } = testData;
+	const { gateway } = payment;
+
+	await mollieHostedCheckout.assertUrl();
+	const orderId = await mollieHostedCheckout.captureOrderNumber();
+	await mollieHostedCheckout.payForOrder( payment );
+
+	await processMolliePaymentStatus(
+		{ mollieHostedCheckout, orderReceived, payForOrder },
+		Number( orderId ),
+		testData
+	);
+
+	const { transaction_id: transactionId } =
+		await wooCommerceApi.getOrder( orderId );
+	await expect(
+		transactionId,
+		`Assert transaction ID ${ transactionId } is defined`
+	).toBeDefined();
+
+	await wooCommerceOrderEdit.visit( orderId );
+	await wooCommerceOrderEdit.assertOrderDetails( testData, transactionId );
+
+	if ( payment.status === 'paid' ) {
+		const expectedNotes = [
+			`${ gateway.slug } payment started (${ transactionId } - test mode).`,
+			`Payment via ${ gateway.name } (${ transactionId }).`,
+			`Order completed using Mollie - ${ gateway.name } payment (${ transactionId } - test mode).`,
+		];
+		await assertOrderNotes( wooCommerceApi, orderId, expectedNotes );
+	}
+};
+
+export const testPayPalExpressProduct = (
+	testData: MollieTestData.ShopOrder
+) => {
+	const { testId, testLabel, payment } = testData;
+	const label = testLabel ? ` ${ testLabel }` : '';
+
+	test( `${ testId } | Transaction - Product - PayPal Express - Payment status ${ payment.status } creates order with expected status${ label }`, async ( {
+		wooCommerceApi,
+		product,
+		mollieHostedCheckout,
+		orderReceived,
+		payForOrder,
+		wooCommerceOrderEdit,
+		mollieApiMethod,
+	} ) => {
+		await preparePayPalExpressOrder(
+			testData,
+			wooCommerceApi,
+			mollieApiMethod
+		);
+
+		await product.visit( testData.products[ 0 ].slug );
+		await expect(
+			product.payPalExpressButton(),
+			'Assert PayPal Express button is visible on Product page'
+		).toBeVisible();
+		await product.payPalExpressButton().click();
+
+		await completePayPalExpressOrder(
+			{
+				wooCommerceApi,
+				mollieHostedCheckout,
+				orderReceived,
+				payForOrder,
+				wooCommerceOrderEdit,
+			},
+			testData
+		);
+	} );
+};
+
+export const testPayPalExpressCart = ( testData: MollieTestData.ShopOrder ) => {
+	const { testId, testLabel, payment } = testData;
+	const label = testLabel ? ` ${ testLabel }` : '';
+
+	test( `${ testId } | Transaction - Cart - PayPal Express - Payment status ${ payment.status } creates order with expected status${ label }`, async ( {
+		wooCommerceApi,
+		utils,
+		cart,
+		mollieHostedCheckout,
+		orderReceived,
+		payForOrder,
+		wooCommerceOrderEdit,
+		mollieApiMethod,
+	} ) => {
+		await preparePayPalExpressOrder(
+			testData,
+			wooCommerceApi,
+			mollieApiMethod
+		);
+
+		await utils.fillVisitorsCart( testData.products );
+		await cart.visit();
+		await expect(
+			cart.payPalExpressButton(),
+			'Assert PayPal Express button is visible on Cart page'
+		).toBeVisible();
+		await cart.payPalExpressButton().click();
+
+		await completePayPalExpressOrder(
+			{
+				wooCommerceApi,
+				mollieHostedCheckout,
+				orderReceived,
+				payForOrder,
+				wooCommerceOrderEdit,
+			},
+			testData
+		);
+	} );
+};
+
+export const testPayPalExpressCheckout = (
+	testData: MollieTestData.ShopOrder
+) => {
+	const { testId, testLabel, payment } = testData;
+	const label = testLabel ? ` ${ testLabel }` : '';
+
+	test( `${ testId } | Transaction - Checkout - PayPal Express - Payment status ${ payment.status } creates order with expected status${ label }`, async ( {
+		wooCommerceApi,
+		utils,
+		checkout,
+		mollieHostedCheckout,
+		orderReceived,
+		payForOrder,
+		wooCommerceOrderEdit,
+		mollieApiMethod,
+	} ) => {
+		await preparePayPalExpressOrder(
+			testData,
+			wooCommerceApi,
+			mollieApiMethod
+		);
+
+		await utils.fillVisitorsCart( testData.products );
+		await checkout.visit();
+		await expect(
+			checkout.payPalExpressButton(),
+			'Assert PayPal Express button is visible on Checkout page'
+		).toBeVisible();
+		await checkout.payPalExpressButton().click();
+
+		await completePayPalExpressOrder(
+			{
+				wooCommerceApi,
+				mollieHostedCheckout,
+				orderReceived,
+				payForOrder,
+				wooCommerceOrderEdit,
+			},
+			testData
+		);
+	} );
+};

--- a/tests/qa/tests/05-transaction/nl-checkout.spec.ts
+++ b/tests/qa/tests/05-transaction/nl-checkout.spec.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { testPaymentStatusOnCheckout } from './_test-scenarios';
+import { checkoutNl } from './_test-data';
+
+// Billink only works with an NL merchant profile, so this runs against a
+// dedicated NL Mollie account/shop config (see the `setup-mollie-nl` project
+// dependency) rather than the default German one the rest of 05-transaction uses.
+for ( const testData of checkoutNl ) {
+	testPaymentStatusOnCheckout( testData );
+}

--- a/tests/qa/tests/05-transaction/nl-classic-checkout.spec.ts
+++ b/tests/qa/tests/05-transaction/nl-classic-checkout.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { testPaymentStatusOnClassicCheckout } from './_test-scenarios';
+import { classicCheckoutNl } from './_test-data';
+
+// Billink only works with an NL merchant profile - the `setup-mollie-nl` project
+// dependency already handles the NL shop config/Mollie reconnect, this only
+// needs to additionally switch to classic cart/checkout pages.
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( { enableClassicPages: true } );
+} );
+
+for ( const testData of classicCheckoutNl ) {
+	testPaymentStatusOnClassicCheckout( testData );
+}

--- a/tests/qa/tests/05-transaction/nl-pay-for-order.spec.ts
+++ b/tests/qa/tests/05-transaction/nl-pay-for-order.spec.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { testPaymentStatusOnPayForOrder } from './_test-scenarios';
+import { payForOrderNl } from './_test-data';
+
+// Billink only works with an NL merchant profile, so this runs against a
+// dedicated NL Mollie account/shop config (see the `setup-mollie-nl` project
+// dependency) rather than the default German one the rest of 05-transaction uses.
+for ( const testData of payForOrderNl ) {
+	testPaymentStatusOnPayForOrder( testData );
+}

--- a/tests/qa/tests/05-transaction/paypal-express.spec.ts
+++ b/tests/qa/tests/05-transaction/paypal-express.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import {
+	testPayPalExpressProduct,
+	testPayPalExpressCart,
+	testPayPalExpressCheckout,
+} from './_test-scenarios';
+import {
+	payPalExpressProduct,
+	payPalExpressCart,
+	payPalExpressCheckout,
+} from './_test-data';
+
+// Each describe block enables only the setting it's testing (and explicitly
+// disables the other two) so the tests also double as regression coverage
+// for the cart/product/checkout display settings not leaking into each other.
+
+// Product page
+test.describe( () => {
+	test.beforeAll( async ( { mollieApi } ) => {
+		await mollieApi.updateMollieGateway( 'paypal', {
+			mollie_paypal_button_enabled_product: 'yes',
+			mollie_paypal_button_enabled_cart: 'no',
+			mollie_paypal_button_enabled_checkout: 'no',
+			mollie_paypal_button_minimum_amount: '0',
+		} );
+	} );
+
+	for ( const testData of payPalExpressProduct ) {
+		testPayPalExpressProduct( testData );
+	}
+} );
+
+// Cart page (Block cart Express Payment area)
+test.describe( () => {
+	test.beforeAll( async ( { mollieApi } ) => {
+		await mollieApi.updateMollieGateway( 'paypal', {
+			mollie_paypal_button_enabled_cart: 'yes',
+			mollie_paypal_button_enabled_product: 'no',
+			mollie_paypal_button_enabled_checkout: 'no',
+			mollie_paypal_button_minimum_amount: '0',
+		} );
+	} );
+
+	for ( const testData of payPalExpressCart ) {
+		testPayPalExpressCart( testData );
+	}
+} );
+
+// Checkout page (Block checkout Express Payment area)
+test.describe( () => {
+	test.beforeAll( async ( { mollieApi } ) => {
+		await mollieApi.updateMollieGateway( 'paypal', {
+			mollie_paypal_button_enabled_checkout: 'yes',
+			mollie_paypal_button_enabled_cart: 'no',
+			mollie_paypal_button_enabled_product: 'no',
+			mollie_paypal_button_minimum_amount: '0',
+		} );
+	} );
+
+	for ( const testData of payPalExpressCheckout ) {
+		testPayPalExpressCheckout( testData );
+	}
+} );
+
+test.afterAll( async ( { mollieApi } ) => {
+	await mollieApi.updateMollieGateway( 'paypal', {
+		mollie_paypal_button_enabled_product: 'no',
+		mollie_paypal_button_enabled_cart: 'no',
+		mollie_paypal_button_enabled_checkout: 'no',
+	} );
+} );

--- a/tests/qa/tests/06-refund/_test-data/index.ts
+++ b/tests/qa/tests/06-refund/_test-data/index.ts
@@ -1,2 +1,3 @@
 export * from './refund-base-order.data';
 export * from './refund.data';
+export * from './late-webhook-after-refund.data';

--- a/tests/qa/tests/06-refund/_test-data/late-webhook-after-refund.data.ts
+++ b/tests/qa/tests/06-refund/_test-data/late-webhook-after-refund.data.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { MollieTestData, gateways, cards } from '../../../resources';
+import { baseOrder } from './refund-base-order.data';
+
+export const lateWebhookAfterRefundEur: MollieTestData.ShopOrder[] = [
+	{
+		...baseOrder,
+		testId: 'C4567642',
+		payment: {
+			gateway: gateways.creditcard,
+			status: 'paid',
+			card: cards.visa,
+		},
+	},
+];

--- a/tests/qa/tests/06-refund/_test-data/refund.data.ts
+++ b/tests/qa/tests/06-refund/_test-data/refund.data.ts
@@ -59,6 +59,30 @@ export const refundViaWooCommerce: MollieTestData.ShopRefund[] = [
 		refundPaymentStatus: 'pending',
 		isMollieClientApiRefund: false,
 	},
+	{
+		...baseOrder,
+		testId: 'C4567635',
+		payment: {
+			gateway: gateways.klarna,
+			status: 'authorized',
+		},
+		refundPercentage: 100,
+		refundOrderStatus: 'refunded', // UNVERIFIED - confirm via real run
+		refundPaymentStatus: 'pending',
+		isMollieClientApiRefund: false,
+	},
+	{
+		...baseOrder,
+		testId: 'C4567636',
+		payment: {
+			gateway: gateways.klarna,
+			status: 'authorized',
+		},
+		refundPercentage: 50,
+		refundOrderStatus: 'completed', // UNVERIFIED - confirm via real run
+		refundPaymentStatus: 'pending',
+		isMollieClientApiRefund: false,
+	},
 ];
 
 export const refundViaMollieDashboard: MollieTestData.ShopRefund[] = [

--- a/tests/qa/tests/06-refund/_test-data/refund.data.ts
+++ b/tests/qa/tests/06-refund/_test-data/refund.data.ts
@@ -47,7 +47,7 @@ export const refundViaWooCommerce: MollieTestData.ShopRefund[] = [
 	},
 	{
 		...baseOrder,
-		testId: 'C0000',
+		testId: 'C4567633',
 		payment: {
 			gateway: gateways.creditcard,
 			status: 'paid',
@@ -104,7 +104,7 @@ export const refundViaMollieDashboard: MollieTestData.ShopRefund[] = [
 	},
 	{
 		...baseOrder,
-		testId: 'C0000',
+		testId: 'C4567634',
 		payment: {
 			gateway: gateways.creditcard,
 			status: 'paid',

--- a/tests/qa/tests/06-refund/_test-scenarios/index.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/index.ts
@@ -1,1 +1,2 @@
 export * from './refund.scenario';
+export * from './late-webhook-after-refund.scenario';

--- a/tests/qa/tests/06-refund/_test-scenarios/late-webhook-after-refund.scenario.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/late-webhook-after-refund.scenario.ts
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { countTotals, expect, WooCommerceApi } from '@inpsyde/playwright-utils/build';
+import { Client as MollieClientApi } from 'mollie-api-typescript';
+import { APIRequestContext } from '@playwright/test';
+/**
+ * Internal dependencies
+ */
+import {
+	test,
+	buildMollieGatewayLabel,
+	processMolliePaymentStatus,
+	updateCurrencyIfNeeded,
+	getOrderStatusFromMollieStatus,
+} from '../../../utils';
+import { WooCommerceOrderEdit } from '../../../utils/admin';
+import { MollieTestData, guests } from '../../../resources';
+
+/**
+ * Refunds a paid order via WooCommerce admin, then replays the original
+ * "paid" webhook Mollie already holds for the payment, and asserts the order
+ * stays refunded instead of being un-refunded by the late replay.
+ *
+ * @param param0
+ * @param param0.wooCommerceApi
+ * @param param0.wooCommerceOrderEdit
+ * @param param0.mollieClientApi
+ * @param param0.visitorRequest
+ * @param orderId
+ * @param molliePaymentId
+ * @param transactionId
+ * @param gatewayName
+ */
+const assertLateWebhookDoesNotUnrefund = async (
+	{
+		wooCommerceApi,
+		wooCommerceOrderEdit,
+		mollieClientApi,
+		visitorRequest,
+	}: {
+		wooCommerceApi: WooCommerceApi;
+		wooCommerceOrderEdit: WooCommerceOrderEdit;
+		mollieClientApi: MollieClientApi;
+		visitorRequest: APIRequestContext;
+	},
+	orderId: number,
+	molliePaymentId: string,
+	transactionId: string,
+	gatewayName: string
+) => {
+	// --- Refund the order fully via WooCommerce admin ---
+	await wooCommerceOrderEdit.visit( orderId );
+	await wooCommerceOrderEdit.refundButton().click();
+	await wooCommerceOrderEdit.makeRefund( gatewayName );
+	await wooCommerceOrderEdit.assertUrl( orderId );
+
+	const refundedOrder = await wooCommerceApi.getOrder( orderId );
+	await expect(
+		refundedOrder.status,
+		'Assert order is Refunded before replaying the webhook'
+	).toEqual( 'refunded' );
+
+	// --- Replay the webhook Mollie already holds for this payment ---
+	const payment = await mollieClientApi.payments.get( {
+		paymentId: molliePaymentId,
+	} );
+	const webhookUrl = payment.webhookUrl;
+	await expect(
+		webhookUrl,
+		'Assert the payment has a webhookUrl registered to replay'
+	).toBeTruthy();
+
+	const replayResponse = await visitorRequest.post( webhookUrl as string, {
+		form: { id: transactionId },
+	} );
+	await expect(
+		replayResponse.status(),
+		'Assert the replayed webhook is accepted (200) - a rejection would mean the secret/lookup itself is broken, not the fix under test'
+	).toBe( 200 );
+
+	// --- Fix-agnostic gate: status must not regress ---
+	const orderAfterReplay = await wooCommerceApi.getOrder( orderId );
+	await expect(
+		orderAfterReplay.status,
+		'Assert the order stays Refunded after the late webhook replay - must not flip back to Processing/Completed'
+	).toEqual( 'refunded' );
+};
+
+export const testLateWebhookAfterRefundOnCheckout = (
+	testData: MollieTestData.ShopOrder
+) => {
+	const { testId, testLabel, payment } = testData;
+	const { gateway } = payment;
+
+	const customer = guests[ gateway.country ];
+	const currency = gateway.currency;
+	Object.assign( testData, { customer, currency } );
+	const gatewayLabel = buildMollieGatewayLabel( gateway );
+	const label = testLabel ? ` ${ testLabel }` : '';
+
+	test( `${ testId } | Refund - Late webhook replay - Checkout - ${ gatewayLabel }${ label }`, async ( {
+		wooCommerceApi,
+		utils,
+		checkout,
+		mollieHostedCheckout,
+		orderReceived,
+		payForOrder,
+		wooCommerceOrderEdit,
+		mollieClientApi,
+		visitorRequest,
+		isMultistepCheckout,
+		mollieApiMethod,
+	} ) => {
+		test.setTimeout( 3 * 60_000 );
+
+		test.skip(
+			! gateway.availableForApiMethods.includes( mollieApiMethod ),
+			`Test is not eligible for ${ mollieApiMethod } API method.`
+		);
+
+		if ( ! testData.orderStatus ) {
+			testData.orderStatus = await getOrderStatusFromMollieStatus(
+				payment.status,
+				mollieApiMethod
+			);
+		}
+
+		await updateCurrencyIfNeeded( wooCommerceApi, currency );
+
+		const orderTotals = await countTotals( testData );
+		payment.amount = orderTotals.order;
+
+		await utils.fillVisitorsCart( testData.products );
+
+		await ( isMultistepCheckout
+			? checkout.makeMultistepOrder( testData )
+			: checkout.makeOrder( testData ) );
+
+		await mollieHostedCheckout.assertUrl();
+		const orderId = await mollieHostedCheckout.captureOrderNumber();
+		await mollieHostedCheckout.payForOrder( payment );
+		await processMolliePaymentStatus(
+			{ mollieHostedCheckout, orderReceived, payForOrder },
+			Number( orderId ),
+			testData
+		);
+
+		const order = await wooCommerceApi.getOrder( orderId );
+		const transactionId = order.transaction_id;
+		const molliePaymentId = order.meta_data.find(
+			( meta ) => meta.key === '_mollie_payment_id'
+		)?.value;
+		await expect(
+			molliePaymentId,
+			'Assert a Mollie payment ID was recorded on the order'
+		).toBeDefined();
+
+		await assertLateWebhookDoesNotUnrefund(
+			{ wooCommerceApi, wooCommerceOrderEdit, mollieClientApi, visitorRequest },
+			orderId,
+			molliePaymentId,
+			transactionId,
+			gateway.name
+		);
+	} );
+};

--- a/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
@@ -54,30 +54,68 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 
 	test(
 		testTitle,
-		async ( {
-			wooCommerceApi,
-			utils,
-			checkout,
-			mollieHostedCheckout,
-			mollieClientApi,
-			orderReceived,
-			payForOrder,
-			wooCommerceOrderEdit,
-			mollieApiMethod,
-		}, testInfo ) => {
+		async (
+			{
+				wooCommerceApi,
+				utils,
+				checkout,
+				mollieHostedCheckout,
+				mollieClientApi,
+				orderReceived,
+				payForOrder,
+				wooCommerceOrderEdit,
+				mollieApiMethod,
+			},
+			testInfo
+		) => {
 			// exclude tests for payment methods if not available for tested API
 			test.skip(
-				! gateway.availableForApiMethods.includes( mollieApiMethod ), 
+				! gateway.availableForApiMethods.includes( mollieApiMethod ),
 				`Test is not eligible for ${ mollieApiMethod } API method.`
 			);
 
 			// Sets the default orderStatus based on API method, if specific is not set
 			if ( ! testData.orderStatus ) {
-				testData.orderStatus =
-					await getOrderStatusFromMollieStatus( payment.status, mollieApiMethod );
+				testData.orderStatus = await getOrderStatusFromMollieStatus(
+					payment.status,
+					mollieApiMethod
+				);
 			}
-			
-			test.setTimeout( 30 * 60_000 );
+
+			// Manual-capture gateways add a ship/capture precondition on top of the
+			// existing checkout + refund-webhook waits, so give them more headroom.
+			test.setTimeout(
+				gateway.isCaptureRequired ? 40 * 60_000 : 30 * 60_000
+			);
+
+			// Manual-capture gateways (e.g. Klarna) sit authorized-but-uncaptured at
+			// Mollie after checkout - refunding now would route through Mollie's
+			// cancel-on-authorized logic instead of a genuine refund. Completing the
+			// WC order triggers shipAndCaptureOrderAtMollie() (src/Payment/PaymentModule.php),
+			// which ships the order lines at Mollie synchronously within that same
+			// request - but that PHP method catches ApiException and only logs it
+			// (no re-throw), and the WC status is already committed to "completed"
+			// *before* the hook even runs (WC's save() persists the status, then
+			// fires woocommerce_order_status_completed). So polling the WC order's
+			// own status is a tautology - it can never detect a failed/skipped
+			// capture. Poll for the specific success order note the PHP method adds
+			// instead, which is the only real signal capture actually happened.
+			const captureOrderAtMollie = async ( id: number ) => {
+				await wooCommerceApi.updateOrder( id, { status: 'completed' } );
+				await expect( async () => {
+					const notes = await wooCommerceApi.getOrderNotes( id );
+					const captured = notes.some( ( n ) =>
+						n.note.includes(
+							'successfully updated to shipped at Mollie'
+						)
+					);
+					await expect(
+						captured,
+						'Assert order was shipped/captured at Mollie (order note present)'
+					).toBe( true );
+				} ).toPass( { intervals: [ 5_000 ], timeout: 60_000 } );
+			};
+
 			let transactionId: string;
 			let molliePaymentId: string;
 			let orderId: number;
@@ -131,6 +169,11 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 				).toBeDefined();
 			} );
 
+			if ( gateway.isCaptureRequired ) {
+				await test.step( 'Precondition: capture authorized order at Mollie', () =>
+					captureOrderAtMollie( orderId ) );
+			}
+
 			// Test
 
 			// Make refund via Mollie client API
@@ -182,34 +225,62 @@ export const testRefund = ( testData: MollieTestData.ShopRefund ) => {
 				} );
 			}
 
-			await test.step( 'Wait for webhook and assert refund meta ~15 min', async () => {
-				// Assert via API WooCommerce Order refund status and presence of refunds
-				// Delayed webhooks cause following values to arrive in ~10-30 minutes after refund creation
-				await expect( async () => {
+			// `_mollie_processed_refund_ids` is only ever written by
+			// MollieOrderService::processRefunds(), which itself only runs
+			// inside the incoming-webhook handler (doPaymentForOrder()). A
+			// refund made via the Mollie client API happens entirely outside
+			// WooCommerce, so WC genuinely has no other way to learn about it
+			// - it has to wait for the next webhook to reconcile, which can
+			// take up to ~10-30 minutes.
+			// A refund made via the WooCommerce admin UI is the opposite:
+			// RefundProcessor/MollieOrder::refund() creates it at Mollie
+			// synchronously in the same request, so WC already knows about
+			// it immediately. Mollie also doesn't re-ping the webhook just
+			// because a refund was created via its API, so polling for the
+			// meta here would just wait out the full timeout for a signal
+			// that never arrives - check order.refunds instead.
+			if ( isMollieClientApiRefund ) {
+				await test.step( 'Wait for webhook and assert refund meta ~15 min', async () => {
+					await expect( async () => {
+						const order = await wooCommerceApi.getOrder( orderId );
+						orderTotal = order.total;
+						statusAfterRefund = order.status;
+						refunds = order.refunds;
+						refundMeta = order.meta_data.find(
+							( meta ) =>
+								meta.key === '_mollie_processed_refund_ids'
+						);
+
+						await expect(
+							refundMeta,
+							'Assert refund meta is defined'
+						).toBeDefined();
+						await wooCommerceOrderEdit.page.reload();
+					} ).toPass( {
+						intervals: [ 60_000 ],
+						timeout: 30 * 60_000,
+					} );
+
+					await expect(
+						refundMeta.value,
+						'Assert refund meta value has length 1'
+					).toHaveLength( 1 );
+					refundTransactionId = refundMeta.value[ 0 ];
+				} );
+			} else {
+				await test.step( 'Assert refund is reflected on the order', async () => {
 					const order = await wooCommerceApi.getOrder( orderId );
 					orderTotal = order.total;
 					statusAfterRefund = order.status;
 					refunds = order.refunds;
-					refundMeta = order.meta_data.find(
-						( meta ) => meta.key === '_mollie_processed_refund_ids'
-					);
 
 					await expect(
-						refundMeta,
-						'Assert refund meta is defined'
-					).toBeDefined();
-					await wooCommerceOrderEdit.page.reload();
-				} ).toPass( {
-					intervals: [ 60_000 ],
-					timeout: 30 * 60_000,
+						refunds,
+						'Assert refund is present on the order'
+					).toHaveLength( 1 );
+					refundTransactionId = refunds[ 0 ].id;
 				} );
-
-				await expect(
-					refundMeta.value,
-					'Assert refund meta value has length 1'
-				).toHaveLength( 1 );
-				refundTransactionId = refundMeta.value[ 0 ];
-			} );
+			}
 
 			await test.step( 'Assert refund details', async ( step ) => {
 				step.skip(

--- a/tests/qa/tests/06-refund/refund-late-webhook-replay.spec.ts
+++ b/tests/qa/tests/06-refund/refund-late-webhook-replay.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { testLateWebhookAfterRefundOnCheckout } from './_test-scenarios';
+import { lateWebhookAfterRefundEur } from './_test-data';
+import { shopConfigDefault } from '../../resources';
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( shopConfigDefault );
+	await utils.installAndActivateMollie();
+	await utils.cleanReconnectMollie();
+} );
+
+for ( const testData of lateWebhookAfterRefundEur ) {
+	testLateWebhookAfterRefundOnCheckout( testData );
+}

--- a/tests/qa/tests/08-bug-verification/piwoo-890.spec.ts
+++ b/tests/qa/tests/08-bug-verification/piwoo-890.spec.ts
@@ -140,7 +140,7 @@ test.describe( 'Order-received page double-counted after Mollie return (PIWOO-89
 		return responses;
 	};
 
-	test( 'Nothing broke: the order confirmation page still loads and displays correctly after paying with Mollie', async ( {
+	test( 'C4567603 | Nothing broke: the order confirmation page still loads and displays correctly after paying with Mollie', async ( {
 		utils,
 		checkout,
 		mollieHostedCheckout,
@@ -215,7 +215,7 @@ test.describe( 'Order-received page double-counted after Mollie return (PIWOO-89
 		}
 	} );
 
-	test( 'The thank-you page is observed as such exactly once across the whole Mollie return redirect chain', async ( {
+	test( 'C4567604 | The thank-you page is observed as such exactly once across the whole Mollie return redirect chain', async ( {
 		utils,
 		checkout,
 		mollieHostedCheckout,

--- a/tests/qa/tests/08-bug-verification/piwoo-910-webhook-authentication.spec.ts
+++ b/tests/qa/tests/08-bug-verification/piwoo-910-webhook-authentication.spec.ts
@@ -49,7 +49,7 @@ test.beforeAll( async ( { utils } ) => {
 } );
 
 test.describe( 'Webhook authentication (mollie_webhook_secret)', () => {
-	test( 'REST webhook rejects requests with no secret, a wrong secret, or an unknown transaction', async ( {
+	test( 'C4567601 | REST webhook rejects requests with no secret, a wrong secret, or an unknown transaction', async ( {
 		visitorRequest,
 		requestUtils,
 	} ) => {
@@ -103,7 +103,7 @@ test.describe( 'Webhook authentication (mollie_webhook_secret)', () => {
 		).toBe( 401 );
 	} );
 
-	test( 'A real Mollie payment still completes the order automatically, and the webhook endpoint accepts the secret it embeds', async ( {
+	test( 'C4567602 | A real Mollie payment still completes the order automatically, and the webhook endpoint accepts the secret it embeds', async ( {
 		utils,
 		checkout,
 		mollieHostedCheckout,

--- a/tests/qa/tests/08-bug-verification/piwoo-923-late-webhook-replay.spec.ts
+++ b/tests/qa/tests/08-bug-verification/piwoo-923-late-webhook-replay.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Verifies PIWOO-923 ("late paid webhook after refund silently un-refunds a
+ * pay-later order"). Per the report, MollieOrderService::orderNeedsPayment()
+ * (MollieOrderService.php:334-363) unconditionally returns true for any
+ * order carrying `_mollie_authorized = '1'`, regardless of the order's
+ * current status or refund state. That meta is set once by
+ * onWebhookAuthorized() and never cleared, so a late/duplicate webhook
+ * delivered by Mollie after a pay-later (authorize-then-capture) order has
+ * already been refunded still reaches doPaymentForOrder()'s "order doesn't
+ * need payment" dispatch (MollieOrderService.php:275-288) and is routed to
+ * the matching onWebhook*() handler by live Mollie status - never checking
+ * amountRefunded or the order's own WooCommerce status.
+ *
+ * For Klarna specifically (Orders API), a captured order's live Mollie
+ * status is "completed", so the handler actually invoked on replay is
+ * onWebhookCompleted() (WebhookHandler.php:185-243), not onWebhookPaid() -
+ * same missing-guard defect, different method name, since Mollie's Payments
+ * API "paid" and Orders API "completed" are the two names for "this
+ * transaction settled" that the ticket's onWebhookPaid example generalizes
+ * over. Both unconditionally call $order->payment_complete(), which can
+ * flip an already-Refunded order back to Processing/Completed.
+ *
+ * This can't be observed by waiting for a real duplicate webhook - Mollie's
+ * redelivery timing isn't controllable from a test and there's no guarantee
+ * one arrives during a test run. Instead, this replays the webhook
+ * directly: RestApi::callback() (RestApi.php) authenticates a POST to
+ * /wp-json/mollie/v1/webhook via the mollie_webhook_secret embedded in the
+ * webhookUrl Mollie already holds for the payment (same mechanism verified
+ * in piwoo-910-webhook-authentication.spec.ts). Mollie's Payment/Order
+ * resources have no "refunded" status value - status stays "completed"
+ * forever once captured (refund info is carried separately via
+ * amountRefunded/_links.refunds) - so POSTing to that same webhookUrl again
+ * after the order has been refunded reproduces exactly the payload a
+ * genuine late redelivery would carry, deterministically and on demand.
+ *
+ * Out of scope here: the equivalent race for late "canceled"/"failed"
+ * webhooks against an already-settled order (same ticket, and PIWOO-927 for
+ * the canceled case specifically) - reproducing those needs a second,
+ * superseded payment attempt on the same order, which this spec doesn't set
+ * up. Also out of scope: whether stock is genuinely double-reduced - WC
+ * core guards reduce_stock via a `_reduced_stock` order-meta flag
+ * independent of this bug, so the stock assertion below is a soft
+ * diagnostic, not the fix-agnostic gate.
+ */
+
+/**
+ * External dependencies
+ */
+import { countTotals } from '@inpsyde/playwright-utils/build';
+/**
+ * Internal dependencies
+ */
+import { test, expect, processMolliePaymentStatus } from '../../utils';
+import {
+	gateways,
+	orders,
+	products,
+	shopConfigDefault,
+	MollieTestData,
+} from '../../resources';
+
+const STOCK_BASELINE = 100;
+
+const testOrder: MollieTestData.ShopOrder = {
+	...orders.default,
+	products: [ products.mollieSimple100 ],
+	payment: { gateway: gateways.klarna, status: 'authorized' },
+};
+
+let testProductId: number;
+
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
+	await utils.configureStore( shopConfigDefault );
+	await utils.installAndActivateMollie();
+	await utils.cleanReconnectMollie();
+
+	const product = await wooCommerceApi.getProductBySlug(
+		products.mollieSimple100.slug
+	);
+	testProductId = product.id;
+	await wooCommerceApi.updateProduct( testProductId, {
+		manage_stock: true,
+		stock_quantity: STOCK_BASELINE,
+	} );
+} );
+
+test.afterAll( async ( { wooCommerceApi } ) => {
+	// mollieSimple100 is shared across the whole suite - put it back to its
+	// default (unmanaged) stock state so other specs aren't affected by this
+	// spec's stock tracking.
+	await wooCommerceApi.updateProduct( testProductId, {
+		manage_stock: false,
+	} );
+} );
+
+test( 'C4567637 | A late "completed" webhook replay must not un-refund an already-refunded Klarna order', async ( {
+	utils,
+	checkout,
+	mollieHostedCheckout,
+	payForOrder,
+	orderReceived,
+	wooCommerceApi,
+	wooCommerceOrderEdit,
+	mollieClientApi,
+	visitorRequest,
+} ) => {
+	test.setTimeout( 3 * 60_000 );
+
+	// --- Precondition: place and authorize a Klarna (pay-later) order ---
+	const orderTotals = await countTotals( testOrder );
+	testOrder.payment.amount = orderTotals.order;
+
+	await utils.fillVisitorsCart( testOrder.products );
+	await checkout.makeOrder( testOrder );
+	await mollieHostedCheckout.assertUrl();
+	const orderId = await mollieHostedCheckout.captureOrderNumber();
+	await mollieHostedCheckout.payForOrder( testOrder.payment );
+	await processMolliePaymentStatus(
+		{ mollieHostedCheckout, orderReceived, payForOrder },
+		Number( orderId ),
+		testOrder
+	);
+
+	const authorizedOrder = await wooCommerceApi.getOrder( orderId );
+	const transactionId = authorizedOrder.transaction_id;
+	const molliePaymentId = authorizedOrder.meta_data.find(
+		( meta ) => meta.key === '_mollie_payment_id'
+	)?.value;
+	await expect(
+		molliePaymentId,
+		'Assert a Mollie payment ID was recorded on the order'
+	).toBeDefined();
+
+	// --- Precondition: capture (ship) the order at Mollie ---
+	// Polling the WC order's own status here would be a tautology - WC
+	// commits "completed" before the capture hook that calls Mollie even
+	// runs. Poll for the specific success order note instead. Klarna's
+	// authorize->capture can land on either the Orders API (shipAll) or the
+	// Payments API (manual capture) depending on the store's api_switch
+	// setting, and each writes a different note - accept either.
+	await wooCommerceApi.updateOrder( orderId, { status: 'completed' } );
+	await expect( async () => {
+		const notes = await wooCommerceApi.getOrderNotes( orderId );
+		const captured = notes.some(
+			( note ) =>
+				note.note.includes( 'successfully updated to shipped at Mollie' ) ||
+				note.note.includes( 'payment capture of' )
+		);
+		await expect(
+			captured,
+			'Assert order was shipped/captured at Mollie (order note present)'
+		).toBe( true );
+	} ).toPass( { intervals: [ 5_000 ], timeout: 60_000 } );
+
+	const capturedProduct = await wooCommerceApi.getProduct( testProductId );
+	const stockAfterCapture = capturedProduct.stock_quantity;
+	await expect
+		.soft(
+			stockAfterCapture,
+			'Diagnostic: stock reduced once for the authorized order'
+		)
+		.toBeLessThan( STOCK_BASELINE );
+
+	// --- Refund the order fully via WooCommerce admin ---
+	await wooCommerceOrderEdit.visit( orderId );
+	await wooCommerceOrderEdit.refundButton().click();
+	await wooCommerceOrderEdit.makeRefund( testOrder.payment.gateway.name );
+	await wooCommerceOrderEdit.assertUrl( orderId );
+
+	const refundedOrder = await wooCommerceApi.getOrder( orderId );
+	await expect(
+		refundedOrder.status,
+		'Assert order is Refunded before replaying the webhook'
+	).toEqual( 'refunded' );
+
+	const stockAfterRefund = (
+		await wooCommerceApi.getProduct( testProductId )
+	).stock_quantity;
+
+	// --- Replay the webhook Mollie already holds for this payment ---
+	const payment = await mollieClientApi.payments.get( {
+		paymentId: molliePaymentId,
+	} );
+	const webhookUrl = payment.webhookUrl;
+	await expect(
+		webhookUrl,
+		'Assert the payment has a webhookUrl registered to replay'
+	).toBeTruthy();
+
+	const replayResponse = await visitorRequest.post( webhookUrl as string, {
+		form: { id: transactionId },
+	} );
+	await expect(
+		replayResponse.status(),
+		'Assert the replayed webhook is accepted (200) - a rejection would mean the secret/lookup itself is broken, not the fix under test'
+	).toBe( 200 );
+
+	// --- The fix-agnostic gate: status must not regress ---
+	const orderAfterReplay = await wooCommerceApi.getOrder( orderId );
+	await expect(
+		orderAfterReplay.status,
+		'Assert the order stays Refunded after the late webhook replay - must not flip back to Processing/Completed'
+	).toEqual( 'refunded' );
+
+	// --- Diagnostics: informative, not a hard gate (see file header) ---
+	await expect
+		.soft(
+			orderAfterReplay.refunds.map( ( refund ) => refund.total ),
+			'Diagnostic: refund record(s) must not be lost'
+		)
+		.toEqual( refundedOrder.refunds.map( ( refund ) => refund.total ) );
+
+	const stockAfterReplay = (
+		await wooCommerceApi.getProduct( testProductId )
+	).stock_quantity;
+	await expect
+		.soft(
+			stockAfterReplay,
+			'Diagnostic: stock must not be reduced a second time by a re-run payment_complete()'
+		)
+		.toEqual( stockAfterRefund );
+
+	const notesAfterReplay = await wooCommerceApi.getOrderNotes( orderId );
+	await expect
+		.soft(
+			notesAfterReplay.some( ( note ) =>
+				note.note.includes( 'Order completed at Mollie for' )
+			),
+			'Diagnostic: an onWebhookCompleted() note appearing here is direct evidence the handler re-ran against a refunded order'
+		)
+		.toBe( false );
+} );

--- a/tests/qa/tests/09-payment-status-transition/_test-data/eur-checkout-transition.data.ts
+++ b/tests/qa/tests/09-payment-status-transition/_test-data/eur-checkout-transition.data.ts
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { MollieTestData, gateways } from '../../../resources';
+import { baseOrder } from './transaction-base-order-transition.data';
+
+export const checkoutTransitionsEur: MollieTestData.ShopOrderTransition[] = [
+	{
+		...baseOrder,
+		testId: 'C4567638',
+		transition: 'onHoldToFinal',
+		payment: {
+			gateway: gateways.banktransfer,
+			status: 'canceled',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567639',
+		transition: 'onHoldToFinal',
+		payment: {
+			gateway: gateways.banktransfer,
+			status: 'expired',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567640',
+		transition: 'onHoldToFinal',
+		payment: {
+			gateway: gateways.banktransfer,
+			status: 'paid',
+		},
+	},
+	{
+		...baseOrder,
+		testId: 'C4567641',
+		transition: 'authorizedToVoided',
+		payment: {
+			gateway: gateways.klarna,
+			status: 'authorized',
+		},
+	},
+];

--- a/tests/qa/tests/09-payment-status-transition/_test-data/index.ts
+++ b/tests/qa/tests/09-payment-status-transition/_test-data/index.ts
@@ -1,0 +1,2 @@
+export * from './transaction-base-order-transition.data';
+export * from './eur-checkout-transition.data';

--- a/tests/qa/tests/09-payment-status-transition/_test-data/transaction-base-order-transition.data.ts
+++ b/tests/qa/tests/09-payment-status-transition/_test-data/transaction-base-order-transition.data.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { orders, MollieTestData, products } from '../../../resources';
+
+export const baseOrder: MollieTestData.ShopOrder = {
+	...orders.default,
+	products: [ products.mollieSimple100 ],
+};

--- a/tests/qa/tests/09-payment-status-transition/_test-scenarios/checkout-transition.scenario.ts
+++ b/tests/qa/tests/09-payment-status-transition/_test-scenarios/checkout-transition.scenario.ts
@@ -1,0 +1,281 @@
+/**
+ * External dependencies
+ */
+import { countTotals, expect, WooCommerceApi } from '@inpsyde/playwright-utils/build';
+import { Client as MollieClientApi } from 'mollie-api-typescript';
+/**
+ * Internal dependencies
+ */
+import {
+	test,
+	buildMollieGatewayLabel,
+	processMolliePaymentStatus,
+	updateCurrencyIfNeeded,
+	getOrderStatusFromMollieStatus,
+} from '../../../utils';
+import { MollieTestData, MollieSettings, guests } from '../../../resources';
+
+/**
+ * Only banktransfer/directdebit are driven to "on-hold" at checkout
+ * (PaymentProcessor::updatePaymentStatusForDelayedMethods() hardcodes it to
+ * those two). Other `confirmationDelayed` gateways (e.g. iDEAL) stay
+ * "pending" the whole time - never visibly on-hold.
+ *
+ * Timing: on-hold is set the instant WC creates the order, before the
+ * customer touches Mollie's checkout page. Any action there lets WC's return
+ * handler process the live status and move the order on - so `order` must be
+ * fetched right after redirect, before any page interaction, or this check
+ * reliably loses the race. Soft assertion as a safety net only; expected to
+ * pass.
+ *
+ * Only for "expired"/"paid": Mollie's API can't force a second, independent
+ * webhook for those after the fact (unlike "canceled" - see
+ * assertOnHoldCancelledByMollie).
+ *
+ * @param order
+ */
+const assertStartsOnHold = async (
+	order: Awaited< ReturnType< WooCommerceApi[ 'getOrder' ] > >
+) => {
+	await expect
+		.soft(
+			order.status,
+			'Assert order genuinely starts on-hold before settling to its final status'
+		)
+		.toEqual( 'on-hold' );
+};
+
+/**
+ * Deterministic version of the on-hold -> cancelled transition: instead of
+ * picking "canceled" directly on the Mollie hosted checkout page (a single
+ * webhook that may never leave the order observably on-hold), this hard-
+ * asserts the order is on-hold right after checkout (the order's real
+ * initial status - see assertStartsOnHold), then cancels the payment through
+ * the real Mollie API - no need to interact with Mollie's checkout page at
+ * all. No sandbox-timing race: on-hold and cancelled are each backed by
+ * their own real, independently-verified state.
+ *
+ * @param param0
+ * @param param0.wooCommerceApi
+ * @param param0.mollieClientApi
+ * @param orderId
+ * @param molliePaymentId
+ * @param mollieApiMethod
+ */
+const assertOnHoldCancelledByMollie = async (
+	{
+		wooCommerceApi,
+		mollieClientApi,
+	}: {
+		wooCommerceApi: WooCommerceApi;
+		mollieClientApi: MollieClientApi;
+	},
+	orderId: number,
+	molliePaymentId: string,
+	mollieApiMethod: MollieSettings.ApiMethod
+) => {
+	const order = await wooCommerceApi.getOrder( orderId );
+	await expect(
+		order.status,
+		'Assert the order is genuinely on-hold before Mollie cancels the payment'
+	).toEqual( 'on-hold' );
+
+	await mollieClientApi.payments.cancel( { paymentId: molliePaymentId } );
+
+	const expectedStatus = getOrderStatusFromMollieStatus(
+		'canceled',
+		mollieApiMethod
+	);
+	await expect( async () => {
+		const orderAfterCancel = await wooCommerceApi.getOrder( orderId );
+		await expect(
+			orderAfterCancel.status,
+			`Assert the order settles to "${ expectedStatus }" after Mollie cancels the still on-hold payment`
+		).toEqual( expectedStatus );
+	} ).toPass( { intervals: [ 5_000 ], timeout: 60_000 } );
+};
+
+/**
+ * Drives an authorized-but-uncaptured (manual-capture) order to "cancelled"
+ * and asserts the plugin's StateChangeCapture -> VoidPayment path actually
+ * voided the payment at Mollie. VoidPayment adds no order note on success
+ * (src/MerchantCapture/Capture/Action/VoidPayment.php only notes on failure),
+ * so the Mollie payment's own status is the only reliable signal.
+ *
+ * UNVERIFIED: assumes the "on_status_change_enabled" merchant-capture setting
+ * is enabled on the test shop by default - confirm via a real run, and if it
+ * isn't, this needs a utils.configureStore()-style precondition first.
+ *
+ * @param param0
+ * @param param0.wooCommerceApi
+ * @param param0.mollieClientApi
+ * @param orderId
+ * @param molliePaymentId
+ */
+const voidAuthorizedOrder = async (
+	{
+		wooCommerceApi,
+		mollieClientApi,
+	}: {
+		wooCommerceApi: WooCommerceApi;
+		mollieClientApi: MollieClientApi;
+	},
+	orderId: number,
+	molliePaymentId: string
+) => {
+	await wooCommerceApi.updateOrder( orderId, { status: 'cancelled' } );
+
+	await expect( async () => {
+		const payment = await mollieClientApi.payments.get( {
+			paymentId: molliePaymentId,
+		} );
+		await expect(
+			payment.status,
+			'Assert the Mollie payment was voided after the merchant cancelled the still-authorized order'
+		).toEqual( 'canceled' );
+	} ).toPass( { intervals: [ 5_000 ], timeout: 60_000 } );
+
+	const orderAfterVoid = await wooCommerceApi.getOrder( orderId );
+	await expect(
+		orderAfterVoid.status,
+		'Assert the WooCommerce order reflects the cancellation'
+	).toEqual( 'cancelled' );
+};
+
+export const testOrderStatusTransitionOnCheckout = (
+	testData: MollieTestData.ShopOrderTransition
+) => {
+	const { testId, testLabel, payment, transition } = testData;
+	const { gateway } = payment;
+
+	const customer = guests[ gateway.country ];
+	const currency = gateway.currency;
+	Object.assign( testData, { customer, currency } );
+	const gatewayLabel = buildMollieGatewayLabel( gateway );
+	const label = testLabel ? ` ${ testLabel }` : '';
+
+	test( `${ testId } | Transaction - Checkout - ${ gatewayLabel } - Payment status ${ payment.status } - Transition ${ transition }${ label }`, async ( {
+		wooCommerceApi,
+		utils,
+		checkout,
+		mollieHostedCheckout,
+		orderReceived,
+		payForOrder,
+		mollieClientApi,
+		isMultistepCheckout,
+		mollieApiMethod,
+	} ) => {
+		test.setTimeout( 3 * 60_000 );
+
+		// exclude tests for payment methods if not available for tested API
+		test.skip(
+			! gateway.availableForApiMethods.includes( mollieApiMethod ),
+			`Test is not eligible for ${ mollieApiMethod } API method.`
+		);
+
+		if ( ! testData.orderStatus ) {
+			testData.orderStatus = await getOrderStatusFromMollieStatus(
+				payment.status,
+				mollieApiMethod
+			);
+		}
+
+		await updateCurrencyIfNeeded( wooCommerceApi, currency );
+
+		const orderTotals = await countTotals( testData );
+		payment.amount = orderTotals.order;
+
+		await utils.fillVisitorsCart( testData.products );
+
+		await ( isMultistepCheckout
+			? checkout.makeMultistepOrder( testData )
+			: checkout.makeOrder( testData ) );
+
+		await mollieHostedCheckout.assertUrl();
+		const orderId = await mollieHostedCheckout.captureOrderNumber();
+
+		if ( transition === 'onHoldToFinal' ) {
+			// "on-hold" is the order's real initial status
+			// (AbstractPaymentMethod::getInitialOrderStatus()), set the
+			// instant WC creates the order - before the customer does
+			// anything on Mollie's checkout page. Once they complete any
+			// action there (even just picking "open"), WC's return handler
+			// processes the live payment status and moves the order on (to
+			// "pending"), so it must be checked here, before any page
+			// interaction, not afterward.
+			const orderBeforePayment = await wooCommerceApi.getOrder( orderId );
+			const molliePaymentId = orderBeforePayment.meta_data.find(
+				( meta ) => meta.key === '_mollie_payment_id'
+			)?.value;
+			await expect(
+				molliePaymentId,
+				'Assert a Mollie payment ID was recorded on the order'
+			).toBeDefined();
+
+			if ( payment.status === 'canceled' ) {
+				// Deterministic: cancel the still-open payment directly via
+				// the Mollie API - no need to interact with the checkout
+				// page at all (see assertOnHoldCancelledByMollie).
+				await assertOnHoldCancelledByMollie(
+					{ wooCommerceApi, mollieClientApi },
+					orderId,
+					molliePaymentId,
+					mollieApiMethod
+				);
+				return;
+			}
+
+			// expired / paid: Mollie's API offers no way to force a second
+			// webhook after the fact, so fall back to a single sandbox
+			// click. (A "pending" case was considered too, to verify
+			// onWebhookPending() genuinely never moves the order - but
+			// Mollie's test-mode simulator doesn't offer "pending" as a
+			// selectable outcome for banktransfer, only Open/Paid/Expired,
+			// so there's no way to trigger it through this mechanism.)
+			await assertStartsOnHold( orderBeforePayment );
+			await mollieHostedCheckout.payForOrder( payment );
+			await processMolliePaymentStatus(
+				{ mollieHostedCheckout, orderReceived, payForOrder },
+				Number( orderId ),
+				testData
+			);
+
+			// processMolliePaymentStatus only checks page-redirect behavior,
+			// not the order's actual status - assert that explicitly too.
+			await expect( async () => {
+				const orderAfterPayment = await wooCommerceApi.getOrder( orderId );
+				await expect(
+					orderAfterPayment.status,
+					`Assert the order settles to "${ testData.orderStatus }"`
+				).toEqual( testData.orderStatus );
+			} ).toPass( { intervals: [ 5_000 ], timeout: 60_000 } );
+			return;
+		}
+
+		// authorizedToVoided needs the order to settle first (authorized),
+		// so drive that via the sandbox.
+		await mollieHostedCheckout.payForOrder( payment );
+		await processMolliePaymentStatus(
+			{ mollieHostedCheckout, orderReceived, payForOrder },
+			Number( orderId ),
+			testData
+		);
+
+		const order = await wooCommerceApi.getOrder( orderId );
+		const molliePaymentId = order.meta_data.find(
+			( meta ) => meta.key === '_mollie_payment_id'
+		)?.value;
+		await expect(
+			molliePaymentId,
+			'Assert a Mollie payment ID was recorded on the order'
+		).toBeDefined();
+
+		if ( transition === 'authorizedToVoided' ) {
+			await voidAuthorizedOrder(
+				{ wooCommerceApi, mollieClientApi },
+				orderId,
+				molliePaymentId
+			);
+		}
+	} );
+};

--- a/tests/qa/tests/09-payment-status-transition/_test-scenarios/index.ts
+++ b/tests/qa/tests/09-payment-status-transition/_test-scenarios/index.ts
@@ -1,0 +1,1 @@
+export * from './checkout-transition.scenario';

--- a/tests/qa/tests/09-payment-status-transition/eur-block-transition.spec.ts
+++ b/tests/qa/tests/09-payment-status-transition/eur-block-transition.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { testOrderStatusTransitionOnCheckout } from './_test-scenarios';
+import { checkoutTransitionsEur } from './_test-data';
+import { shopConfigDefault } from '../../resources';
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( shopConfigDefault );
+	await utils.installAndActivateMollie();
+	await utils.cleanReconnectMollie();
+} );
+
+for ( const testData of checkoutTransitionsEur ) {
+	testOrderStatusTransitionOnCheckout( testData );
+}

--- a/tests/qa/tests/_setup/mollie.setup.ts
+++ b/tests/qa/tests/_setup/mollie.setup.ts
@@ -2,7 +2,11 @@
  * Internal dependencies
  */
 import { test as setup } from '../../utils';
-import { shopConfigDefault } from '../../resources';
+import {
+	shopConfigDefault,
+	shopConfigNetherlands,
+	mollieApiKeys,
+} from '../../resources';
 
 // --- Mollie Germany ---
 
@@ -10,6 +14,14 @@ setup( 'setup:mollie;', async ( { utils } ) => {
 	await utils.configureStore( shopConfigDefault );
 	await utils.installAndActivateMollie();
 	await utils.cleanReconnectMollie();
+} );
+
+// --- Mollie Netherlands (Billink) ---
+
+setup( 'setup:mollie:nl;', async ( { utils } ) => {
+	await utils.configureStore( shopConfigNetherlands );
+	await utils.installAndActivateMollie();
+	await utils.cleanReconnectMollie( mollieApiKeys.nl );
 } );
 
 // --- Setup specific Mollie API (assumes Mollie is already installed) ---

--- a/tests/qa/tests/_setup/multistep.setup.ts
+++ b/tests/qa/tests/_setup/multistep.setup.ts
@@ -99,5 +99,35 @@ setup(
 				).toBeOK();
 			}
 		);
+
+		await setup.step(
+			'Disable Germanized Legal Checkboxes (terms)',
+			async () => {
+				const url = urls.germanized.admin.checkboxes.legal;
+				const wpnonce = await requestUtils.getPageNonce( url );
+				const response = await requestUtils.request.post( url, {
+					form: {
+						woocommerce_gzd_checkboxes_terms_admin_name: 'Legal',
+						woocommerce_gzd_checkboxes_terms_admin_desc:
+							'General legal checkbox which shall include terms and cancellation policy.',
+						woocommerce_gzd_checkboxes_terms_label:
+							'With your order, you agree to have read and understood our {term_link}Terms and Conditions{/term_link} and {revocation_link}Cancellation Policy{/revocation_link}.',
+						woocommerce_gzd_checkboxes_terms_error_message:
+							'To complete the order you have to accept to our {term_link}Terms and Conditions{/term_link} and {revocation_link}Cancellation Policy{/revocation_link}.',
+						woocommerce_gzd_checkboxes_terms_is_mandatory: '1',
+						woocommerce_gzd_checkboxes_terms_template_name:
+							'checkout/terms.php',
+						woocommerce_gzd_checkboxes_terms_html_id: 'legal',
+						woocommerce_gzd_checkboxes_terms_html_name: 'legal',
+						save: 'Save changes',
+						_wpnonce: wpnonce,
+					},
+				} );
+				await expect(
+					response,
+					'Assert Germanized Legal Checkboxes (terms) is disabled successfully'
+				).toBeOK();
+			}
+		);
 	}
 );

--- a/tests/qa/utils/frontend/cart.ts
+++ b/tests/qa/utils/frontend/cart.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { Locator } from '@playwright/test';
+import { Cart as CartBase } from '@inpsyde/playwright-utils/build';
+
+export class Cart extends CartBase {
+	// Locators
+	payPalExpressButton = (): Locator =>
+		this.page
+			.locator( '#mollie-PayPal-button' )
+			.locator( 'input[type="image"], button' );
+}

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -292,12 +292,11 @@ export class Checkout extends CheckoutBase {
 		await this.continueWithConfirmationButton().click();
 		await this.page.waitForLoadState();
 
-		// Terms and conditions checkbox was removed (found on 04.12.2025)
-		await expect(
-			this.termsAndConditionsCheckbox(),
-			'Assert terms and conditions checkbox is visible'
-		).toBeVisible();
-		await this.termsAndConditionsCheckbox().check();
+		// await expect(
+		// 	this.termsAndConditionsCheckbox(),
+		// 	'Assert terms and conditions checkbox is visible'
+		// ).toBeVisible();
+		// await this.termsAndConditionsCheckbox().check();
 
 		await this.placeOrder();
 	};

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -60,6 +60,11 @@ export class Checkout extends CheckoutBase {
 			`label[for="radio-control-wc-payment-method-options-mollie_wc_gateway_${ slug }"]`
 		);
 
+	payPalExpressButton = (): Locator =>
+		this.page
+			.locator( '#mollie-PayPal-button' )
+			.locator( 'input[type="image"], button' );
+
 	paymentOptionLogo = ( name: string ): Locator =>
 		this.paymentOptionsContainer()
 			.locator( '.wc-block-components-radio-control__option', {

--- a/tests/qa/utils/frontend/classic-checkout.ts
+++ b/tests/qa/utils/frontend/classic-checkout.ts
@@ -291,11 +291,11 @@ export class ClassicCheckout extends ClassicCheckoutBase {
 		await this.selectShippingMethod( order.shipping.settings.title );
 		await this.page.waitForTimeout( 1000 );
 		await this.page.waitForLoadState( 'networkidle' );
-		await expect(
-			this.termsAndConditionsCheckbox(),
-			'Assert terms and conditions checkbox is visible'
-		).toBeVisible();
-		await this.termsAndConditionsCheckbox().check();
+		// await expect(
+		// 	this.termsAndConditionsCheckbox(),
+		// 	'Assert terms and conditions checkbox is visible'
+		// ).toBeVisible();
+		// await this.termsAndConditionsCheckbox().check();
 
 		await this.placeOrder();
 	};

--- a/tests/qa/utils/frontend/index.ts
+++ b/tests/qa/utils/frontend/index.ts
@@ -2,3 +2,5 @@ export * from './checkout';
 export * from './classic-checkout';
 export * from './pay-for-order';
 export * from './mollie-hosted-checkout';
+export * from './product';
+export * from './cart';

--- a/tests/qa/utils/frontend/product.ts
+++ b/tests/qa/utils/frontend/product.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { Locator } from '@playwright/test';
+import { Product as ProductBase } from '@inpsyde/playwright-utils/build';
+
+export class Product extends ProductBase {
+	// Locators
+	payPalExpressButton = (): Locator =>
+		this.page
+			.locator( '#mollie-PayPal-button' )
+			.locator( 'input[type="image"], button' );
+}

--- a/tests/qa/utils/helpers/env.helper.ts
+++ b/tests/qa/utils/helpers/env.helper.ts
@@ -48,7 +48,7 @@ export const resetEnvironment = async (): Promise< void > => {
 	} else if ( envType === 'ssh' ) {
 		checkEnvVars( [ 'SSH_LOGIN', 'SSH_HOST', 'SSH_PORT' ] );
 
-		const WP_VERSION = process.env.WP_VERSION ?? '6.9';
+		const WP_VERSION = process.env.WP_VERSION ?? '7.1';
 		const WP_TYPE = process.env.WP_TYPE ?? 'single';
 		const remoteCmd = `$HOME/bin/reset-wp.sh --wp-version=${ WP_VERSION } --wp-type=${ WP_TYPE }`;
 

--- a/tests/qa/utils/test.ts
+++ b/tests/qa/utils/test.ts
@@ -34,6 +34,8 @@ import {
 	ClassicCheckout,
 	PayForOrder,
 	MollieHostedCheckout,
+	Product,
+	Cart,
 } from './frontend';
 import { MollieApi, Utils } from '.';
 import { MollieSettings } from '../resources';
@@ -63,6 +65,8 @@ type TestBaseExtend = BaseExtend & {
 	payForOrder: PayForOrder;
 	orderReceived: OrderReceived;
 	mollieHostedCheckout: MollieHostedCheckout;
+	product: Product;
+	cart: Cart;
 
 	// Complex fixtures
 	utils: Utils;
@@ -172,6 +176,12 @@ const test = base.extend< TestBaseExtend >( {
 	},
 	mollieHostedCheckout: async ( { visitorPage }, use ) => {
 		await use( new MollieHostedCheckout( { page: visitorPage } ) );
+	},
+	product: async ( { visitorPage }, use ) => {
+		await use( new Product( { page: visitorPage } ) );
+	},
+	cart: async ( { visitorPage }, use ) => {
+		await use( new Cart( { page: visitorPage } ) );
 	},
 
 	// Complex fixtures

--- a/tests/qa/utils/urls.ts
+++ b/tests/qa/utils/urls.ts
@@ -36,6 +36,9 @@ export const urls = {
 				additionalCosts:
 					'./wp-admin/admin.php?page=wc-settings&tab=germanized-taxes&section=additional_costs',
 			},
+			checkboxes: {
+				legal: './wp-admin/admin.php?page=wc-settings&tab=germanized-checkboxes&checkbox_id=terms',
+			},
 		},
 	},
 };

--- a/tests/qa/utils/utils.ts
+++ b/tests/qa/utils/utils.ts
@@ -76,11 +76,16 @@ export class Utils {
 	 * 	- Clears Mollie DB
 	 * 	- Sets mollie API keys
 	 * 	- Sets API method (Payment or Order API)
+	 *
+	 * @param apiKeys defaults to mollieApiKeys.default; pass a different key set
+	 *                (e.g. mollieApiKeys.nl) for tests needing another merchant profile.
 	 */
-	cleanReconnectMollie = async () => {
-		await this.mollieApi.setMollieApiKeys( mollieApiKeys.default );
+	cleanReconnectMollie = async (
+		apiKeys: MollieSettings.ApiKeys = mollieApiKeys.default
+	) => {
+		await this.mollieApi.setMollieApiKeys( apiKeys );
 		await this.mollieApi.cleanMollieDb();
-		await this.mollieApi.setMollieApiKeys( mollieApiKeys.default );
+		await this.mollieApi.setMollieApiKeys( apiKeys );
 		await this.mollieApi.setAdvancedSettings( {
 			apiMethod: this.mollieApiMethod,
 		} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@inpsyde/playwright-utils@^5.1.0":
-  version "5.1.0"
-  resolved "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.1.0/352e0a83c72bd7e62793c5d8b55b469cff37f40d"
-  integrity sha512-nqbelr1rodaibIkyGrium77BnZxq8ksX9LZvMqjUt5wZhWGvxvLbjutRdUF3bOV+kS1nXgFz6urF7NWObL062A==
+"@inpsyde/playwright-utils@^5.1.1":
+  version "5.1.1"
+  resolved "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.1.1/afe7d8593b6eada858a353119c66e6106209bf1f"
+  integrity sha512-QApRv8oyxhnjmFN/f/oYigG+nynRaZReKuffW1X+1FL9SCnGrKjxNp51uUU/AR5EKzXTKRWWWD9o3E4fh6Xncw==
   dependencies:
     "@axe-core/playwright" "^4.10.1"
     "@percy/cli" "^1.30.6"
@@ -2348,15 +2348,10 @@
   dependencies:
     "@opentelemetry/core" "^1.1.0"
 
-"@parcel/watcher-linux-x64-glibc@2.5.6":
+"@parcel/watcher-win32-x64@2.5.6":
   version "2.5.6"
-  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz"
-  integrity sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==
-
-"@parcel/watcher-linux-x64-musl@2.5.6":
-  version "2.5.6"
-  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz"
-  integrity sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==
+  resolved "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz"
+  integrity sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.6"
@@ -3606,15 +3601,10 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
   version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz"
-  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
-
-"@unrs/resolver-binding-linux-x64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz"
-  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 "@webassemblyjs/ast@^1.14.1", "@webassemblyjs/ast@1.14.1":
   version "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,23 +1341,23 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@inpsyde/playwright-utils@^5.1.1":
-  version "5.1.1"
-  resolved "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.1.1/afe7d8593b6eada858a353119c66e6106209bf1f"
-  integrity sha512-QApRv8oyxhnjmFN/f/oYigG+nynRaZReKuffW1X+1FL9SCnGrKjxNp51uUU/AR5EKzXTKRWWWD9o3E4fh6Xncw==
+"@inpsyde/playwright-utils@^5.2.0":
+  version "5.2.0"
+  resolved "https://npm.pkg.github.com/download/@inpsyde/playwright-utils/5.2.0/2986ad3e90353eea12359717501d2d7441911610"
+  integrity sha512-DJA6XLLKSB4J0umsK3hK4VV/gOsk7qE+MShpuDdUv68B8hFRmplLnxet7S2XPi3HusvOaEoFhK1oML3JhJrZUg==
   dependencies:
     "@axe-core/playwright" "^4.10.1"
     "@percy/cli" "^1.30.6"
     "@percy/playwright" "^1.0.6"
-    "@playwright/test" "^1.45.0"
+    "@playwright/test" "^1.59.0"
     "@types/woocommerce__woocommerce-rest-api" "^1.0.5"
     "@woocommerce/woocommerce-rest-api" "^1.0.1"
     "@wordpress/e2e-test-utils-playwright" "^1.0.0"
     axe-core "^4.10.2"
     axe-html-reporter "^2.2.11"
     lighthouse "^12.0.0"
-    playwright "^1.49.0"
-    playwright-core "^1.49.0"
+    playwright "^1.59.0"
+    playwright-core "^1.59.0"
     playwright-lighthouse "^4.0.0"
 
 "@inquirer/ansi@^1.0.2":
@@ -2761,7 +2761,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.45.0", "@playwright/test@^1.56.1", "@playwright/test@^1.59.0", "@playwright/test@>=1":
+"@playwright/test@^1.56.1", "@playwright/test@^1.59.0", "@playwright/test@>=1":
   version "1.59.0"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.0.tgz"
   integrity sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==
@@ -10325,7 +10325,7 @@ pkg-dir@^7.0.0:
   dependencies:
     find-up "^6.3.0"
 
-playwright-core@^1.19.2, playwright-core@^1.49.0, "playwright-core@>= 1.0.0", playwright-core@>=1, playwright-core@1.59.1:
+playwright-core@^1.19.2, playwright-core@^1.59.0, "playwright-core@>= 1.0.0", playwright-core@>=1, playwright-core@1.59.1:
   version "1.59.1"
   resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz"
   integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
@@ -10343,7 +10343,7 @@ playwright-lighthouse@^4.0.0:
     chalk "^4.1.2"
     ua-parser-js "^1.0.2"
 
-playwright@^1.49.0:
+playwright@^1.59.0:
   version "1.59.1"
   resolved "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz"
   integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==


### PR DESCRIPTION
## QA updates for 8.1.10 — PIWOO-923 test, refund fixes, Billink/Wero/NL coverage

### Summary

- Add test for PIWOO-923 (late webhook replay must not un-refund)
- Add new refund tests
- Fix multistep checkout tests (disable legal checkbox)
- Move Billink tests to a separate NL project; add NL settings and projects for Billink
- Add Billink and Wero transaction tests
- Add phone-validation tests (and fix them)
- Update playwright-utils to 5.1.1
- Fix refund test IDs; add IDs to 08-bug-verification tests