### PR TITLE
Pin a hash of used Build & Distribute workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   create_archive:
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}


### PR DESCRIPTION
Pin the particular hash of a Build & Distribute reusable workwlow used to create plugin builds.

This guarantees that we will use that workflow at particular commit, and not just at the latest one of the `main` branch